### PR TITLE
fix extremely nasty bug with esbuild

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "dev": "env-cmd -f ../../.env cross-env NODE_ENV=development bun --watch src/main.ts",
     "format": "prettier --write src",
     "lint": "tsc && eslint --fix src",
-    "start": "env-cmd -f ../../.env cross-env API_PROD_SERVER_PORT=$API_DEV_SERVER_PORT NODE_ENV=production ESBUILD_BINARY_PATH=dist/bin/esbuild node dist/app.mjs",
+    "start": "env-cmd -f ../../.env cross-env NODE_OPTIONS='--enable-source-maps' API_PROD_SERVER_PORT=$API_DEV_SERVER_PORT NODE_ENV=production ESBUILD_BINARY_PATH=dist/bin/esbuild node dist/app.mjs",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/api/scripts/build.js
+++ b/apps/api/scripts/build.js
@@ -77,6 +77,7 @@ await esbuild.build({
     runtimePlugin({ outdir }),
     nativeModulesPlugin()
   ],
+  sourcemap: process.env.DEBUG?.trim().toLowerCase() === 'true',
   target: ['node18', 'es2022'],
   tsconfig
 });

--- a/apps/api/src/demo/demo.service.ts
+++ b/apps/api/src/demo/demo.service.ts
@@ -58,12 +58,16 @@ export class DemoService {
         this.instrumentsService.createFromBundle(montrealCognitiveAssessment)
       ]);
 
+      this.logger.debug('Done creating forms');
+
       await this.instrumentsService.createFromBundle(breakoutTask);
+      this.logger.debug('Done creating interactive instruments');
 
       const groups: Group[] = [];
       for (const group of DEMO_GROUPS) {
         groups.push(await this.groupsService.create(group));
       }
+      this.logger.debug('Done creating groups');
 
       for (const user of DEMO_USERS) {
         await this.usersService.create({
@@ -71,8 +75,10 @@ export class DemoService {
           groupIds: user.groupNames.map((name) => groups.find((group) => group.name === name)!.id)
         });
       }
+      this.logger.debug('Done creating users');
 
       for (let i = 0; i < dummySubjectCount; i++) {
+        this.logger.debug(`Creating dummy subject ${i + 1}/${dummySubjectCount}`);
         const group = randomValue(groups);
         const subject = await this.createSubject();
         await this.visitsService.create({
@@ -81,6 +87,7 @@ export class DemoService {
           subjectIdData: subject
         });
         for (const form of forms) {
+          this.logger.debug(`Creating dummy records for form ${form.name}`);
           for (let i = 0; i < 10; i++) {
             const data = this.createFormRecordData(
               await form.toInstance({ kind: 'FORM' }),
@@ -101,6 +108,7 @@ export class DemoService {
             });
           }
         }
+        this.logger.debug(`Done creating dummy subject ${i + 1}`);
       }
     } catch (err) {
       if (err instanceof Error) {

--- a/packages/instrument-transformer/src/base.ts
+++ b/packages/instrument-transformer/src/base.ts
@@ -36,6 +36,7 @@ export abstract class BaseInstrumentTransformer {
 
   private build(source: string, options: BuildOptions = {}) {
     return this.transpiler.build({
+      external: ['*'],
       format: 'esm',
       metafile: true,
       minify: true,


### PR DESCRIPTION
ESBuild attempts to resolve files marked as external by plugin `onResolve` hook. This resolution happens from the directory where the `esbuild` binary happens, rather than from the file which invokes `InstrumentTransformer.transformRuntimeImports()`. Since this only occurs in production builds (because the default TypeScript module resolution will respect the path mapping in `tsconfig.json`), there is no stack trace available. To diagnose, build locally with `DEBUG=true`, then run the start script which will identify the problem as being caused by native code (the esbuild binary).