### PR TITLE
Allow for sex to be added in custom identifier, optionally allow for species to be added to subject 

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -68,7 +68,8 @@ type GroupSettings {
   defaultIdentificationMethod   SubjectIdentificationMethod
   idValidationRegex             String?
   idValidationRegexErrorMessage ErrorMessage?
-  subjectIdDisplayLength        Int?  
+  subjectIdDisplayLength        Int? 
+  speciesVisible                Boolean?  
 }
 
 model Group {
@@ -159,6 +160,7 @@ model Subject {
   lastName          String?
   sessions          Session[]
   sex               Sex?
+  species           String?
   instrumentRecords InstrumentRecord[]
   assignments       Assignment[]
 

--- a/apps/web/src/features/datahub/components/MasterDataTable.tsx
+++ b/apps/web/src/features/datahub/components/MasterDataTable.tsx
@@ -15,72 +15,47 @@ export const MasterDataTable = ({ data, onSelect }: MasterDataTableProps) => {
   const { t } = useTranslation();
   const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
   const speciesVisible = useAppStore((store) => store.currentGroup?.settings.speciesVisible);
-  if (speciesVisible) {
-    return (
-      <ClientTable<Subject>
-        columns={[
-          {
-            field: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
-            label: t('datahub.index.table.subject')
-          },
-          {
-            field: (subject) => (subject.dateOfBirth ? toBasicISOString(new Date(subject.dateOfBirth)) : 'NULL'),
-            label: t('core.identificationData.dateOfBirth.label')
-          },
-          {
-            field: (subject) => {
-              switch (subject.sex) {
-                case 'FEMALE':
-                  return t('core.identificationData.sex.female');
-                case 'MALE':
-                  return t('core.identificationData.sex.male');
-                default:
-                  return 'NULL';
-              }
-            },
-            label: t('core.identificationData.sex.label')
-          },
-          {
-            field: (subject) => subject.species ?? 'NULL',
-            label: t({
-              en: 'Species',
-              fr: 'Espece animale'
-            })
-          }
-        ]}
-        data={data}
-        data-cy="master-data-table"
-        entriesPerPage={15}
-        minRows={15}
-        onEntryClick={onSelect}
-      />
-    );
-  }
+
+  const baseColumns = [
+    {
+      field: (subject: Subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
+      label: t('datahub.index.table.subject')
+    },
+    {
+      field: (subject: Subject) => (subject.dateOfBirth ? toBasicISOString(new Date(subject.dateOfBirth)) : 'NULL'),
+      label: t('core.identificationData.dateOfBirth.label')
+    },
+    {
+      field: (subject: Subject) => {
+        switch (subject.sex) {
+          case 'FEMALE':
+            return t('core.identificationData.sex.female');
+          case 'MALE':
+            return t('core.identificationData.sex.male');
+          default:
+            return 'NULL';
+        }
+      },
+      label: t('core.identificationData.sex.label')
+    }
+  ];
+
+  const columns = speciesVisible
+    ? [
+        ...baseColumns,
+        {
+          field: (subject: Subject) => subject.species ?? 'NULL',
+          label: t({
+            en: 'Species',
+            fr: 'Espece animale'
+          })
+        }
+      ]
+    : baseColumns;
+
   return (
     <ClientTable<Subject>
-      columns={[
-        {
-          field: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
-          label: t('datahub.index.table.subject')
-        },
-        {
-          field: (subject) => (subject.dateOfBirth ? toBasicISOString(new Date(subject.dateOfBirth)) : 'NULL'),
-          label: t('core.identificationData.dateOfBirth.label')
-        },
-        {
-          field: (subject) => {
-            switch (subject.sex) {
-              case 'FEMALE':
-                return t('core.identificationData.sex.female');
-              case 'MALE':
-                return t('core.identificationData.sex.male');
-              default:
-                return 'NULL';
-            }
-          },
-          label: t('core.identificationData.sex.label')
-        }
-      ]}
+      columns={columns}
       data={data}
       data-cy="master-data-table"
       entriesPerPage={15}

--- a/apps/web/src/features/datahub/components/MasterDataTable.tsx
+++ b/apps/web/src/features/datahub/components/MasterDataTable.tsx
@@ -14,6 +14,48 @@ type MasterDataTableProps = {
 export const MasterDataTable = ({ data, onSelect }: MasterDataTableProps) => {
   const { t } = useTranslation();
   const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
+  const speciesVisible = useAppStore((store) => store.currentGroup?.settings.speciesVisible);
+  if (speciesVisible) {
+    return (
+      <ClientTable<Subject>
+        columns={[
+          {
+            field: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
+            label: t('datahub.index.table.subject')
+          },
+          {
+            field: (subject) => (subject.dateOfBirth ? toBasicISOString(new Date(subject.dateOfBirth)) : 'NULL'),
+            label: t('core.identificationData.dateOfBirth.label')
+          },
+          {
+            field: (subject) => {
+              switch (subject.sex) {
+                case 'FEMALE':
+                  return t('core.identificationData.sex.female');
+                case 'MALE':
+                  return t('core.identificationData.sex.male');
+                default:
+                  return 'NULL';
+              }
+            },
+            label: t('core.identificationData.sex.label')
+          },
+          {
+            field: (subject) => subject.species ?? 'NULL',
+            label: t({
+              en: 'Species',
+              fr: 'Espece animale'
+            })
+          }
+        ]}
+        data={data}
+        data-cy="master-data-table"
+        entriesPerPage={15}
+        minRows={15}
+        onEntryClick={onSelect}
+      />
+    );
+  }
   return (
     <ClientTable<Subject>
       columns={[

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -74,7 +74,7 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
             speciesVisible: {
               kind: 'boolean',
               label: t({
-                en: 'Allow for species to be entered and visible in Datahub',
+                en: 'Allow For Species To Be Entered and Visible in Datahub',
                 fr: "Permettre aux espèces d'être saisies et visibles dans Datahub"
               }),
               variant: 'radio'
@@ -156,7 +156,7 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
         idValidationRegex: $RegexString.optional(),
         idValidationRegexErrorMessageEn: z.string().optional(),
         idValidationRegexErrorMessageFr: z.string().optional(),
-        subjectIdDisplayLength: z.number().int().min(1),
+        subjectIdDisplayLength: z.number().int().min(1).optional(),
         speciesVisible: z.boolean().optional()
       })}
       onSubmit={(data) => {

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -22,8 +22,8 @@ type ManageGroupFormProps = {
       accessibleInteractiveInstrumentIds: Set<string>;
       defaultIdentificationMethod?: SubjectIdentificationMethod;
       idValidationRegex?: null | string;
-      subjectIdDisplayLength?: number;
       speciesVisible?: boolean;
+      subjectIdDisplayLength?: number;
     };
   };
   onSubmit: (data: Partial<UpdateGroupData>) => Promisable<any>;
@@ -63,14 +63,6 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
         },
         {
           fields: {
-            subjectIdDisplayLength: {
-              kind: 'number',
-              label: t({
-                en: 'Preferred Subject ID Display Length',
-                fr: "La longueur d'affichage préférée de l'ID"
-              }),
-              variant: 'input'
-            },
             speciesVisible: {
               kind: 'boolean',
               label: t({
@@ -78,6 +70,14 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
                 fr: "Permettre aux espèces d'être saisies et visibles dans Datahub"
               }),
               variant: 'radio'
+            },
+            subjectIdDisplayLength: {
+              kind: 'number',
+              label: t({
+                en: 'Preferred Subject ID Display Length',
+                fr: "La longueur d'affichage préférée de l'ID"
+              }),
+              variant: 'input'
             }
           },
           title: t({
@@ -156,8 +156,8 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
         idValidationRegex: $RegexString.optional(),
         idValidationRegexErrorMessageEn: z.string().optional(),
         idValidationRegexErrorMessageFr: z.string().optional(),
-        subjectIdDisplayLength: z.number().int().min(1).optional(),
-        speciesVisible: z.boolean().optional()
+        speciesVisible: z.boolean().optional(),
+        subjectIdDisplayLength: z.number().int().min(1).optional()
       })}
       onSubmit={(data) => {
         void onSubmit({
@@ -169,8 +169,8 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
               en: data.idValidationRegexErrorMessageEn,
               fr: data.idValidationRegexErrorMessageFr
             },
-            subjectIdDisplayLength: data.subjectIdDisplayLength,
-            speciesVisible: data.speciesVisible
+            speciesVisible: data.speciesVisible,
+            subjectIdDisplayLength: data.subjectIdDisplayLength
           }
         });
       }}

--- a/apps/web/src/features/group/components/ManageGroupForm.tsx
+++ b/apps/web/src/features/group/components/ManageGroupForm.tsx
@@ -23,6 +23,7 @@ type ManageGroupFormProps = {
       defaultIdentificationMethod?: SubjectIdentificationMethod;
       idValidationRegex?: null | string;
       subjectIdDisplayLength?: number;
+      speciesVisible?: boolean;
     };
   };
   onSubmit: (data: Partial<UpdateGroupData>) => Promisable<any>;
@@ -69,6 +70,14 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
                 fr: "La longueur d'affichage préférée de l'ID"
               }),
               variant: 'input'
+            },
+            speciesVisible: {
+              kind: 'boolean',
+              label: t({
+                en: 'Allow for species to be entered and visible in Datahub',
+                fr: "Permettre aux espèces d'être saisies et visibles dans Datahub"
+              }),
+              variant: 'radio'
             }
           },
           title: t({
@@ -147,7 +156,8 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
         idValidationRegex: $RegexString.optional(),
         idValidationRegexErrorMessageEn: z.string().optional(),
         idValidationRegexErrorMessageFr: z.string().optional(),
-        subjectIdDisplayLength: z.number().int().min(1)
+        subjectIdDisplayLength: z.number().int().min(1),
+        speciesVisible: z.boolean().optional()
       })}
       onSubmit={(data) => {
         void onSubmit({
@@ -159,7 +169,8 @@ export const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormPro
               en: data.idValidationRegexErrorMessageEn,
               fr: data.idValidationRegexErrorMessageFr
             },
-            subjectIdDisplayLength: data.subjectIdDisplayLength
+            subjectIdDisplayLength: data.subjectIdDisplayLength,
+            speciesVisible: data.speciesVisible
           }
         });
       }}

