### PR TITLE
feat: support importing appending raw html to instrument body prior to running legacy scripts

### DIFF
--- a/apps/playground/src/instruments/examples/interactive/Interactive-With-Legacy-Script/index.html
+++ b/apps/playground/src/instruments/examples/interactive/Interactive-With-Legacy-Script/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <h1>Instrument</h1>
+    <button type="button" id="submit-btn">Submit</button>
+  </body>
+</html>

--- a/apps/playground/src/instruments/examples/interactive/Interactive-With-Legacy-Script/index.ts
+++ b/apps/playground/src/instruments/examples/interactive/Interactive-With-Legacy-Script/index.ts
@@ -3,6 +3,8 @@
 import { defineInstrument } from '/runtime/v1/@opendatacapture/runtime-core';
 import { z } from '/runtime/v1/zod@3.x';
 
+import html from './index.html';
+
 import './legacy.js?legacy';
 
 export default defineInstrument({
@@ -15,13 +17,12 @@ export default defineInstrument({
   tags: ['Legacy', 'Internet Explorer 6'],
   content: {
     render(done) {
-      const button = document.createElement('button');
-      button.textContent = 'Submit Instrument';
-      document.body.appendChild(button);
+      const button = document.getElementById('submit-btn')!;
       button.addEventListener('click', () => {
         done({ message });
       });
-    }
+    },
+    html
   },
   clientDetails: {
     estimatedDuration: 1,

--- a/apps/playground/src/instruments/index.ts
+++ b/apps/playground/src/instruments/index.ts
@@ -8,7 +8,7 @@ import { loadAssetAsBase64 } from '@/utils/load';
 // Instruments in development
 const EXCLUDED_LABELS: string[] = [];
 
-const textFiles: { [key: string]: string } = import.meta.glob('./**/*.{css,js,jsx,json,ts,tsx,svg}', {
+const textFiles: { [key: string]: string } = import.meta.glob('./**/*.{css,js,jsx,json,ts,tsx,svg,html}', {
   eager: true,
   import: 'default',
   query: '?raw'

--- a/packages/instrument-bundler/src/bundle.ts
+++ b/packages/instrument-bundler/src/bundle.ts
@@ -43,7 +43,7 @@ const GLOBALS = `
 export async function createBundle(output: BuildOutput, options: { minify: boolean }) {
   let inject = '';
   const style = output.css ? `"${btoa(output.css)}"` : undefined;
-  const scripts = output.legacyScripts
+  const scripts = output.legacyScripts?.length
     ? `[${output.legacyScripts.map((content) => `"${btoa(content)}"`).join(', ')}]`
     : undefined;
   if (style || scripts) {

--- a/packages/instrument-interpreter/src/index.ts
+++ b/packages/instrument-interpreter/src/index.ts
@@ -28,8 +28,9 @@ export class InstrumentInterpreter {
     options?: InterpretOptions<TKind>
   ): Promise<SomeInstrument<TKind>> {
     let instrument: AnyInstrument;
+    let value: unknown;
     try {
-      const value: unknown = await evaluateInstrument(bundle);
+      value = await evaluateInstrument(bundle);
       if (!options?.validate) {
         instrument = value as SomeInstrument<TKind>;
       } else if (options.kind === 'FORM') {
@@ -44,6 +45,12 @@ export class InstrumentInterpreter {
         throw new Error(`Unexpected kind: ${options.kind}`);
       }
     } catch (error) {
+      if (value) {
+        console.error({
+          message: 'Validation Error',
+          value
+        });
+      }
       throw new Error(`Failed to evaluate instrument bundle`, { cause: error });
     }
     instrument.id = options?.id;

--- a/packages/react-core/src/components/InteractiveContent/InteractiveContent.tsx
+++ b/packages/react-core/src/components/InteractiveContent/InteractiveContent.tsx
@@ -121,7 +121,19 @@ export const InteractiveContent = React.memo<InteractiveContentProps>(function I
           lang={resolvedLanguage}
           name="interactive-instrument"
           ref={iFrameRef}
-          srcDoc={`<script type="module">${bootstrapScript}</script>`}
+          srcDoc={[
+            `<!DOCTYPE html>`,
+            `<html>`,
+            `<head>`,
+            `<meta charset="UTF-8">`,
+            `<meta name="viewport" content="width=device-width, initial-scale=1.0">`,
+            `<title>Document</title>`,
+            `<script type="module">${bootstrapScript}</script>`,
+            `</head>`,
+            `<body>`,
+            `</body>`,
+            `</html>`
+          ].join('')}
           style={{ backgroundColor: 'white', height: dimensions, scale: `${scale}%`, width: dimensions }}
           title="Open Data Capture - Interactive Instrument"
         />

--- a/packages/react-core/src/components/InteractiveContent/bootstrap.js
+++ b/packages/react-core/src/components/InteractiveContent/bootstrap.js
@@ -54,6 +54,21 @@ if (!bundle) {
 /** @type {import('@opendatacapture/runtime-core').InteractiveInstrument }*/
 const instrument = await evaluateInstrument(bundle);
 
+if (instrument.content.meta) {
+  Object.entries(instrument.content.meta).forEach(([name, content]) => {
+    const meta = document.createElement('meta');
+    meta.name = name;
+    meta.content = content;
+    document.head.appendChild(meta);
+  });
+}
+
+const encodedStyle = instrument.content.__injectHead?.style;
+if (encodedStyle) {
+  const style = atob(encodedStyle);
+  document.head.insertAdjacentHTML('beforeend', `<style>${style}</style>`);
+}
+
 if (instrument.content.html) {
   document.body.insertAdjacentHTML('beforeend', instrument.content.html);
 }
@@ -65,11 +80,5 @@ scripts?.forEach((encodedScript) => {
   script.textContent = atob(encodedScript);
   document.head.appendChild(script);
 });
-
-const encodedStyle = instrument.content.__injectHead?.style;
-if (encodedStyle) {
-  const style = atob(encodedStyle);
-  document.head.insertAdjacentHTML('beforeend', `<style>${style}</style>`);
-}
 
 await instrument.content.render(done);

--- a/packages/react-core/src/components/InteractiveContent/bootstrap.js
+++ b/packages/react-core/src/components/InteractiveContent/bootstrap.js
@@ -51,9 +51,13 @@ if (!bundle) {
   throw new Error("Failed to get 'data-bundle' attribute from frame element");
 }
 
+/** @type {import('@opendatacapture/runtime-core').InteractiveInstrument }*/
 const instrument = await evaluateInstrument(bundle);
 
-/** @type {string[] | undefined} */
+if (instrument.content.html) {
+  document.body.insertAdjacentHTML('beforeend', instrument.content.html);
+}
+
 const scripts = instrument.content.__injectHead?.scripts;
 scripts?.forEach((encodedScript) => {
   const script = document.createElement('script');

--- a/packages/runtime-core/src/types/instrument.interactive.ts
+++ b/packages/runtime-core/src/types/instrument.interactive.ts
@@ -25,6 +25,7 @@ declare type InteractiveInstrument<
         /** base64 encoded css */
         readonly style?: string;
       };
+      html?: string;
       render: (done: (data: TData) => void) => Promisable<void>;
     };
     kind: 'INTERACTIVE';

--- a/packages/runtime-core/src/types/instrument.interactive.ts
+++ b/packages/runtime-core/src/types/instrument.interactive.ts
@@ -26,6 +26,9 @@ declare type InteractiveInstrument<
         readonly style?: string;
       };
       html?: string;
+      meta?: {
+        [name: string]: string;
+      };
       render: (done: (data: TData) => void) => Promisable<void>;
     };
     kind: 'INTERACTIVE';

--- a/packages/schemas/src/instrument/instrument.interactive.ts
+++ b/packages/schemas/src/instrument/instrument.interactive.ts
@@ -13,6 +13,7 @@ const $InteractiveInstrument = $ScalarInstrument.extend({
       })
       .optional()
       .readonly(),
+    html: z.string().optional(),
     render: $AnyFunction
   }),
   details: $InstrumentDetails,

--- a/packages/schemas/src/instrument/instrument.interactive.ts
+++ b/packages/schemas/src/instrument/instrument.interactive.ts
@@ -14,6 +14,7 @@ const $InteractiveInstrument = $ScalarInstrument.extend({
       .optional()
       .readonly(),
     html: z.string().optional(),
+    meta: z.record(z.string(), z.string()).optional(),
     render: $AnyFunction
   }),
   details: $InstrumentDetails,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive instruments can include inline HTML and meta tags; HTML/meta/style are applied before scripts.
  * Playground: added an example demonstrating an interactive instrument using legacy script markup.

* **Bug Fixes**
  * Prevents injecting empty legacy script payloads when none are present.

* **Chores**
  * Improved error reporting during instrument evaluation for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->