### PR TITLE
Make interactive dashboard cards scrollable, fix mobile ui issue.

### DIFF
--- a/apps/web/src/routes/_app/dashboard.tsx
+++ b/apps/web/src/routes/_app/dashboard.tsx
@@ -202,7 +202,7 @@ const RouteComponent = () => {
                     </Dialog.Title>
                   </Dialog.Header>
                   <hr></hr>
-                  <ul className="flex flex-col gap-5 overflow-auto">
+                  <ul className="flex max-h-[60vh] flex-col gap-5 overflow-auto pr-3">
                     {userInfoQuery.isLoading && <Spinner />}
                     {userInfoQuery.isError && (
                       <p>
@@ -286,7 +286,7 @@ const RouteComponent = () => {
                       })}
                     </Dialog.Title>
                   </Dialog.Header>
-                  <ul className="flex flex-col gap-5 overflow-auto">
+                  <ul className="flex max-h-[60vh] flex-col gap-5 overflow-auto pr-3">
                     {!instrumentInfo && (
                       <p>
                         {t({
@@ -355,7 +355,7 @@ const RouteComponent = () => {
                       })}
                     </Dialog.Title>
                   </Dialog.Header>
-                  <ul className="flex flex-col gap-5 overflow-auto">
+                  <ul className="flex max-h-[60vh] flex-col gap-5 overflow-auto pr-3">
                     {!instrumentInfo && (
                       <p>
                         {t({


### PR DESCRIPTION
Works on issue #1291 

Makes interactive cards scrollable. 

Resolves issue of instrument card not being closable on mobile. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Constrained vertical height for Users, Instruments, and Records modals to improve scrolling behavior.
  * Added horizontal padding inside those modal lists for clearer spacing and improved visual alignment.
  * Overall result: smoother scrolling and cleaner presentation within the affected modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->