### PR TITLE
change 'file doesn't exist' to 'file doesn't exist or size is <= 0'

### DIFF
--- a/apps/gateway/scripts/run.sh
+++ b/apps/gateway/scripts/run.sh
@@ -5,7 +5,7 @@ set -eu
 DATABASE_FILE=${GATEWAY_DATABASE_URL#file:}
 EMPTY_DATABASE_FILE="/app/gateway.tmpl.db"
 
-if [ ! -f "$DATABASE_FILE" ]; then
+if [ ! -s "$DATABASE_FILE" ]; then
   cp "$EMPTY_DATABASE_FILE" "$DATABASE_FILE"
 fi
 


### PR DESCRIPTION
the following is required to remove the errors in the docker log about missing DB tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database initialization to ensure the template database is copied if the existing database file is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->