### PR TITLE
Allow for subject id display length to be changes as a group setting

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -68,6 +68,7 @@ type GroupSettings {
   defaultIdentificationMethod   SubjectIdentificationMethod
   idValidationRegex             String?
   idValidationRegexErrorMessage ErrorMessage?
+  subjectIdDisplayLength        Int?  
 }
 
 model Group {
@@ -82,8 +83,7 @@ model Group {
   settings                GroupSettings
   sessions                Session[]
   subjects                Subject[]          @relation(fields: [subjectIds], references: [id])
-  subjectIds              String[]
-  subjectDisplayLength    String?             
+  subjectIds              String[]           
   type                    GroupType
   userIds                 String[]           @db.ObjectId
   users                   User[]             @relation(fields: [userIds], references: [id])

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -83,6 +83,7 @@ model Group {
   sessions                Session[]
   subjects                Subject[]          @relation(fields: [subjectIds], references: [id])
   subjectIds              String[]
+  subjectDisplayLength    String?             
   type                    GroupType
   userIds                 String[]           @db.ObjectId
   users                   User[]             @relation(fields: [userIds], references: [id])

--- a/apps/web/src/features/datahub/components/MasterDataTable.tsx
+++ b/apps/web/src/features/datahub/components/MasterDataTable.tsx
@@ -18,10 +18,7 @@ export const MasterDataTable = ({ data, onSelect }: MasterDataTableProps) => {
     <ClientTable<Subject>
       columns={[
         {
-          field: (subject) =>
-            subjectIdDisplaySetting
-              ? removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting)
-              : removeSubjectIdScope(subject.id).slice(0, 9),
+          field: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
           label: t('datahub.index.table.subject')
         },
         {

--- a/apps/web/src/features/datahub/components/MasterDataTable.tsx
+++ b/apps/web/src/features/datahub/components/MasterDataTable.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { Subject } from '@opendatacapture/schemas/subject';
 import { removeSubjectIdScope } from '@opendatacapture/subject-utils';
 
+import { useAppStore } from '@/store';
+
 export type MasterDataTableProps = {
   data: Subject[];
   onSelect: (subject: Subject) => void;
@@ -11,11 +13,15 @@ export type MasterDataTableProps = {
 
 export const MasterDataTable = ({ data, onSelect }: MasterDataTableProps) => {
   const { t } = useTranslation();
+  const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
   return (
     <ClientTable<Subject>
       columns={[
         {
-          field: (subject) => removeSubjectIdScope(subject.id).slice(0, 9),
+          field: (subject) =>
+            subjectIdDisplaySetting
+              ? removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting)
+              : removeSubjectIdScope(subject.id).slice(0, 9),
           label: t('datahub.index.table.subject')
         },
         {

--- a/apps/web/src/features/datahub/components/SubjectLayout.tsx
+++ b/apps/web/src/features/datahub/components/SubjectLayout.tsx
@@ -28,9 +28,7 @@ export const SubjectLayout = () => {
               en: 'Instrument Records for Subject {}',
               fr: "Dossiers d'instruments pour le client {}"
             },
-            subjectIdDisplaySetting
-              ? removeSubjectIdScope(subjectId).slice(0, subjectIdDisplaySetting)
-              : removeSubjectIdScope(subjectId).slice(0, 9)
+            removeSubjectIdScope(subjectId).slice(0, subjectIdDisplaySetting ?? 9)
           )}
         </Heading>
       </PageHeader>

--- a/apps/web/src/features/datahub/components/SubjectLayout.tsx
+++ b/apps/web/src/features/datahub/components/SubjectLayout.tsx
@@ -8,6 +8,7 @@ import { Outlet, useParams } from 'react-router-dom';
 import { LoadingFallback } from '@/components/LoadingFallback';
 import { PageHeader } from '@/components/PageHeader';
 import { config } from '@/config';
+import { useAppStore } from '@/store';
 
 import { TabLink } from './TabLink';
 
@@ -16,6 +17,7 @@ export const SubjectLayout = () => {
   const { t } = useTranslation('datahub');
   const subjectId = params.subjectId!;
   const basePathname = `/datahub/${subjectId}`;
+  const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
 
   return (
     <React.Fragment>
@@ -26,7 +28,9 @@ export const SubjectLayout = () => {
               en: 'Instrument Records for Subject {}',
               fr: "Dossiers d'instruments pour le client {}"
             },
-            removeSubjectIdScope(subjectId).slice(0, 9)
+            subjectIdDisplaySetting
+              ? removeSubjectIdScope(subjectId).slice(0, subjectIdDisplaySetting)
+              : removeSubjectIdScope(subjectId).slice(0, 9)
           )}
         </Heading>
       </PageHeader>

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -61,6 +61,16 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
         },
         {
           fields: {
+            subjectIdDisplayLength: {
+              kind: 'number',
+              label: 'Enter preferred ID display length',
+              variant: 'input'
+            }
+          },
+          title: 'Subject ID display length'
+        },
+        {
+          fields: {
             defaultIdentificationMethod: {
               kind: 'string',
               label: t('group.manage.defaultSubjectIdMethod'),
@@ -129,7 +139,8 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
         defaultIdentificationMethod: $SubjectIdentificationMethod.optional(),
         idValidationRegex: $RegexString.optional(),
         idValidationRegexErrorMessageEn: z.string().optional(),
-        idValidationRegexErrorMessageFr: z.string().optional()
+        idValidationRegexErrorMessageFr: z.string().optional(),
+        subjectIdDisplayLength: z.number().int().min(1)
       })}
       onSubmit={(data) => {
         void onSubmit({

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -65,15 +65,15 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
             subjectIdDisplayLength: {
               kind: 'number',
               label: t({
-                en: 'Enter preferred ID display length',
-                fr: 'Entrez la longueur d\'affichage préférée de l\'ID'
+                en: 'Preferred Subject ID Display Length',
+                fr: "La longueur d'affichage préférée de l'ID"
               }),
               variant: 'input'
             }
           },
           title: t({
-            en: 'Subject ID display length',
-            fr: 'Longueur d\'affichage de l\'ID du sujet'
+            en: 'Display Settings',
+            fr: "Paramètres d'affichage"
           })
         },
         {

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -22,6 +22,7 @@ export type ManageGroupFormProps = {
       accessibleInteractiveInstrumentIds: Set<string>;
       defaultIdentificationMethod?: SubjectIdentificationMethod;
       idValidationRegex?: null | string;
+      subjectIdDisplayLength?: number;
     };
   };
   onSubmit: (data: Partial<UpdateGroupData>) => Promisable<any>;
@@ -151,7 +152,8 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
             idValidationRegexErrorMessage: {
               en: data.idValidationRegexErrorMessageEn,
               fr: data.idValidationRegexErrorMessageFr
-            }
+            },
+            subjectIdDisplayLength: data.subjectIdDisplayLength
           }
         });
       }}

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -64,11 +64,17 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
           fields: {
             subjectIdDisplayLength: {
               kind: 'number',
-              label: 'Enter preferred ID display length',
+              label: t({
+                en: 'Enter preferred ID display length',
+                fr: 'Entrez la longueur d\'affichage préférée de l\'ID'
+              }),
               variant: 'input'
             }
           },
-          title: 'Subject ID display length'
+          title: t({
+            en: 'Subject ID display length',
+            fr: 'Longueur d\'affichage de l\'ID du sujet'
+          })
         },
         {
           fields: {

--- a/packages/schemas/src/group/group.ts
+++ b/packages/schemas/src/group/group.ts
@@ -12,7 +12,8 @@ export const $GroupSettings = z.object({
       en: z.string().nullish(),
       fr: z.string().nullish()
     })
-    .nullish()
+    .nullish(),
+  subjectIdDisplayLength: z.number().nullish()
 });
 
 export type GroupType = z.infer<typeof $GroupType>;


### PR DESCRIPTION
resolves issue #1144 

Lets group manage adjust length of the subject id displayed in datahub and subject layout table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable "Subject ID display length" setting to group management, allowing customization of how many characters of the subject ID are shown in tables and headers.
  - Group administrators can now set the preferred subject ID display length in the group settings form.

- **Enhancements**
  - Subject IDs in tables and headers now dynamically reflect the configured display length, improving readability and customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->