--- a/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable perfectionist/sort-objects */
 
-import { useAppStore } from '@/store';
 import { Form } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { FormTypes } from '@opendatacapture/runtime-core';
@@ -13,6 +12,8 @@ import type { Sex, SubjectIdentificationMethod } from '@opendatacapture/schemas/
 import { encodeScopedSubjectId, generateSubjectHash } from '@opendatacapture/subject-utils';
 import type { Promisable } from 'type-fest';
 import { z } from 'zod/v4';
+
+import { useAppStore } from '@/store';
 
 const currentDate = new Date();
 

--- a/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
@@ -120,7 +120,7 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
               kind: 'dynamic',
               deps: ['subjectIdentificationMethod'],
               render({ subjectIdentificationMethod }) {
-                return subjectIdentificationMethod === 'PERSONAL_INFO'
+                return subjectIdentificationMethod === 'PERSONAL_INFO' || subjectIdentificationMethod === 'CUSTOM_ID'
                   ? {
                       description: t('core.identificationData.sex.description'),
                       kind: 'string',

--- a/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable perfectionist/sort-objects */
 
+import { useAppStore } from '@/store';
 import { Form } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { FormTypes } from '@opendatacapture/runtime-core';
@@ -28,6 +29,7 @@ type StartSessionFormData = {
   subjectIdentificationMethod: SubjectIdentificationMethod;
   subjectLastName?: string;
   subjectSex?: Sex;
+  subjectSpecies?: string;
 };
 
 type StartSessionFormProps = {
@@ -39,6 +41,7 @@ type StartSessionFormProps = {
 
 export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubmit }: StartSessionFormProps) => {
   const { resolvedLanguage, t } = useTranslation();
+  const speciesVisible = useAppStore((store) => store.currentGroup?.settings.speciesVisible);
   return (
     <Form
       preventResetValuesOnReset
@@ -133,6 +136,26 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
                     }
                   : null;
               }
+            },
+            subjectSpecies: {
+              kind: 'dynamic',
+              deps: ['subjectIdentificationMethod'],
+              render({ subjectIdentificationMethod }) {
+                return subjectIdentificationMethod === 'CUSTOM_ID' && speciesVisible
+                  ? {
+                      description: t({
+                        en: 'Please enter the species of the animal',
+                        fr: 'Entrer la Espèce animale'
+                      }),
+                      kind: 'string',
+                      label: t({
+                        en: 'Species',
+                        fr: 'Entrer la Espèce animale'
+                      }),
+                      variant: 'input'
+                    }
+                  : null;
+              }
             }
           }
         },
