### PR TITLE
add serve-instrument to docs

### DIFF
--- a/docs/en/3-guides/3.0-how-to-create-an-instrument.mdx
+++ b/docs/en/3-guides/3.0-how-to-create-an-instrument.mdx
@@ -8,6 +8,13 @@ sidebar:
 import { Steps } from '@astrojs/starlight/components';
 import Screenshot from '@/components/common/Screenshot.astro';
 
+There are two ways to create and test an instrument:
+
+- **Instrument Playground**: create, validate, and upload your instrument in the browser.
+- **Local Development (CLI)**: run an instrument folder on your machine using `@opendatacapture/serve-instrument`.
+
+## Instrument Playground (Recommended)
+
 ### Steps
 
 <Steps>
@@ -31,3 +38,21 @@ import Screenshot from '@/components/common/Screenshot.astro';
     <Screenshot alt="upload bundle form" name="upload-bundle" />
 
 </Steps>
+
+## Local Development (CLI)
+
+To use the CLI you must have **Node.js** installed on your machine.
+
+Install the CLI globally:
+
+```bash
+npm install -g @opendatacapture/serve-instrument
+```
+
+Then run it against your instrument folder containing an entrypoint (index.tsx, index.jsx, index.ts, index.js):
+
+```bash
+serve-instrument ./path/to/instrument
+```
+
+The server watches the instrument directory and rebuilds automatically when files change (refresh the browser to load the latest bundle).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guide sections for creating instruments: Instrument Playground (recommended) for in-browser creation, validation, and upload, and Local Development (CLI) with setup instructions, automatic rebuild on file changes, and browser refresh capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->