### PR TITLE
Fix stuck navbar ui issue on iphone se

### DIFF
--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -95,16 +95,18 @@ export const Navbar = () => {
           ))}
         </nav>
         <Sheet.Footer className="mt-auto">
-          <div className="flex justify-end gap-2">
+          <div className="flex w-full justify-between gap-2 md:justify-end">
             <UserDropup />
-            <LanguageToggle
-              options={{
-                en: 'English',
-                fr: 'Français'
-              }}
-              variant="outline"
-            />
-            <ThemeToggle variant="outline" />
+            <div className="flex gap-2">
+              <LanguageToggle
+                options={{
+                  en: 'English',
+                  fr: 'Français'
+                }}
+                variant="outline"
+              />
+              <ThemeToggle variant="outline" />
+            </div>
           </div>
         </Sheet.Footer>
       </Sheet.Content>

--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -58,7 +58,7 @@ export const Navbar = () => {
           <Branding className="h-10" fontSize="md" />
         </Sheet.Header>
         <Separator />
-        <nav className="flex w-full grow flex-col divide-y divide-slate-200 dark:divide-slate-700">
+        <nav className="flex w-full grow flex-col divide-y divide-slate-200 overflow-auto dark:divide-slate-700">
           {navItems.map((items, i) => (
             <div className="flex flex-col py-1 first:pt-0 last:pb-0" key={i}>
               {items.map(({ disabled, url, ...props }) => (


### PR DESCRIPTION
Small fix to resolve stuck navbar on iphone se horizontal view

allows the navbar items to be scrollable if they all don't fix on the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navbar now supports vertical scrolling when content overflows, preventing layout breakage on smaller screens or with many items.

* **Style / UI**
  * Footer controls rearranged for improved spacing and alignment across screen sizes, enhancing usability and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->