### PR TITLE
Fix set interpretation on backend

### DIFF
--- a/apps/web/src/features/upload/hooks/useUploadInstrumentRecords.ts
+++ b/apps/web/src/features/upload/hooks/useUploadInstrumentRecords.ts
@@ -2,12 +2,14 @@ import { useNotificationsStore } from '@douglasneuroinformatics/libui/hooks';
 import type { UploadInstrumentRecordsData } from '@opendatacapture/schemas/instrument-records';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { replacer } from '@douglasneuroinformatics/libjs';
 
 export function useUploadInstrumentRecords() {
   const addNotification = useNotificationsStore((store) => store.addNotification);
   return useMutation({
     mutationFn: async (data: UploadInstrumentRecordsData) => {
-      await axios.post('/v1/instrument-records/upload', data);
+      const replacedData = JSON.parse(JSON.stringify(data, replacer));
+      await axios.post('/v1/instrument-records/upload', replacedData);
     },
     onSuccess() {
       addNotification({ type: 'success' });

--- a/apps/web/src/features/upload/utils.ts
+++ b/apps/web/src/features/upload/utils.ts
@@ -364,9 +364,9 @@ export function createUploadTemplateCSV(instrument: AnyUnilingualFormInstrument)
   const instrumentSchema = instrument.validationSchema as z.AnyZodObject;
 
   let shape: { [key: string]: z.ZodTypeAny } = {};
-  //Todo include ZodEffect as a typename like our other types
+  // TODO - include ZodEffect as a typename like our other types
   if ((instrumentSchema._def.typeName as string) === 'ZodEffects') {
-    //find a type safe way to call this
+    // TODO - find a type safe way to call this
     shape = instrumentSchema._def.schema._def.shape() as { [key: string]: z.ZodTypeAny };
   } else {
     shape = instrumentSchema.shape as { [key: string]: z.ZodTypeAny };

--- a/apps/web/src/features/upload/utils.ts
+++ b/apps/web/src/features/upload/utils.ts
@@ -364,7 +364,9 @@ export function createUploadTemplateCSV(instrument: AnyUnilingualFormInstrument)
   const instrumentSchema = instrument.validationSchema as z.AnyZodObject;
 
   let shape: { [key: string]: z.ZodTypeAny } = {};
+  //Todo include ZodEffect as a typename like our other types
   if ((instrumentSchema._def.typeName as string) === 'ZodEffects') {
+    //find a type safe way to call this
     shape = instrumentSchema._def.schema._def.shape() as { [key: string]: z.ZodTypeAny };
   } else {
     shape = instrumentSchema.shape as { [key: string]: z.ZodTypeAny };

--- a/apps/web/src/features/upload/utils.ts
+++ b/apps/web/src/features/upload/utils.ts
@@ -362,9 +362,15 @@ function generateSampleData({
 export function createUploadTemplateCSV(instrument: AnyUnilingualFormInstrument) {
   // TODO - type validationSchema as object
   const instrumentSchema = instrument.validationSchema as z.AnyZodObject;
-  const shape = instrumentSchema.shape as { [key: string]: z.ZodTypeAny };
 
-  const columnNames = Object.keys(instrumentSchema.shape as z.AnyZodObject);
+  let shape: { [key: string]: z.ZodTypeAny } = {};
+  if ((instrumentSchema._def.typeName as string) === 'ZodEffects') {
+    shape = instrumentSchema._def.schema._def.shape() as { [key: string]: z.ZodTypeAny };
+  } else {
+    shape = instrumentSchema.shape as { [key: string]: z.ZodTypeAny };
+  }
+
+  const columnNames = Object.keys(shape);
 
   const csvColumns = INTERNAL_HEADERS.concat(columnNames);
 


### PR DESCRIPTION
Initially set data was being sent as empty object {}

Now with replacer and reviver functions the set data is not lost in serialization and can be processed correctly on the backend 

related to issue #918 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced data validation and processing for instrument records uploads.
	- Added data transformation before sending upload requests.
	- Improved flexibility in handling various schema types for upload templates.

- **Bug Fixes**
	- Improved handling of incoming records through updated parsing methods.
	- Enhanced error handling with clearer messages for schema mismatches and empty data lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->