### PR TITLE
Add group to export

### DIFF
--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -160,7 +160,7 @@ export class InstrumentRecordsService {
           sessionType: record.session.type,
           subjectAge: record.subject.dateOfBirth ? yearsPassed(record.subject.dateOfBirth) : null,
           // eslint-disable-next-line perfectionist/sort-objects
-          groupId: record.subject.groupIds.length > 0 ? record.subject.groupIds.join(' ') : DEFAULT_GROUP_NAME,
+          groupId: record.subject.groupIds[0] ?? DEFAULT_GROUP_NAME,
           subjectId: record.subject.id,
           subjectSex: record.subject.sex,
           timestamp: record.date.toISOString(),

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -160,7 +160,7 @@ export class InstrumentRecordsService {
           sessionType: record.session.type,
           subjectAge: record.subject.dateOfBirth ? yearsPassed(record.subject.dateOfBirth) : null,
           // eslint-disable-next-line perfectionist/sort-objects
-          groupId: record.subject.groupIds.join(' ') ?? DEFAULT_GROUP_NAME,
+          groupId: record.subject.groupIds.length > 0 ? record.subject.groupIds.join(' ') : DEFAULT_GROUP_NAME,
           subjectId: record.subject.id,
           subjectSex: record.subject.sex,
           timestamp: record.date.toISOString(),

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -158,6 +158,8 @@ export class InstrumentRecordsService {
           sessionId: record.session.id,
           sessionType: record.session.type,
           subjectAge: record.subject.dateOfBirth ? yearsPassed(record.subject.dateOfBirth) : null,
+          // eslint-disable-next-line perfectionist/sort-objects
+          groupId: record.subject.groupIds.join(' ') ?? 'root',
           subjectId: record.subject.id,
           subjectSex: record.subject.sex,
           timestamp: record.date.toISOString(),

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -4,6 +4,7 @@ import type { Model } from '@douglasneuroinformatics/libnest';
 import { linearRegression } from '@douglasneuroinformatics/libstats';
 import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import type { ScalarInstrument } from '@opendatacapture/runtime-core';
+import { DEFAULT_GROUP_NAME } from '@opendatacapture/schemas/core';
 import type {
   CreateInstrumentRecordData,
   InstrumentRecord,
@@ -159,7 +160,7 @@ export class InstrumentRecordsService {
           sessionType: record.session.type,
           subjectAge: record.subject.dateOfBirth ? yearsPassed(record.subject.dateOfBirth) : null,
           // eslint-disable-next-line perfectionist/sort-objects
-          groupId: record.subject.groupIds.join(' ') ?? 'root',
+          groupId: record.subject.groupIds.join(' ') ?? DEFAULT_GROUP_NAME,
           subjectId: record.subject.id,
           subjectSex: record.subject.sex,
           timestamp: record.date.toISOString(),

--- a/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
@@ -3,6 +3,7 @@
 import { Form } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { FormTypes } from '@opendatacapture/runtime-core';
+import { DEFAULT_GROUP_NAME } from '@opendatacapture/schemas/core';
 import type { Group } from '@opendatacapture/schemas/group';
 import { $SessionType } from '@opendatacapture/schemas/session';
 import type { CreateSessionData } from '@opendatacapture/schemas/session';
@@ -253,7 +254,7 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
           });
         } else {
           subjectId = encodeScopedSubjectId(subjectId, {
-            groupName: currentGroup?.name ?? 'root'
+            groupName: currentGroup?.name ?? DEFAULT_GROUP_NAME
           });
         }
         await onSubmit({

--- a/packages/schemas/src/core/core.ts
+++ b/packages/schemas/src/core/core.ts
@@ -6,6 +6,8 @@ import type { Json, JsonLiteral, Language } from '@opendatacapture/runtime-core'
 import type { Simplify } from 'type-fest';
 import { z } from 'zod';
 
+export const DEFAULT_GROUP_NAME = 'root';
+
 export type AppAction = z.infer<typeof $AppAction>;
 export const $AppAction = z.enum(['create', 'delete', 'manage', 'read', 'update']);
 

--- a/packages/schemas/src/instrument-records/instrument-records.ts
+++ b/packages/schemas/src/instrument-records/instrument-records.ts
@@ -45,6 +45,7 @@ export const $InstrumentRecord = $BaseModel.extend({
 export type InstrumentRecord = z.infer<typeof $InstrumentRecord>;
 
 export type InstrumentRecordsExport = {
+  groupId: string;
   instrumentEdition: number;
   instrumentName: string;
   measure: string;


### PR DESCRIPTION
Works on issue #1005 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exported instrument records now include a group identification field.
- **Improvements**
  - Consistent use of a default group name across the application for group-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->