### PR TITLE
add profiles to each service to allow for the gateway profile

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,9 @@ services:
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
+    profiles:
+      - '' #load by default without having to specify docker compose --profile
+      - gateway
   api:
     image: ghcr.io/douglasneuroinformatics/open-data-capture-api:${RELEASE_CHANNEL}
     build:
@@ -43,6 +46,8 @@ services:
       - VERBOSE
     expose:
       - 80
+    profiles:
+      - '' #load by default without having to specify docker compose --profile
   gateway:
     image: ghcr.io/douglasneuroinformatics/open-data-capture-gateway:${RELEASE_CHANNEL}
     build:
@@ -54,6 +59,9 @@ services:
       - ${GATEWAY_PORT}:80
     expose:
       - 80
+    profiles:
+      - '' #load by default without having to specify docker compose --profile
+      - gateway
     restart: unless-stopped
     environment:
       - NODE_ENV=production
@@ -76,6 +84,8 @@ services:
       - PLAUSIBLE_WEB_DATA_DOMAIN
     expose:
       - 80
+    profiles:
+      - '' #load by default without having to specify docker compose --profile
     restart: unless-stopped
   mongo:
     image: mongo:${MONGODB_VERSION}
@@ -93,3 +103,5 @@ services:
     volumes:
       - ./mongo/config:/data/configdb
       - ./mongo/data:/data/db
+    profiles:
+      - '' #load by default without having to specify docker compose --profile


### PR DESCRIPTION
by adding profile sections to each of the services (api,web,caddy,gateway,mongo) in the docker-compose.yml file, you can now start ODC 2 ways:

docker compose up -d     (which gives yout the full stack)
or
docker compose --profile gateway up -d   (which gives you only caddy and gateway)

The latter is useeful when you have a gateway running on a server that is different than the web/api/mongo server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced service management in Docker Compose with default loading profiles for `caddy`, `api`, `gateway`, `web`, and `mongo`.
	- Simplified command usage by eliminating the need to specify profiles when starting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->