### PR TITLE
chore: publish runtime v1.4.0

### DIFF
--- a/docs/en/6-changelogs/5.1-runtime.md
+++ b/docs/en/6-changelogs/5.1-runtime.md
@@ -5,6 +5,17 @@ sidebar:
   order: 1
 ---
 
+### 1.4.0 (2024-07-24)
+
+- Addded `jspsych@8.0.1`
+- Added `@jspsych/plugin-html-button-response@2.0.0`
+- Added `@jspsych/plugin-html-keyboard-response@2.0.0`
+- Added `@jspsych/plugin-image-button-response@2.0.0`
+- Added `@jspsych/plugin-image-keyboard-response@2.0.0`
+- Added `@jspsych/plugin-preload@2.0.0`
+- Added `@jspsych/plugin-survey-html-form@2.0.0`
+- Added `@jspsych/plugin-survey-text@2.0.0`
+
 ### 1.3.0 (2024-07-10)
 
 - Added `simple-statistics`

--- a/runtime/v1/package.json
+++ b/runtime/v1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendatacapture/runtime-v1",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Douglas Neuroinformatics",
     "email": "support@douglasneuroinformatics.ca"


### PR DESCRIPTION
Already updated on playground. Now available on npm. 