@@ -189,6 +212,7 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
             .max(MIN_DATE_OF_BIRTH, { message: t('session.errors.mustBeAdult') })
             .optional(),
           subjectSex: z.enum(['MALE', 'FEMALE']).optional(),
+          subjectSpecies: z.string().optional(),
           sessionType: $SessionType.exclude(['REMOTE']),
           sessionDate: z
             .date()
@@ -243,7 +267,8 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
         subjectFirstName,
         subjectLastName,
         subjectDateOfBirth,
-        subjectSex
+        subjectSex,
+        subjectSpecies
       }) => {
         if (!subjectId) {
           subjectId = await generateSubjectHash({
@@ -266,7 +291,8 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
             firstName: subjectFirstName,
             lastName: subjectLastName,
             dateOfBirth: subjectDateOfBirth,
-            sex: subjectSex
+            sex: subjectSex,
+            species: subjectSpecies
           }
         });
       }}

--- a/packages/schemas/src/group/group.ts
+++ b/packages/schemas/src/group/group.ts
@@ -13,8 +13,8 @@ export const $GroupSettings = z.object({
       fr: z.string().nullish()
     })
     .nullish(),
-  subjectIdDisplayLength: z.number().nullish(),
-  speciesVisible: z.boolean()
+  speciesVisible: z.boolean().nullish(),
+  subjectIdDisplayLength: z.number().nullish()
 });
 
 export type GroupType = z.infer<typeof $GroupType>;

