### PR TITLE
Add no gateway profile

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - '' #load by default without having to specify docker compose --profile
       - gateway
       - fullstack
+      - nogateway
   api:
     image: ghcr.io/douglasneuroinformatics/open-data-capture-api:${RELEASE_CHANNEL}
     build:
@@ -48,6 +49,7 @@ services:
     profiles:
       - '' #load by default without having to specify docker compose --profile
       - fullstack
+      - nogateway
   gateway:
     image: ghcr.io/douglasneuroinformatics/open-data-capture-gateway:${RELEASE_CHANNEL}
     build:
@@ -90,6 +92,7 @@ services:
     profiles:
       - '' #load by default without having to specify docker compose --profile
       - fullstack
+      - nogateway
     restart: unless-stopped
   mongo:
     image: mongo:${MONGODB_VERSION}
@@ -110,6 +113,7 @@ services:
     profiles:
       - '' #load by default without having to specify docker compose --profile
       - fullstack
+      - nogateway
   playground:
     build:
       context: .
@@ -122,3 +126,4 @@ services:
     profiles:
       - fullstack
       - playground
+      - nogateway

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,4 +126,3 @@ services:
     profiles:
       - fullstack
       - playground
-      - nogateway


### PR DESCRIPTION
this profile is used by mouseODC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new "nogateway" profile to several services in the Docker Compose setup, allowing for more flexible service selection when starting the application with specific profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->