### PR TITLE
fix: switch dynamic import of evaluateInstrument to static in bootstrap.js

### DIFF
--- a/apps/api/src/groups/__tests__/groups.service.spec.ts
+++ b/apps/api/src/groups/__tests__/groups.service.spec.ts
@@ -3,6 +3,7 @@ import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { InstrumentsService } from '@/instruments/instruments.service';
 import type { Model } from '@/prisma/prisma.types';
 import { getModelToken } from '@/prisma/prisma.utils';
 
@@ -14,7 +15,11 @@ describe('GroupsService', () => {
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      providers: [GroupsService, MockFactory.createForModelToken(getModelToken('Group'))]
+      providers: [
+        GroupsService,
+        MockFactory.createForModelToken(getModelToken('Group')),
+        MockFactory.createForService(InstrumentsService)
+      ]
     }).compile();
     groupModel = moduleRef.get(getModelToken('Group'));
     groupsService = moduleRef.get(GroupsService);

--- a/apps/api/src/instruments/__tests__/instruments.integration.spec.ts
+++ b/apps/api/src/instruments/__tests__/instruments.integration.spec.ts
@@ -1,20 +1,13 @@
 import { ValidationPipe } from '@douglasneuroinformatics/libnest/core';
+import { CryptoService } from '@douglasneuroinformatics/libnest/modules';
+import { MockFactory, type MockedInstance } from '@douglasneuroinformatics/libnest/testing';
 import { HttpStatus } from '@nestjs/common';
 import { type NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
-// import {
-//   briefPsychiatricRatingScale,
-//   enhancedDemographicsQuestionnaire,
-//   happinessQuestionnaire,
-//   miniMentalStateExamination,
-//   montrealCognitiveAssessment
-// } from '@opendatacapture/instrument-library';
-import { MockFactory, type MockedInstance } from '@douglasneuroinformatics/libnest/testing';
 import { ObjectId } from 'mongodb';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { ConfigurationService } from '@/configuration/configuration.service';
 import type { Model } from '@/prisma/prisma.types';
 import { getModelToken } from '@/prisma/prisma.utils';
 
@@ -33,7 +26,7 @@ describe('/instruments', () => {
       providers: [
         InstrumentsService,
         MockFactory.createForModelToken(getModelToken('Instrument')),
-        MockFactory.createForService(ConfigurationService)
+        MockFactory.createForService(CryptoService)
       ]
     }).compile();
 

--- a/apps/api/src/instruments/__tests__/instruments.service.spec.ts
+++ b/apps/api/src/instruments/__tests__/instruments.service.spec.ts
@@ -1,8 +1,8 @@
+import { CryptoService } from '@douglasneuroinformatics/libnest/modules';
 import { MockFactory, type MockedInstance } from '@douglasneuroinformatics/libnest/testing';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { ConfigurationService } from '@/configuration/configuration.service';
 import type { Model } from '@/prisma/prisma.types';
 import { getModelToken } from '@/prisma/prisma.utils';
 
@@ -17,7 +17,7 @@ describe('InstrumentsService', () => {
       providers: [
         InstrumentsService,
         MockFactory.createForModelToken(getModelToken('Instrument')),
-        MockFactory.createForService(ConfigurationService)
+        MockFactory.createForService(CryptoService)
       ]
     }).compile();
     instrumentsService = moduleRef.get(InstrumentsService);

--- a/apps/api/src/subjects/__tests__/subjects.integration.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.integration.spec.ts
@@ -4,7 +4,6 @@ import { MockFactory, type MockedInstance } from '@douglasneuroinformatics/libne
 import { HttpStatus } from '@nestjs/common';
 import { type NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
-import type { ClinicalSubjectIdentificationData } from '@opendatacapture/schemas/subject';
 import request from 'supertest';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -13,6 +12,8 @@ import { getModelToken } from '@/prisma/prisma.utils';
 
 import { SubjectsController } from '../subjects.controller';
 import { SubjectsService } from '../subjects.service';
+
+import type { CreateSubjectDto } from '../dto/create-subject.dto';
 
 describe('/subjects', () => {
   let app: NestExpressApplication;
@@ -43,11 +44,12 @@ describe('/subjects', () => {
   });
 
   describe('POST /subjects', () => {
-    let createSubjectDto: ClinicalSubjectIdentificationData;
+    let createSubjectDto: CreateSubjectDto;
     beforeEach(() => {
       createSubjectDto = {
         dateOfBirth: new Date(),
         firstName: 'John',
+        id: 'root$123',
         lastName: 'Smith',
         sex: 'MALE'
       };

--- a/packages/instrument-renderer/src/components/InteractiveContent/bootstrap.js
+++ b/packages/instrument-renderer/src/components/InteractiveContent/bootstrap.js
@@ -4,7 +4,7 @@
  * @opendatacapture/runtime-v1 specified as a peer dependency.
  */
 
-const { evaluateInstrument } = await import('/runtime/v1/opendatacapture@1.0.0/internal.js');
+import { evaluateInstrument } from '/runtime/v1/opendatacapture@1.0.0/internal.js';
 
 const THEME_ATTRIBUTE = 'data-mode';
 


### PR DESCRIPTION
This change is a workaround for the following (probable) bug in Safari.

## Bug Report

When using an `iframe` element  with the `srcdoc` attribute set to a JavaScript module using dynamic import with top-level await, module execution silently fails in Safari Version 17.4.1 (19618.1.15.11.14). For example, the following code logs "start import" in Safari, whereas Chrome and Firefox log "start import", "end import", and "hello" as expected.

**hello.js**

```javascript
export function sayHello() {
  console.log('hello');
}
```

**index.html**
```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
  </head>
  <body>
    <h1>My Website</h1>
    <iframe
      srcdoc="
        <script type='module'>
        console.log('start import');
        const { sayHello } = await import('/hello.js');
        console.log('end import');
        sayHello();
      </script>"
      frameborder="0"
    ></iframe>
  </body>
</html>
```

This problem appears to be specific to top-level await using dynamic import, as the following code behaves as expected (it logs "start import", "end import", then "hello" after a one second delay): 

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
  </head>
  <body>
    <h1>My Website</h1>
    <iframe
      srcdoc="
        <script type='module'>
        console.log('start import');
        import { sayHello } from '/hello.js';
        console.log('end import');
        await new Promise((res) => setTimeout(res, 1000));
        sayHello();
      </script>"
      frameborder="0"
    ></iframe>
  </body>
</html>
```

It also seems specific to `srcdoc`, since the following code also behaves as expected:

**iframe.html**
```html
<script type="module">
  console.log('start import');
  const { sayHello } = await import('/hello.js');
  console.log('end import');
  sayHello();
</script>
```

**index.html**

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
  </head>
  <body>
    <h1>My Website</h1>
    <iframe src="/iframe.html" frameborder="0"></iframe>
  </body>
</html>
```