--- a/packages/schemas/src/group/group.ts
+++ b/packages/schemas/src/group/group.ts
@@ -13,7 +13,8 @@ export const $GroupSettings = z.object({
       fr: z.string().nullish()
     })
     .nullish(),
-  subjectIdDisplayLength: z.number().nullish()
+  subjectIdDisplayLength: z.number().nullish(),
+  speciesVisible: z.boolean()
 });
 
 export type GroupType = z.infer<typeof $GroupType>;

--- a/packages/schemas/src/subject/subject.ts
+++ b/packages/schemas/src/subject/subject.ts
@@ -22,7 +22,8 @@ export const $Subject = $BaseModel.extend({
   firstName: z.string().min(1).nullish(),
   groupIds: z.array(z.string().min(1)),
   lastName: z.string().min(1).nullish(),
-  sex: $Sex.nullish()
+  sex: $Sex.nullish(),
+  species: z.string().optional().nullish()
 });
 
 export type CreateSubjectData = z.infer<typeof $CreateSubjectData>;
@@ -31,5 +32,6 @@ export const $CreateSubjectData = $Subject.pick({
   firstName: true,
   id: true,
   lastName: true,
-  sex: true
+  sex: true,
+  species: true
 });


### PR DESCRIPTION
closes issues #1160 #1159 

Allows for sex to be added to a subject with a custom identifier as their id

Adds a new setting in the group management form to allow a subject species to be visible.
Adds a species attribute to subject.
Let  species to be added to a subject if group setting allows it.
new master data table that can display subjects' species if group setting is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying and managing a subject's species information throughout the application.
  * Introduced a new group setting to control the visibility of species data.
  * Enhanced forms and data tables to include species fields and columns when enabled.

* **Bug Fixes**
  * Made the subject ID display length field optional in group management forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->