### PR TITLE
update corepack before installing pnpm to avoid failure

### DIFF
--- a/apps/playground/Dockerfile
+++ b/apps/playground/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV NODE_OPTIONS="--max-old-space-size=8192"
+RUN npm i -g corepack@latest
 RUN corepack enable
 RUN pnpm install -g turbo@latest
 


### PR DESCRIPTION
playground image wouldn't build because of corepack failing:  https://github.com/pnpm/pnpm/issues/9029#:~:text=pnpm%20i%20%2Dg%20corepack%40latest

updating corepack first fixes the pnpm install failure and makes the service functional again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled enhanced package manager support in container builds for smoother dependency handling.
- **Style**
	- Improved configuration consistency for a standardized build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->