### PR TITLE
fix AI mistakes

### DIFF
--- a/docs/en/2-tutorials/2.3-simulate-poor-network.md
+++ b/docs/en/2-tutorials/2.3-simulate-poor-network.md
@@ -9,8 +9,8 @@ This guide explains how to use the staged toxic proxy setup to simulate poor net
 
 When you run `scripts/toxic-proxy.sh`, it configures Toxiproxy with the following simulated network conditions:
 
-- **Downstream bandwidth limit (API → browser):** capped at **5,000 bytes/second** (~5 KB/s).
-- **Upstream bandwidth limit (browser → API):** capped at **2,500 bytes/second** (~2.5 KB/s).
+- **Downstream bandwidth limit (API → browser):** capped at **5,000 KB/second** (~5 MB/s).
+- **Upstream bandwidth limit (browser → API):** capped at **2,500 KB/second** (~2.5 MB/s).
 - **Intermittent latency and jitter (downstream):**
   - Base latency of **50 ms**, plus up to **500 ms of jitter**.
   - Applied with **20% toxicity**, meaning only about 1 in 5 downstream requests/responses are delayed in this way.

--- a/scripts/toxic-proxy.sh
+++ b/scripts/toxic-proxy.sh
@@ -35,13 +35,13 @@ sleep 1
 
 toxiproxy-cli create --listen "0.0.0.0:$API_DEV_TOXIC_PROXY_PORT" --upstream "127.0.0.1:$API_DEV_SERVER_PORT" odc-api
 
-toxiproxy-cli toxic add -n downstream-bandwidth -t bandwidth -a rate=5000 -a type=downstream odc-api
+toxiproxy-cli toxic add -n downstream-bandwidth -t bandwidth -a rate=5000 -a --downstream odc-api
 
-toxiproxy-cli toxic add -n upstream-bandwidth -t bandwidth -a rate=2500 -a type=upstream odc-api
+toxiproxy-cli toxic add -n upstream-bandwidth -t bandwidth -a rate=2500 -a --upstream odc-api
 
-toxiproxy-cli toxic add -n latency -t latency -a latency=50 -a jitter=500 -a type=downstream -toxicity 0.2 odc-api
+toxiproxy-cli toxic add -n latency -t latency -a latency=50 -a jitter=500 -a --downstream -toxicity 0.2 odc-api
 
-toxiproxy-cli toxic add -n random-resets -t reset_peer -a type=tox_type=downstream -toxicity 0.1 odc-api
+toxiproxy-cli toxic add -n random-resets -t reset_peer -a --downstream -toxicity 0.1 odc-api
 
 wait "$TOXIPROXY_PID"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bandwidth limit examples in the network simulation tutorial to use kilobytes/second (KB/s) and megabytes/second (MB/s) units instead of bytes/second.

* **Chores**
  * Fixed command syntax to properly specify downstream and upstream parameters in network simulation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->