### PR TITLE
Set sample data

### DIFF
--- a/apps/web/src/features/upload/hooks/useUploadInstrumentRecords.ts
+++ b/apps/web/src/features/upload/hooks/useUploadInstrumentRecords.ts
@@ -8,9 +8,11 @@ import axios from 'axios';
 export function useUploadInstrumentRecords() {
   const addNotification = useNotificationsStore((store) => store.addNotification);
   return useMutation({
-    mutationFn: async (data: UploadInstrumentRecordsData) => {
-      const replacedData = JSON.parse(JSON.stringify(data, replacer)) as Json;
-      await axios.post('/v1/instrument-records/upload', replacedData);
+    mutationFn: async (uploadData: UploadInstrumentRecordsData) => {
+      uploadData.records.forEach((item) => {
+        item.data = JSON.parse(JSON.stringify(item.data, replacer)) as Json;
+      });
+      await axios.post('/v1/instrument-records/upload', uploadData);
     },
     onSuccess() {
       addNotification({ type: 'success' });

--- a/apps/web/src/features/upload/utils.test.ts
+++ b/apps/web/src/features/upload/utils.test.ts
@@ -17,8 +17,12 @@ describe('getZodTypeName', () => {
   it('should parse a z.boolean()', () => {
     expect(getZodTypeName(z.boolean())).toMatchObject({ isOptional: false, success: true, typeName: 'ZodBoolean' });
   });
-  it('should parse a z.set(z.string())', () => {
-    expect(getZodTypeName(z.set(z.string()))).toMatchObject({ isOptional: false, success: true, typeName: 'ZodSet' });
+  it('should parse a z.set(z.enum([]))', () => {
+    expect(getZodTypeName(z.set(z.enum(['a', 'b', 'c'])))).toMatchObject({
+      isOptional: false,
+      success: true,
+      typeName: 'ZodSet'
+    });
   });
   it('should parse a z.string().optional()', () => {
     expect(getZodTypeName(z.string().optional())).toMatchObject({

--- a/apps/web/src/features/upload/utils.ts
+++ b/apps/web/src/features/upload/utils.ts
@@ -73,6 +73,10 @@ function isZodEnumDef(def: AnyZodTypeDef): def is z.ZodEnumDef {
   return def.typeName === z.ZodFirstPartyTypeKind.ZodEnum;
 }
 
+function isZodSetDef(def: AnyZodTypeDef): def is z.ZodSetDef {
+  return def.typeName === z.ZodFirstPartyTypeKind.ZodSet;
+}
+
 function isZodArrayDef(def: AnyZodTypeDef): def is z.ZodArrayDef {
   return def.typeName === 'ZodArray';
 }
@@ -126,6 +130,7 @@ export function reformatInstrumentData({
 
 export function getZodTypeName(schema: z.ZodTypeAny, isOptional?: boolean): ZodTypeNameResult {
   const def: unknown = schema._def;
+  console.log('zod def', def);
   if (isZodTypeDef(def)) {
     if (isZodOptionalDef(def)) {
       return getZodTypeName(def.innerType, true);
@@ -138,7 +143,24 @@ export function getZodTypeName(schema: z.ZodTypeAny, isOptional?: boolean): ZodT
       };
     } else if (isZodArrayDef(def)) {
       return interpretZodArray(schema, def.typeName, isOptional);
+    } else if (isZodSetDef(def)) {
+      const innerDef: unknown = def.valueType._def;
+
+      if (isZodTypeDef(innerDef) && isZodEnumDef(innerDef)) {
+        return {
+          enumValues: innerDef.values,
+          isOptional: Boolean(isOptional),
+          success: true,
+          typeName: def.typeName
+        };
+      } else {
+        return {
+          message: 'Invalid types with set definition',
+          success: false
+        };
+      }
     }
+
     return {
       isOptional: Boolean(isOptional),
       success: true,
@@ -315,7 +337,18 @@ function generateSampleData({
     case 'ZodNumber':
       return formatTypeInfo('number', isOptional);
     case 'ZodSet':
-      return formatTypeInfo('SET(a,b,c)', isOptional);
+      try {
+        let possibleEnumOutputs = 'SET(';
+        for (const val of enumValues!) {
+          possibleEnumOutputs += val + '/';
+        }
+        possibleEnumOutputs = possibleEnumOutputs.slice(0, -1);
+        possibleEnumOutputs += ', ...)';
+        return formatTypeInfo(possibleEnumOutputs, isOptional);
+      } catch {
+        throw new Error('Invalid Enum error');
+      }
+
     case 'ZodString':
       return formatTypeInfo('string', isOptional);
     case 'ZodEnum':


### PR DESCRIPTION
create sample data for set fields when a template is generated for example

z.set(z.enum([a,b,c])

becomes sample data SET(a/b/c, ...)

closes issue #1002 

related to issue #918 

