### PR TITLE
fix: remove password from user schema

### DIFF
--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -58,12 +58,18 @@ export class UsersService {
         lastName,
         sex,
         username: username
+      },
+      omit: {
+        hashedPassword: true
       }
     });
   }
 
   async deleteById(id: string, { ability }: EntityOperationOptions = {}) {
     return this.userModel.delete({
+      omit: {
+        hashedPassword: true
+      },
       where: { AND: [accessibleQuery(ability, 'delete', 'User')], id }
     });
   }
@@ -72,12 +78,18 @@ export class UsersService {
   async deleteByUsername(username: string, { ability }: EntityOperationOptions = {}) {
     const user = await this.findByUsername(username);
     return this.userModel.delete({
+      omit: {
+        hashedPassword: true
+      },
       where: { AND: [accessibleQuery(ability, 'delete', 'User')], id: user.id }
     });
   }
 
   async find({ groupId }: { groupId?: string } = {}, { ability }: EntityOperationOptions = {}) {
     return this.userModel.findMany({
+      omit: {
+        hashedPassword: true
+      },
       where: {
         AND: [accessibleQuery(ability, 'read', 'User'), { groupIds: groupId ? { has: groupId } : undefined }]
       }
@@ -86,6 +98,9 @@ export class UsersService {
 
   async findById(id: string, { ability }: EntityOperationOptions = {}) {
     const user = await this.userModel.findFirst({
+      omit: {
+        hashedPassword: true
+      },
       where: { AND: [accessibleQuery(ability, 'read', 'User')], id }
     });
     if (!user) {
@@ -97,6 +112,9 @@ export class UsersService {
   async findByUsername(username: string, { ability }: EntityOperationOptions = {}) {
     const user = await this.userModel.findFirst({
       include: { groups: true },
+      omit: {
+        hashedPassword: true
+      },
       where: { AND: [accessibleQuery(ability, 'read', 'User'), { username }] }
     });
     if (!user) {
@@ -112,6 +130,9 @@ export class UsersService {
         groups: {
           connect: groupIds?.map((id) => ({ id }))
         }
+      },
+      omit: {
+        hashedPassword: true
       },
       where: { AND: [accessibleQuery(ability, 'update', 'User')], id }
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendatacapture",
   "type": "module",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "private": true,
   "packageManager": "pnpm@9.15.4",
   "license": "Apache-2.0",

--- a/packages/demo/src/index.ts
+++ b/packages/demo/src/index.ts
@@ -2,8 +2,9 @@ import { deepFreeze } from '@douglasneuroinformatics/libjs';
 import type { CreateGroupData } from '@opendatacapture/schemas/group';
 import type { User } from '@opendatacapture/schemas/user';
 
-type DemoUser = Pick<User, 'basePermissionLevel' | 'firstName' | 'lastName' | 'password' | 'username'> & {
+type DemoUser = Pick<User, 'basePermissionLevel' | 'firstName' | 'lastName' | 'username'> & {
   groupNames: readonly string[];
+  password: string;
 };
 
 type DemoGroup = CreateGroupData & { dummyIdPrefix?: string };

--- a/packages/schemas/src/user/user.ts
+++ b/packages/schemas/src/user/user.ts
@@ -23,7 +23,6 @@ export const $User = $BaseModel.extend({
   firstName: z.string().min(1),
   groupIds: z.array(z.string()),
   lastName: z.string().min(1),
-  password: z.string().min(1),
   sex: $Sex.nullish(),
   username: z.string().min(1)
 });
@@ -35,11 +34,11 @@ export const $CreateUserData = $User
     firstName: true,
     groupIds: true,
     lastName: true,
-    password: true,
     username: true
   })
   .extend({
     dateOfBirth: z.coerce.date().optional(),
+    password: z.string().min(1),
     sex: $Sex.optional()
   });
 


### PR DESCRIPTION
The hashed password changed name from `password` to `hashedPassword`, which was not reflected in the user schema. However, the hashed password should not be sent to the admin client at all. All the user methods have been revised to no longer return this value.

Fixes #1114
