### PR TITLE
Data upload now considers group in upload when possible

### DIFF
--- a/apps/web/src/features/upload/utils.ts
+++ b/apps/web/src/features/upload/utils.ts
@@ -117,7 +117,7 @@ export function reformatInstrumentData({
     recordsList.push(createdRecord);
   }
   const reformatForSending: UploadInstrumentRecordsData = {
-    groupId: undefined,
+    groupId: currentGroup?.id,
     instrumentId: instrument.id,
     records: recordsList
   };


### PR DESCRIPTION
Fixes the issue of upload not including the users group onto the data when they upload it. Thus making it not visible to the users data hub.

resolves issue #1021 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of group identifiers in the data upload process, ensuring valid group IDs are used.
  
- **Bug Fixes**
	- Addressed an issue where the `groupId` was previously set to `undefined`, enhancing data integrity.

- **Chores**
	- Added comments for future improvements in error handling and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->