### PR TITLE
add ability to change language in interactive instrument

### DIFF
--- a/apps/playground/src/instruments/examples/interactive/Multilingual-Interactive/index.ts
+++ b/apps/playground/src/instruments/examples/interactive/Multilingual-Interactive/index.ts
@@ -10,6 +10,10 @@ const translations = {
       fr: 'Bonjour'
     }
   },
+  changeLanguage: {
+    en: 'Change Language',
+    fr: 'Changer de langue'
+  },
   submit: {
     en: 'Submit',
     fr: 'Soumettre'
@@ -27,16 +31,26 @@ export default defineInstrument({
   content: {
     render(done) {
       const i18n = createI18Next({ translations });
-      const button = document.createElement('button');
 
-      button.textContent = i18n.t('submit');
-      document.body.appendChild(button);
+      const changeLanguageButton = document.createElement('button');
+      changeLanguageButton.textContent = i18n.t('changeLanguage');
+      document.body.appendChild(changeLanguageButton);
+
+      changeLanguageButton.addEventListener('click', () => {
+        console.log(i18n.resolvedLanguage);
+        i18n.changeLanguage(i18n.resolvedLanguage === 'en' ? 'fr' : 'en');
+      });
+
+      const submitButton = document.createElement('button');
+      submitButton.textContent = i18n.t('submit');
+      document.body.appendChild(submitButton);
 
       i18n.onLanguageChange = () => {
-        button.textContent = i18n.t('submit');
+        changeLanguageButton.textContent = i18n.t('changeLanguage');
+        submitButton.textContent = i18n.t('submit');
       };
 
-      button.addEventListener('click', () => {
+      submitButton.addEventListener('click', () => {
         done({ message: i18n.t('greetings.hello') });
       });
     }
@@ -45,7 +59,7 @@ export default defineInstrument({
     description: '<PLACEHOLDER>',
     estimatedDuration: 1,
     instructions: ['<PLACEHOLDER>'],
-    license: 'UNLICENSED',
+    license: 'Apache-2.0',
     title: '<PLACEHOLDER>'
   },
   measures: {},

--- a/packages/instrument-renderer/src/components/InteractiveContent/InteractiveContent.tsx
+++ b/packages/instrument-renderer/src/components/InteractiveContent/InteractiveContent.tsx
@@ -1,8 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@douglasneuroinformatics/libui/components';
+import { type Theme, useTheme } from '@douglasneuroinformatics/libui/hooks';
+import type { Language } from '@opendatacapture/runtime-core';
 import { $Json, type Json } from '@opendatacapture/schemas/core';
 import { ZoomInIcon, ZoomOutIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { Promisable } from 'type-fest';
 
 import bootstrapScript from './bootstrap?raw';
@@ -16,9 +19,34 @@ export const InteractiveContent = React.memo<InteractiveContentProps>(function I
   bundle,
   onSubmit
 }) {
+  const { i18n } = useTranslation();
+  const [_, updateTheme] = useTheme();
   const [scale, setScale] = useState(100);
-  const handler = useCallback(
-    (event: CustomEvent) => {
+
+  const handleChangeLanguageEvent = useCallback(
+    (event: CustomEvent<Language>) => {
+      if (event.detail === 'en' || event.detail === 'fr') {
+        void i18n.changeLanguage(event.detail);
+      } else {
+        console.error(`Cannot change language: invalid language '${event.detail}', expected 'en' or 'fr'`);
+      }
+    },
+    [updateTheme]
+  );
+
+  const handleChangeThemeEvent = useCallback(
+    (event: CustomEvent<Theme>) => {
+      if (event.detail === 'dark' || event.detail === 'light') {
+        updateTheme(event.detail);
+      } else {
+        console.error(`Cannot change theme: invalid theme '${event.detail}', expected 'dark' or 'light'`);
+      }
+    },
+    [updateTheme]
+  );
+
+  const handleDoneEvent = useCallback(
+    (event: CustomEvent<Json>) => {
       void (async function () {
         const data = await $Json.parseAsync(event.detail);
         await onSubmit(data);
@@ -28,9 +56,19 @@ export const InteractiveContent = React.memo<InteractiveContentProps>(function I
   );
 
   useEffect(() => {
-    document.addEventListener('done', handler, false);
-    return () => document.removeEventListener('done', handler, false);
-  }, [handler]);
+    document.addEventListener('changeLanguage', handleChangeLanguageEvent, false);
+    return () => document.removeEventListener('changeLanguage', handleChangeLanguageEvent, false);
+  }, [handleChangeLanguageEvent]);
+
+  useEffect(() => {
+    document.addEventListener('changeTheme', handleChangeThemeEvent, false);
+    return () => document.removeEventListener('changeTheme', handleChangeThemeEvent, false);
+  }, [handleChangeThemeEvent]);
+
+  useEffect(() => {
+    document.addEventListener('done', handleDoneEvent, false);
+    return () => document.removeEventListener('done', handleDoneEvent, false);
+  }, [handleDoneEvent]);
 
   const dimensions = `${(100 / scale) * 100}%`;
 

--- a/packages/instrument-renderer/src/index.ts
+++ b/packages/instrument-renderer/src/index.ts
@@ -1,7 +1,12 @@
+import type { Theme } from '@douglasneuroinformatics/libui/hooks';
+import type { Json, Language } from '@opendatacapture/runtime-core';
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface GlobalEventHandlersEventMap {
-    done: CustomEvent;
+    changeLanguage: CustomEvent<Language>;
+    changeTheme: CustomEvent<Theme>;
+    done: CustomEvent<Json>;
   }
 }
 

--- a/packages/runtime-core/src/i18n.d.ts
+++ b/packages/runtime-core/src/i18n.d.ts
@@ -14,6 +14,7 @@ declare type TranslationKey<T extends { [key: string]: unknown }, Key = keyof T>
 
 /** @alpha */
 declare type I18N<T extends { [key: string]: unknown }> = {
+  changeLanguage: (language: Language) => void;
   readonly resolvedLanguage: Language;
   set onLanguageChange(value: LanguageChangeHandler);
   readonly t: (key: TranslationKey<T>) => string;

--- a/packages/runtime-core/src/i18n.js
+++ b/packages/runtime-core/src/i18n.js
@@ -27,10 +27,15 @@ export function createI18Next({ fallbackLanguage = 'en', translations } = {}) {
   languageAttributeObserver.observe(documentElement, { attributes: true });
 
   return {
+    changeLanguage: (language) => {
+      window.top.document.dispatchEvent(new CustomEvent('changeLanguage', { detail: language }));
+    },
     set onLanguageChange(handler) {
       handleLanguageChange = handler;
     },
-    resolvedLanguage,
+    get resolvedLanguage() {
+      return resolvedLanguage;
+    },
     t: (key) => {
       const value = get(translations, key);
       if (typeof value === 'string') {


### PR DESCRIPTION
Consider example:

```ts
/* eslint-disable perfectionist/sort-objects */

const { defineInstrument, createI18Next } = await import('/runtime/v1/@opendatacapture/runtime-core/index.js');
const { z } = await import('/runtime/v1/zod@3.23.6/index.js');

const translations = {
  greetings: {
    hello: {
      en: 'Hello',
      fr: 'Bonjour'
    }
  },
  changeLanguage: {
    en: 'Change Language',
    fr: 'Changer de langue'
  },
  submit: {
    en: 'Submit',
    fr: 'Soumettre'
  }
};

export default defineInstrument({
  kind: 'INTERACTIVE',
  language: 'en',
  tags: ['<PLACEHOLDER>'],
  internal: {
    edition: 1,
    name: '<PLACEHOLDER>'
  },
  content: {
    render(done) {
      const i18n = createI18Next({ translations });

      const changeLanguageButton = document.createElement('button');
      changeLanguageButton.textContent = i18n.t('changeLanguage');
      document.body.appendChild(changeLanguageButton);

      changeLanguageButton.addEventListener('click', () => {
        console.log(i18n.resolvedLanguage);
        i18n.changeLanguage(i18n.resolvedLanguage === 'en' ? 'fr' : 'en');
      });

      const submitButton = document.createElement('button');
      submitButton.textContent = i18n.t('submit');
      document.body.appendChild(submitButton);

      i18n.onLanguageChange = () => {
        changeLanguageButton.textContent = i18n.t('changeLanguage');
        submitButton.textContent = i18n.t('submit');
      };

      submitButton.addEventListener('click', () => {
        done({ message: i18n.t('greetings.hello') });
      });
    }
  },
  details: {
    description: '<PLACEHOLDER>',
    estimatedDuration: 1,
    instructions: ['<PLACEHOLDER>'],
    license: 'Apache-2.0',
    title: '<PLACEHOLDER>'
  },
  measures: {},
  validationSchema: z.object({
    message: z.string()
  })
});

```