### PR TITLE
fix bugs

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -168,7 +168,6 @@ enum AppSubject {
   InstrumentRecord
   Session
   Subject
-  Summary
   User
 }
 

--- a/apps/api/src/ability/ability.factory.ts
+++ b/apps/api/src/ability/ability.factory.ts
@@ -27,18 +27,17 @@ export class AbilityFactory {
         ability.can('read', 'Session', { groupId: { in: user.groupIds } });
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: user.groupIds } });
-        ability.can('read', 'Summary');
         ability.can('read', 'User', { groupIds: { hasSome: user.groupIds } });
-
         break;
       case 'STANDARD':
         ability.can('read', 'Group', { id: { in: user.groupIds } });
         ability.can('read', 'Instrument');
         ability.can('create', 'InstrumentRecord');
-        ability.can('read', 'Session');
+        ability.can('read', 'Session', { groupId: { in: user.groupIds } });
         ability.can('create', 'Session');
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: user.groupIds } });
+        break;
     }
     user.additionalPermissions.forEach(({ action, subject }) => {
       ability.can(action, subject);

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -233,6 +233,10 @@ export class InstrumentRecordsService {
       where: { AND: [accessibleQuery(ability, 'read', 'InstrumentRecord'), { groupId }, { instrumentId }] }
     });
 
+    if (3 > records.length) {
+      return {};
+    }
+
     const data: { [key: string]: [x: number[], y: number[]] } = {};
     for (const record of records) {
       const numericMeasures = pickBy(record.computedMeasures, isNumber);

--- a/apps/api/src/summary/summary.controller.ts
+++ b/apps/api/src/summary/summary.controller.ts
@@ -12,7 +12,12 @@ export class SummaryController {
   constructor(private readonly summaryService: SummaryService) {}
 
   @Get()
-  @RouteAccess([{ action: 'read', subject: 'Instrument' }])
+  @RouteAccess([
+    { action: 'read', subject: 'Instrument' },
+    { action: 'read', subject: 'InstrumentRecord' },
+    { action: 'read', subject: 'Subject' },
+    { action: 'read', subject: 'User' }
+  ])
   async getSummary(@CurrentUser('ability') ability: AppAbility, @Query('groupId') groupId?: string): Promise<Summary> {
     return this.summaryService.getSummary(groupId, { ability });
   }

--- a/apps/web/src/features/admin/pages/ManageUsersPage.tsx
+++ b/apps/web/src/features/admin/pages/ManageUsersPage.tsx
@@ -178,10 +178,6 @@ export const ManageUsersPage = () => {
                           en: 'Subject',
                           fr: 'Client'
                         }),
-                        Summary: t({
-                          en: 'Summary',
-                          fr: 'Résumé'
-                        }),
                         User: t({
                           en: 'User',
                           fr: 'Utilisateur'

--- a/apps/web/src/features/dashboard/pages/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import type { AppSubjectName } from '@opendatacapture/schemas/core';
 import { Navigate } from 'react-router-dom';
 
 import { PageHeader } from '@/components/PageHeader';
@@ -13,7 +14,11 @@ export const DashboardPage = () => {
   const currentUser = useAppStore((store) => store.currentUser);
   const { t } = useTranslation();
 
-  if (!currentUser?.ability.can('read', 'Summary')) {
+  const ability = currentUser?.ability;
+  const subjects: AppSubjectName[] = ['Instrument', 'InstrumentRecord', 'Subject', 'User'];
+  const isAuthorized = subjects.every((subject) => ability?.can('read', subject));
+
+  if (!isAuthorized) {
     return <Navigate to="/session/start-session" />;
   }
 

--- a/apps/web/src/hooks/useNavItems.ts
+++ b/apps/web/src/hooks/useNavItems.ts
@@ -39,15 +39,21 @@ export function useNavItems() {
   const setupState = useSetupState();
 
   useEffect(() => {
+    const ability = currentUser?.ability;
     const globalItems: NavItem[] = [];
-    if (currentUser?.ability.can('read', 'Summary')) {
+    if (
+      ability?.can('read', 'Instrument') &&
+      ability.can('read', 'InstrumentRecord') &&
+      ability.can('read', 'Subject') &&
+      ability.can('read', 'User')
+    ) {
       globalItems.push({
         icon: BarChartBigIcon,
         label: t('layout.navLinks.dashboard'),
         url: '/dashboard'
       });
     }
-    if (currentUser?.ability.can('read', 'Subject') && currentUser.ability.can('read', 'InstrumentRecord')) {
+    if (ability?.can('read', 'Subject') && ability.can('read', 'InstrumentRecord')) {
       globalItems.push({
         icon: DatabaseIcon,
         label: t('layout.navLinks.datahub'),
@@ -55,8 +61,8 @@ export function useNavItems() {
       });
     }
     if (
-      currentUser?.ability.can('read', 'Subject') &&
-      currentUser.ability.can('create', 'InstrumentRecord') &&
+      ability?.can('read', 'Subject') &&
+      ability.can('create', 'InstrumentRecord') &&
       setupState.data?.isExperimentalFeaturesEnabled
     ) {
       globalItems.push({
@@ -65,7 +71,7 @@ export function useNavItems() {
         url: '/upload'
       });
     }
-    if (currentGroup && currentUser?.ability.can('manage', 'Group')) {
+    if (currentGroup && ability?.can('manage', 'Group')) {
       globalItems.push({
         icon: UsersIcon,
         label: t('layout.navLinks.manageGroup'),
@@ -74,7 +80,7 @@ export function useNavItems() {
     }
 
     const adminItems: NavItem[] = [];
-    if (currentUser?.ability.can('manage', 'all')) {
+    if (ability?.can('manage', 'all')) {
       adminItems.push({
         icon: CogIcon,
         label: t({
@@ -102,7 +108,7 @@ export function useNavItems() {
     }
 
     const sessionItems: NavItem[] = [];
-    if (currentUser?.ability.can('create', 'Session')) {
+    if (ability?.can('create', 'Session')) {
       sessionItems.push({
         disabled: currentSession !== null,
         icon: CirclePlayIcon,
@@ -110,7 +116,7 @@ export function useNavItems() {
         url: '/session/start-session'
       });
     }
-    if (currentUser?.ability.can('create', 'InstrumentRecord')) {
+    if (ability?.can('create', 'InstrumentRecord')) {
       sessionItems.push({
         disabled: currentSession === null,
         icon: ComputerIcon,
@@ -118,7 +124,7 @@ export function useNavItems() {
         url: '/instruments/accessible-instruments'
       });
     }
-    if (currentUser?.ability.can('read', 'Subject') && currentUser.ability.can('read', 'InstrumentRecord')) {
+    if (ability?.can('read', 'Subject') && ability.can('read', 'InstrumentRecord')) {
       sessionItems.push({
         disabled: currentSession === null,
         icon: EyeIcon,

--- a/packages/schemas/src/core/core.ts
+++ b/packages/schemas/src/core/core.ts
@@ -17,7 +17,6 @@ export const $AppSubjectName = z.enum([
   'InstrumentRecord',
   'Session',
   'Subject',
-  'Summary',
   'User'
 ]);
 


### PR DESCRIPTION
closes #1011 (caused by regression model having less than three records)
closes #1013 (caused by permission issue where user is able to access route, but secondary permission check fails causing internal error)

Summary permission has been removed. Now, to read the summary, a user must have permission to read all of `Instrument`, `InstrumentRecord`, `Subject`, and `User`.