### PR TITLE
Subject service tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@douglasneuroinformatics/libcrypto": "catalog:",
     "@douglasneuroinformatics/libjs": "catalog:",
-    "@douglasneuroinformatics/libnest": "^7.3.2",
+    "@douglasneuroinformatics/libnest": "^7.3.3",
     "@douglasneuroinformatics/libpasswd": "catalog:",
     "@douglasneuroinformatics/libstats": "catalog:",
     "@faker-js/faker": "^9.4.0",

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -26,7 +26,16 @@ describe('SubjectsService', () => {
         {
           provide: PRISMA_CLIENT_TOKEN,
           useValue: {
-            $transaction: vi.fn()
+            $transaction: vi.fn(),
+            instrumentRecord: {
+              deleteMany: vi.fn()
+            },
+            session: {
+              deleteMany: vi.fn()
+            },
+            subject: {
+              deleteMany: vi.fn()
+            }
           }
         }
       ]
@@ -81,6 +90,9 @@ describe('SubjectsService', () => {
       subjectModel.findFirst.mockResolvedValueOnce({ id: '123' });
       await subjectsService.deleteById('123', { force: true });
       expect(subjectModel.delete).not.toHaveBeenCalled();
+      expect(prismaClient.session.deleteMany).toHaveBeenCalled();
+      expect(prismaClient.instrumentRecord.deleteMany).toHaveBeenCalled();
+      expect(prismaClient.subject.deleteMany).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -93,6 +93,7 @@ describe('SubjectsService', () => {
       expect(prismaClient.session.deleteMany).toHaveBeenCalled();
       expect(prismaClient.instrumentRecord.deleteMany).toHaveBeenCalled();
       expect(prismaClient.subject.deleteMany).toHaveBeenCalled();
+      expect(prismaClient.$transaction).toHaveBeenCalledOnce();
     });
   });
 

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -95,6 +95,10 @@ describe('SubjectsService', () => {
       expect(prismaClient.subject.deleteMany).toHaveBeenCalled();
       expect(prismaClient.$transaction).toHaveBeenCalledOnce();
     });
+    it('should throw NotFoundException when subject does not exist', async () => {
+      subjectModel.findFirst.mockResolvedValueOnce(null);
+      await expect(subjectsService.deleteById('123')).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 
   describe('findById', () => {

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -1,11 +1,10 @@
-import { CryptoService, getModelToken } from '@douglasneuroinformatics/libnest';
+import { CryptoService, getModelToken, PRISMA_CLIENT_TOKEN } from '@douglasneuroinformatics/libnest';
 import type { ExtendedPrismaClient, Model } from '@douglasneuroinformatics/libnest';
 import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
 import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { pick } from 'lodash-es';
-import { PRISMA_CLIENT_TOKEN } from 'node_modules/@douglasneuroinformatics/libnest/dist/modules/prisma/prisma.config';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SubjectsService } from '../subjects.service';


### PR DESCRIPTION
closes issue #1184 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for deleting subjects covering normal deletion, forced deletion (which triggers related-record removals within a transaction), and handling of non-existent subjects; tests include enhanced mocks to simulate database transaction behavior.
* **Chores**
  * Updated a backend dependency to a patch release to align with the test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->