### PR TITLE
allow for custom identifier to have the option to enter subject's sex

### DIFF
--- a/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/features/session/components/StartSessionForm/StartSessionForm.tsx
@@ -105,30 +105,18 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
               }
             },
             subjectDateOfBirth: {
-              kind: 'dynamic',
-              deps: [],
-              render() {
-                return {
-                  kind: 'date',
-                  label: t('core.identificationData.dateOfBirth.label')
-                };
-              }
+              kind: 'date',
+              label: t('core.identificationData.dateOfBirth.label')
             },
             subjectSex: {
-              kind: 'dynamic',
-              deps: [],
-              render() {
-                return {
-                  description: t('core.identificationData.sex.description'),
-                  kind: 'string',
-                  label: t('core.identificationData.sex.label'),
-                  options: {
-                    FEMALE: t('core.identificationData.sex.female'),
-                    MALE: t('core.identificationData.sex.male')
-                  },
-                  variant: 'select'
-                };
-              }
+              description: t('core.identificationData.sex.description'),
+              kind: 'string',
+              label: t('core.identificationData.sex.label'),
+              options: {
+                FEMALE: t('core.identificationData.sex.female'),
+                MALE: t('core.identificationData.sex.male')
+              },
+              variant: 'select'
             }
           }
         },


### PR DESCRIPTION
closes issue #1159 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The subject sex and date of birth fields in the session start form are now always displayed, regardless of the identification method used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->