### PR TITLE
Add user to session

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -202,6 +202,7 @@ model User {
   basePermissionLevel   BasePermissionLevel?
   additionalPermissions AuthRule[]
   firstName             String
+  sessions              Session[]
   groupIds              String[]             @db.ObjectId
   groups                Group[]              @relation(fields: [groupIds], references: [id])
   lastName              String
@@ -229,6 +230,8 @@ model Session {
   instrumentRecords InstrumentRecord[]
   subject           Subject?           @relation(fields: [subjectId], references: [id])
   subjectId         String
+  user              User?              @relation(fields: [userId], references: [id])         
+  userId            String?
   type              SessionType
 
   @@map("SessionModel")

--- a/apps/api/src/sessions/dto/create-session.dto.ts
+++ b/apps/api/src/sessions/dto/create-session.dto.ts
@@ -2,6 +2,7 @@ import { ValidationSchema } from '@douglasneuroinformatics/libnest';
 import { $CreateSessionData } from '@opendatacapture/schemas/session';
 import type { SessionType } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
+import type { CreateUserData } from '@opendatacapture/schemas/user';
 
 @ValidationSchema($CreateSessionData)
 export class CreateSessionDto {
@@ -9,4 +10,5 @@ export class CreateSessionDto {
   groupId: null | string;
   subjectData: CreateSubjectData;
   type: SessionType;
+  userData: CreateUserData;
 }

--- a/apps/api/src/sessions/dto/create-session.dto.ts
+++ b/apps/api/src/sessions/dto/create-session.dto.ts
@@ -9,5 +9,5 @@ export class CreateSessionDto {
   groupId: null | string;
   subjectData: CreateSubjectData;
   type: SessionType;
-  userId: null | string | undefined;
+  userId?: null | string;
 }

--- a/apps/api/src/sessions/dto/create-session.dto.ts
+++ b/apps/api/src/sessions/dto/create-session.dto.ts
@@ -2,7 +2,6 @@ import { ValidationSchema } from '@douglasneuroinformatics/libnest';
 import { $CreateSessionData } from '@opendatacapture/schemas/session';
 import type { SessionType } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
-import type { CreateUserData } from '@opendatacapture/schemas/user';
 
 @ValidationSchema($CreateSessionData)
 export class CreateSessionDto {
@@ -10,5 +9,5 @@ export class CreateSessionDto {
   groupId: null | string;
   subjectData: CreateSubjectData;
   type: SessionType;
-  userData: CreateUserData;
+  userId: null | string | undefined;
 }

--- a/apps/api/src/sessions/sessions.module.ts
+++ b/apps/api/src/sessions/sessions.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { GroupsModule } from '@/groups/groups.module';
 import { SubjectsModule } from '@/subjects/subjects.module';
+import { UsersModule } from '@/users/users.module';
 
 import { SessionsController } from './sessions.controller';
 import { SessionsService } from './sessions.service';
@@ -9,7 +10,7 @@ import { SessionsService } from './sessions.service';
 @Module({
   controllers: [SessionsController],
   exports: [SessionsService],
-  imports: [GroupsModule, SubjectsModule],
+  imports: [GroupsModule, SubjectsModule, UsersModule],
   providers: [SessionsService]
 })
 export class SessionsModule {}

--- a/apps/api/src/sessions/sessions.module.ts
+++ b/apps/api/src/sessions/sessions.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 
 import { GroupsModule } from '@/groups/groups.module';
 import { SubjectsModule } from '@/subjects/subjects.module';
-import { UsersModule } from '@/users/users.module';
 
 import { SessionsController } from './sessions.controller';
 import { SessionsService } from './sessions.service';
@@ -10,7 +9,7 @@ import { SessionsService } from './sessions.service';
 @Module({
   controllers: [SessionsController],
   exports: [SessionsService],
-  imports: [GroupsModule, SubjectsModule, UsersModule],
+  imports: [GroupsModule, SubjectsModule],
   providers: [SessionsService]
 })
 export class SessionsModule {}

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -29,16 +29,16 @@ export class SessionsService {
     });
   }
 
-  async create({ date, groupId, subjectData, type, userId }: CreateSessionData): Promise<Session> {
+  async create({ date, groupId, subjectData, type, username }: CreateSessionData): Promise<Session> {
     this.loggingService.debug({ message: 'Attempting to create session' });
     const subject = await this.resolveSubject(subjectData);
 
     let user: null | Omit<User, 'hashedPassword'> = null;
 
-    if (userId) {
+    if (username) {
       user = await this.prismaClient.user.findFirst({
         where: {
-          username: userId
+          username: username
         }
       });
       // user = await this.userService.findById(userId);

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -36,7 +36,7 @@ export class SessionsService {
     let user: null | Omit<User, 'hashedPassword'> = null;
 
     if (userId) {
-      user = await this.prismaClient.user.findUnique({
+      user = await this.prismaClient.user.findFirst({
         where: {
           username: userId
         }

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -1,5 +1,5 @@
-import { accessibleQuery, InjectModel, LoggingService } from '@douglasneuroinformatics/libnest';
-import type { Model } from '@douglasneuroinformatics/libnest';
+import { accessibleQuery, InjectModel, InjectPrismaClient, LoggingService } from '@douglasneuroinformatics/libnest';
+import type { ExtendedPrismaClient, Model } from '@douglasneuroinformatics/libnest';
 import { Injectable } from '@nestjs/common';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common/exceptions';
 import type { Group } from '@opendatacapture/schemas/group';
@@ -15,6 +15,7 @@ import { UsersService } from '@/users/users.service';
 @Injectable()
 export class SessionsService {
   constructor(
+    @InjectPrismaClient() private readonly prismaClient: ExtendedPrismaClient,
     @InjectModel('Session') private readonly sessionModel: Model<'Session'>,
     private readonly groupsService: GroupsService,
     private readonly loggingService: LoggingService,
@@ -35,7 +36,12 @@ export class SessionsService {
     let user: null | Omit<User, 'hashedPassword'> = null;
 
     if (userId) {
-      user = await this.userService.findById(userId);
+      user = await this.prismaClient.user.findUnique({
+        where: {
+          username: userId
+        }
+      });
+      // user = await this.userService.findById(userId);
     }
 
     // If the subject is not yet associated with the group, check it exists then append it

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -10,7 +10,6 @@ import type { Prisma, Session, Subject, User } from '@prisma/client';
 import type { EntityOperationOptions } from '@/core/types';
 import { GroupsService } from '@/groups/groups.service';
 import { SubjectsService } from '@/subjects/subjects.service';
-import { UsersService } from '@/users/users.service';
 
 @Injectable()
 export class SessionsService {
@@ -19,8 +18,7 @@ export class SessionsService {
     @InjectModel('Session') private readonly sessionModel: Model<'Session'>,
     private readonly groupsService: GroupsService,
     private readonly loggingService: LoggingService,
-    private readonly subjectsService: SubjectsService,
-    private readonly userService: UsersService
+    private readonly subjectsService: SubjectsService
   ) {}
 
   async count(where: Prisma.SessionWhereInput = {}, { ability }: EntityOperationOptions = {}) {

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -41,7 +41,6 @@ export class SessionsService {
           username: username
         }
       });
-      // user = await this.userService.findById(userId);
     }
 
     // If the subject is not yet associated with the group, check it exists then append it

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -40,6 +40,13 @@ export class UsersController {
     return this.usersService.findById(id, { ability });
   }
 
+  @ApiOperation({ summary: 'Get User by Username' })
+  @Get('/Check-Username/:username')
+  @RouteAccess({ action: 'read', subject: 'User' })
+  findByUsername(@Param('username') username: string, @CurrentUser('ability') ability: AppAbility) {
+    return this.usersService.findByUsername(username, { ability });
+  }
+
   @ApiOperation({ summary: 'Update User' })
   @Patch(':id')
   @RouteAccess({ action: 'update', subject: 'User' })

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -41,7 +41,7 @@ export class UsersController {
   }
 
   @ApiOperation({ summary: 'Get User by Username' })
-  @Get('/Check-Username/:username')
+  @Get('/check-username/:username')
   @RouteAccess({ action: 'read', subject: 'User' })
   findByUsername(@Param('username') username: string, @CurrentUser('ability') ability: AppAbility) {
     return this.usersService.findByUsername(username, { ability });

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -12,6 +12,13 @@ import { UsersService } from './users.service';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
+  @ApiOperation({ summary: 'Get User by Username' })
+  @Get('/check-username/:username')
+  @RouteAccess({ action: 'read', subject: 'User' })
+  checkUsernameExists(@Param('username') username: string, @CurrentUser('ability') ability: AppAbility) {
+    return this.usersService.checkUsernameExists(username, { ability });
+  }
+
   @ApiOperation({ summary: 'Create User' })
   @Post()
   @RouteAccess({ action: 'create', subject: 'User' })
@@ -38,13 +45,6 @@ export class UsersController {
   @RouteAccess({ action: 'read', subject: 'User' })
   findById(@Param('id') id: string, @CurrentUser('ability') ability: AppAbility) {
     return this.usersService.findById(id, { ability });
-  }
-
-  @ApiOperation({ summary: 'Get User by Username' })
-  @Get('/check-username/:username')
-  @RouteAccess({ action: 'read', subject: 'User' })
-  findByUsername(@Param('username') username: string, @CurrentUser('ability') ability: AppAbility) {
-    return this.usersService.findByUsername(username, { ability });
   }
 
   @ApiOperation({ summary: 'Update User' })

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -17,7 +17,7 @@ export class UsersService {
     private readonly groupsService: GroupsService
   ) {}
 
-  async checkUsernameExists(username: string, { ability }: EntityOperationOptions = {}) {
+  async checkUsernameExists(username: string, { ability }: EntityOperationOptions = {}): Promise<{ success: boolean }> {
     const user = await this.userModel.findFirst({
       include: { groups: true },
       omit: {
@@ -26,9 +26,9 @@ export class UsersService {
       where: { AND: [accessibleQuery(ability, 'read', 'User'), { username }] }
     });
     if (!user) {
-      return false;
+      return { success: false };
     }
-    return user;
+    return { success: true };
   }
 
   async count(

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -17,6 +17,20 @@ export class UsersService {
     private readonly groupsService: GroupsService
   ) {}
 
+  async checkUsernameExists(username: string, { ability }: EntityOperationOptions = {}) {
+    const user = await this.userModel.findFirst({
+      include: { groups: true },
+      omit: {
+        hashedPassword: true
+      },
+      where: { AND: [accessibleQuery(ability, 'read', 'User'), { username }] }
+    });
+    if (!user) {
+      return false;
+    }
+    return user;
+  }
+
   async count(
     filter: NonNullable<Parameters<Model<'User'>['count']>[0]>['where'] = {},
     { ability }: EntityOperationOptions = {}

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -13,8 +13,6 @@ import { encodeScopedSubjectId, generateSubjectHash } from '@opendatacapture/sub
 import type { Promisable } from 'type-fest';
 import { z } from 'zod/v4';
 
-import type { CurrentUser } from '@/store/types';
-
 const currentDate = new Date();
 
 const EIGHTEEN_YEARS = 568025136000; // milliseconds
@@ -34,15 +32,15 @@ type StartSessionFormData = {
 
 type StartSessionFormProps = {
   currentGroup: Group | null;
-  currentUser: CurrentUser | null;
   initialValues?: FormTypes.PartialNullableData<StartSessionFormData>;
   onSubmit: (data: CreateSessionData) => Promisable<void>;
   readOnly: boolean;
+  username: string | undefined;
 };
 
 export const StartSessionForm = ({
   currentGroup,
-  currentUser,
+  username,
   initialValues,
   readOnly,
   onSubmit
@@ -253,7 +251,7 @@ export const StartSessionForm = ({
         await onSubmit({
           date: sessionDate,
           groupId: currentGroup?.id ?? null,
-          username: currentUser?.username ?? null,
+          username: username ?? null,
           type: sessionType,
           subjectData: {
             id: subjectId,

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable perfectionist/sort-objects */
 
+import type { CurrentUser } from '@/store/types';
 import { Form } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { FormTypes } from '@opendatacapture/runtime-core';
@@ -9,7 +10,6 @@ import { $SessionType } from '@opendatacapture/schemas/session';
 import type { CreateSessionData } from '@opendatacapture/schemas/session';
 import { $SubjectIdentificationMethod } from '@opendatacapture/schemas/subject';
 import type { Sex, SubjectIdentificationMethod } from '@opendatacapture/schemas/subject';
-import type { User } from '@opendatacapture/schemas/user';
 import { encodeScopedSubjectId, generateSubjectHash } from '@opendatacapture/subject-utils';
 import type { Promisable } from 'type-fest';
 import { z } from 'zod/v4';
@@ -33,7 +33,7 @@ type StartSessionFormData = {
 
 type StartSessionFormProps = {
   currentGroup: Group | null;
-  currentUser: User | null;
+  currentUser: CurrentUser | null;
   initialValues?: FormTypes.PartialNullableData<StartSessionFormData>;
   onSubmit: (data: CreateSessionData) => Promisable<void>;
   readOnly: boolean;
@@ -252,7 +252,7 @@ export const StartSessionForm = ({
         await onSubmit({
           date: sessionDate,
           groupId: currentGroup?.id ?? null,
-          userId: currentUser?.id ?? null,
+          userId: currentUser?.username ?? null,
           type: sessionType,
           subjectData: {
             id: subjectId,

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -9,6 +9,7 @@ import { $SessionType } from '@opendatacapture/schemas/session';
 import type { CreateSessionData } from '@opendatacapture/schemas/session';
 import { $SubjectIdentificationMethod } from '@opendatacapture/schemas/subject';
 import type { Sex, SubjectIdentificationMethod } from '@opendatacapture/schemas/subject';
+import type { User } from '@opendatacapture/schemas/user';
 import { encodeScopedSubjectId, generateSubjectHash } from '@opendatacapture/subject-utils';
 import type { Promisable } from 'type-fest';
 import { z } from 'zod/v4';
@@ -32,12 +33,19 @@ type StartSessionFormData = {
 
 type StartSessionFormProps = {
   currentGroup: Group | null;
+  currentUser: User | null;
   initialValues?: FormTypes.PartialNullableData<StartSessionFormData>;
   onSubmit: (data: CreateSessionData) => Promisable<void>;
   readOnly: boolean;
 };
 
-export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubmit }: StartSessionFormProps) => {
+export const StartSessionForm = ({
+  currentGroup,
+  currentUser,
+  initialValues,
+  readOnly,
+  onSubmit
+}: StartSessionFormProps) => {
   const { resolvedLanguage, t } = useTranslation();
   return (
     <Form
@@ -244,6 +252,7 @@ export const StartSessionForm = ({ currentGroup, initialValues, readOnly, onSubm
         await onSubmit({
           date: sessionDate,
           groupId: currentGroup?.id ?? null,
+          userId: currentUser?.id ?? null,
           type: sessionType,
           subjectData: {
             id: subjectId,

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -253,7 +253,7 @@ export const StartSessionForm = ({
         await onSubmit({
           date: sessionDate,
           groupId: currentGroup?.id ?? null,
-          userId: currentUser?.username ?? null,
+          username: currentUser?.username ?? null,
           type: sessionType,
           subjectData: {
             id: subjectId,

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable perfectionist/sort-objects */
 
-import type { CurrentUser } from '@/store/types';
 import { Form } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { FormTypes } from '@opendatacapture/runtime-core';
@@ -13,6 +12,8 @@ import type { Sex, SubjectIdentificationMethod } from '@opendatacapture/schemas/
 import { encodeScopedSubjectId, generateSubjectHash } from '@opendatacapture/subject-utils';
 import type { Promisable } from 'type-fest';
 import { z } from 'zod/v4';
+
+import type { CurrentUser } from '@/store/types';
 
 const currentDate = new Date();
 

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -35,7 +35,7 @@ type StartSessionFormProps = {
   initialValues?: FormTypes.PartialNullableData<StartSessionFormData>;
   onSubmit: (data: CreateSessionData) => Promisable<void>;
   readOnly: boolean;
-  username: string | undefined;
+  username?: null | string;
 };
 
 export const StartSessionForm = ({

--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -165,7 +165,7 @@ const RouteComponent = () => {
                 ctx.issues.push({
                   code: 'custom',
                   input: ctx.value.username,
-                  message: 'Username already exists',
+                  message: t('common.usernameExists'),
                   path: ['username']
                 });
             }

--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -24,6 +24,7 @@ const RouteComponent = () => {
     // check if username exists
 
     const exisitingUsername = await axios.get(`/v1/users/check-username/${encodeURIComponent(data.username)}`);
+
     if (exisitingUsername) {
       return { success: false, errorMessage: t('common.usernameExists') };
     }
@@ -147,7 +148,7 @@ const RouteComponent = () => {
             groupIds: z.set(z.string()).optional(),
             confirmPassword: z.string().min(1)
           })
-          .check(async (ctx) => {
+          .check((ctx) => {
             if (!estimatePasswordStrength(ctx.value.password).success) {
               ctx.issues.push({
                 code: 'custom',

--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -6,14 +6,14 @@ import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { $BasePermissionLevel, $CreateUserData } from '@opendatacapture/schemas/user';
 import type { CreateUserData, User } from '@opendatacapture/schemas/user';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import axios from 'axios';
 import { z } from 'zod/v4';
 
 import { PageHeader } from '@/components/PageHeader';
 import { useCreateUserMutation } from '@/hooks/useCreateUserMutation';
 import { groupsQueryOptions, useGroupsQuery } from '@/hooks/useGroupsQuery';
-import axios from 'axios';
 
-const RouteComponent = () => {
+const RouteComponent = async () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const groupsQuery = useGroupsQuery();
@@ -23,6 +23,8 @@ const RouteComponent = () => {
     createUserMutation.mutate({ data });
     void navigate({ to: '..' });
   };
+
+  const existingUsers = await axios.get(`/v1/users`);
 
   return (
     <div>
@@ -157,7 +159,6 @@ const RouteComponent = () => {
               });
             }
 
-            const existingUsers = await axios.get(`/v1/users`);
             if (existingUsers.data) {
               const usersList = existingUsers.data as Omit<User, 'hashedpassword'>[];
 

--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -22,15 +22,17 @@ const RouteComponent = () => {
 
   const handleSubmit = async (data: CreateUserData) => {
     // check if username exists
-    const existingUsername = await axios.get(`/v1/users/check-username/${encodeURIComponent(data.username)}`);
+    const existingUsername = await axios.get<{ success: boolean }>(
+      `/v1/users/check-username/${encodeURIComponent(data.username)}`
+    );
 
-    if (existingUsername.data !== false) {
+    if (existingUsername.data.success === true) {
       notification.addNotification({
         type: 'error',
         message: t('common.usernameExists')
       });
     } else {
-      createUserMutation.mutate({ data });
+      void createUserMutation.mutateAsync({ data });
 
       void navigate({ to: '..' });
     }

--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -23,9 +23,9 @@ const RouteComponent = () => {
   const handleSubmit: FormProps<any>['onSubmit'] = async (data: CreateUserData) => {
     // check if username exists
 
-    const exisitingUsername = await axios.get(`/v1/users/check-username/${encodeURIComponent(data.username)}`);
+    const existingUsername = await axios.get(`/v1/users/check-username/${encodeURIComponent(data.username)}`);
 
-    if (exisitingUsername) {
+    if (existingUsername) {
       return { success: false, errorMessage: t('common.usernameExists') };
     }
 

--- a/apps/web/src/routes/_app/session/start-session.tsx
+++ b/apps/web/src/routes/_app/session/start-session.tsx
@@ -43,9 +43,9 @@ const RouteComponent = () => {
       </PageHeader>
       <StartSessionForm
         currentGroup={currentGroup}
-        currentUser={currentUser}
         initialValues={initialValues}
         readOnly={currentSession !== null || createSessionMutation.isPending}
+        username={currentUser?.username}
         onSubmit={async (formData) => {
           const session = await createSessionMutation.mutateAsync(formData);
           startSession({ ...session, type: formData.type });

--- a/apps/web/src/routes/_app/session/start-session.tsx
+++ b/apps/web/src/routes/_app/session/start-session.tsx
@@ -15,6 +15,7 @@ const RouteComponent = () => {
   const currentGroup = useAppStore((store) => store.currentGroup);
   const currentSession = useAppStore((store) => store.currentSession);
   const startSession = useAppStore((store) => store.startSession);
+  const currentUser = useAppStore((store) => store.currentUser);
   const location = useLocation();
   const defaultInitialValues = {
     sessionType: 'IN_PERSON',
@@ -42,6 +43,7 @@ const RouteComponent = () => {
       </PageHeader>
       <StartSessionForm
         currentGroup={currentGroup}
+        currentUse={currentUser}
         initialValues={initialValues}
         readOnly={currentSession !== null || createSessionMutation.isPending}
         onSubmit={async (formData) => {

--- a/apps/web/src/routes/_app/session/start-session.tsx
+++ b/apps/web/src/routes/_app/session/start-session.tsx
@@ -43,7 +43,7 @@ const RouteComponent = () => {
       </PageHeader>
       <StartSessionForm
         currentGroup={currentGroup}
-        currentUse={currentUser}
+        currentUser={currentUser}
         initialValues={initialValues}
         readOnly={currentSession !== null || createSessionMutation.isPending}
         onSubmit={async (formData) => {

--- a/apps/web/src/translations/common.json
+++ b/apps/web/src/translations/common.json
@@ -150,5 +150,9 @@
   "username": {
     "en": "Username",
     "fr": "Nom d'utilisateur"
+  },
+  "usernameExists": {
+    "en": "Username already exists",
+    "fr": "Le nom d'utilisateur existe déjà"
   }
 }

--- a/packages/schemas/src/session/session.ts
+++ b/packages/schemas/src/session/session.ts
@@ -22,5 +22,5 @@ export const $CreateSessionData = z.object({
   groupId: z.string().nullable(),
   subjectData: $CreateSubjectData,
   type: $SessionType,
-  userId: z.string().nullish()
+  username: z.string().nullish()
 });

--- a/packages/schemas/src/session/session.ts
+++ b/packages/schemas/src/session/session.ts
@@ -12,7 +12,8 @@ export const $Session = $BaseModel.extend({
   groupId: z.string().nullable(),
   subject: $Subject,
   subjectId: z.string(),
-  type: $SessionType
+  type: $SessionType,
+  userId: z.string().nullable()
 });
 
 export type CreateSessionData = z.infer<typeof $CreateSessionData>;
@@ -20,5 +21,6 @@ export const $CreateSessionData = z.object({
   date: z.coerce.date(),
   groupId: z.string().nullable(),
   subjectData: $CreateSubjectData,
-  type: $SessionType
+  type: $SessionType,
+  userId: z.string().nullish()
 });

--- a/packages/schemas/src/session/session.ts
+++ b/packages/schemas/src/session/session.ts
@@ -13,7 +13,7 @@ export const $Session = $BaseModel.extend({
   subject: $Subject,
   subjectId: z.string(),
   type: $SessionType,
-  userId: z.string().nullable()
+  userId: z.string().nullish()
 });
 
 export type CreateSessionData = z.infer<typeof $CreateSessionData>;

--- a/packages/schemas/src/subject/subject.ts
+++ b/packages/schemas/src/subject/subject.ts
@@ -22,6 +22,7 @@ export const $Subject = $BaseModel.extend({
   firstName: z.string().min(1).nullish(),
   groupIds: z.array(z.string().min(1)),
   lastName: z.string().min(1).nullish(),
+  sessionIds: z.array(z.string()).nullish(),
   sex: $Sex.nullish()
 });
 


### PR DESCRIPTION
works on issues 

#1182 
#1140 

For issue #1182 I've added a check to see if the requested username already exists in our database, if so I added a warning the form to refrain the user from using that name

For issue #1140 schema has been update to have userid attached to sessions. The create session from now tracks userIds and attaches to the created session. In addition, a new method in the users.service that finds a user by their username. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can now be linked to users, allowing for user-associated session tracking.
  * Added the ability to specify a username when starting a session.
  * User creation now checks for existing usernames and provides localized error messages if the username already exists.
  * Introduced a new API endpoint to check if a username exists.

* **Bug Fixes**
  * Improved form validation and feedback during user creation.

* **Localization**
  * Added translations for username existence error messages in English and French.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->