### PR TITLE
fix: switch from alpine to debian

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:iron-alpine AS base
-RUN apk add --update --no-cache openssl1.1-compat
+FROM node:iron AS base
 WORKDIR /app
 ARG RELEASE_VERSION
 ENV GATEWAY_DATABASE_URL="file:/dev/null"

--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:iron-alpine AS base
-RUN apk add --update --no-cache openssl1.1-compat
+FROM node:iron AS base
 WORKDIR /app
 ARG RELEASE_VERSION
 ENV GATEWAY_DATABASE_URL=file:/app/sqlite/gateway.db

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:iron-alpine AS base
-RUN apk add --update --no-cache openssl1.1-compat
+FROM node:iron AS base
 ARG RELEASE_VERSION
 WORKDIR /app
 ENV PNPM_HOME="/pnpm"


### PR DESCRIPTION
`openssl1.1-compat` has been removed in alpine 3.18