### PR TITLE
Adjust age limit

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -99,6 +99,8 @@ type GroupSettings {
   idValidationRegex             String?
   idValidationRegexErrorMessage ErrorMessage?
   subjectIdDisplayLength        Int?
+  minimumAge                    Int?
+  minimumAgeApplied             Boolean?
 }
 
 model Group {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -100,7 +100,6 @@ type GroupSettings {
   idValidationRegexErrorMessage ErrorMessage?
   subjectIdDisplayLength        Int?
   minimumAge                    Int?
-  minimumAgeApplied             Boolean?
 }
 
 model Group {

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -42,7 +42,7 @@ export const StartSessionForm = ({
   onSubmit
 }: StartSessionFormProps) => {
   const { resolvedLanguage, t } = useTranslation();
-  const MIN_DATE_OF_BIRTH = currentGroup?.settings.minimumAgeApplied
+  const minDateOfBirth = currentGroup?.settings.minimumAge
     ? new Date(
         currentDate.getTime() -
           (currentGroup?.settings.minimumAge ? currentGroup?.settings.minimumAge * 31556952000 : 0)
@@ -183,8 +183,8 @@ export const StartSessionForm = ({
             .optional()
             .refine(
               (date) => {
-                if (!date || !MIN_DATE_OF_BIRTH) return true;
-                return date <= MIN_DATE_OF_BIRTH;
+                if (!date || !minDateOfBirth) return true;
+                return date <= minDateOfBirth;
               },
               {
                 message: t({

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -15,9 +15,9 @@ import { z } from 'zod/v4';
 
 const currentDate = new Date();
 
-const EIGHTEEN_YEARS = 568025136000; // milliseconds
+// const EIGHTEEN_YEARS = 568025136000; // milliseconds
 
-const MIN_DATE_OF_BIRTH = new Date(currentDate.getTime() - EIGHTEEN_YEARS);
+//const MIN_DATE_OF_BIRTH = new Date(currentDate.getTime() - EIGHTEEN_YEARS);
 
 type StartSessionFormData = {
   sessionDate: Date;
@@ -46,6 +46,13 @@ export const StartSessionForm = ({
   onSubmit
 }: StartSessionFormProps) => {
   const { resolvedLanguage, t } = useTranslation();
+  const MIN_DATE_OF_BIRTH = currentGroup?.settings.minimumAgeApplied
+    ? new Date(
+        currentDate.getTime() -
+          (currentGroup?.settings.minimumAge ? currentGroup?.settings.minimumAge * 31556952000 : 0)
+      )
+    : undefined;
+
   return (
     <Form
       preventResetValuesOnReset
@@ -177,8 +184,26 @@ export const StartSessionForm = ({
             .optional(),
           subjectDateOfBirth: z
             .date()
-            .max(MIN_DATE_OF_BIRTH, { message: t('session.errors.mustBeAdult') })
-            .optional(),
+
+            // .max(MIN_DATE_OF_BIRTH, { message: t({
+            //   en: `Subject must be above age of ${currentGroup?.settings.minimumAge}`,
+            //   fr: `Le sujet doit être âgé de plus de ${currentGroup?.settings.minimumAge}`
+            // }) })
+            .optional()
+            .refine(
+              (date) => {
+                // If there's no date picked or no limit defined, it's valid
+                if (!date || !MIN_DATE_OF_BIRTH) return true;
+                // Otherwise, ensure the date is not after the maximum allowed date
+                return date <= MIN_DATE_OF_BIRTH;
+              },
+              {
+                message: t({
+                  en: `Subject must be above age of ${currentGroup?.settings.minimumAge}`,
+                  fr: `Le sujet doit être âgé de plus de ${currentGroup?.settings.minimumAge}`
+                })
+              }
+            ),
           subjectSex: z.enum(['MALE', 'FEMALE']).optional(),
           sessionType: $SessionType.exclude(['REMOTE']),
           sessionDate: z

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -15,10 +15,6 @@ import { z } from 'zod/v4';
 
 const currentDate = new Date();
 
-// const EIGHTEEN_YEARS = 568025136000; // milliseconds
-
-//const MIN_DATE_OF_BIRTH = new Date(currentDate.getTime() - EIGHTEEN_YEARS);
-
 type StartSessionFormData = {
   sessionDate: Date;
   sessionType: 'IN_PERSON' | 'RETROSPECTIVE';
@@ -184,17 +180,10 @@ export const StartSessionForm = ({
             .optional(),
           subjectDateOfBirth: z
             .date()
-
-            // .max(MIN_DATE_OF_BIRTH, { message: t({
-            //   en: `Subject must be above age of ${currentGroup?.settings.minimumAge}`,
-            //   fr: `Le sujet doit être âgé de plus de ${currentGroup?.settings.minimumAge}`
-            // }) })
             .optional()
             .refine(
               (date) => {
-                // If there's no date picked or no limit defined, it's valid
                 if (!date || !MIN_DATE_OF_BIRTH) return true;
-                // Otherwise, ensure the date is not after the maximum allowed date
                 return date <= MIN_DATE_OF_BIRTH;
               },
               {

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -43,10 +43,7 @@ export const StartSessionForm = ({
 }: StartSessionFormProps) => {
   const { resolvedLanguage, t } = useTranslation();
   const minDateOfBirth = currentGroup?.settings.minimumAge
-    ? new Date(
-        currentDate.getTime() -
-          (currentGroup?.settings.minimumAge ? currentGroup?.settings.minimumAge * 31556952000 : 0)
-      )
+    ? new Date(currentDate.getTime() - currentGroup.settings.minimumAge * 31556952000)
     : undefined;
 
   return (

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -32,9 +32,9 @@ type ManageGroupFormProps = {
       accessibleInteractiveInstrumentIds: Set<string>;
       defaultIdentificationMethod?: SubjectIdentificationMethod;
       idValidationRegex?: null | string;
-      minimumAge?: number;
-      minimumAgeApplied?: boolean;
-      subjectIdDisplayLength?: number;
+      minimumAge?: null | number;
+      minimumAgeApplied?: boolean | null;
+      subjectIdDisplayLength?: null | number;
     };
   };
   onSubmit: (data: Partial<UpdateGroupData>) => Promisable<any>;

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -247,7 +247,10 @@ const RouteComponent = () => {
       defaultIdentificationMethod,
       idValidationRegex: settings?.idValidationRegex,
       idValidationRegexErrorMessageEn: settings?.idValidationRegexErrorMessage?.en,
-      idValidationRegexErrorMessageFr: settings?.idValidationRegexErrorMessage?.fr
+      idValidationRegexErrorMessageFr: settings?.idValidationRegexErrorMessage?.fr,
+      minimumAge: settings?.minimumAge,
+      minimumAgeApplied: settings?.minimumAgeApplied,
+      subjectIdDisplayLength: settings?.subjectIdDisplayLength
     };
     for (const instrument of availableInstruments) {
       if (instrument.kind === 'FORM') {

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -32,6 +32,8 @@ type ManageGroupFormProps = {
       accessibleInteractiveInstrumentIds: Set<string>;
       defaultIdentificationMethod?: SubjectIdentificationMethod;
       idValidationRegex?: null | string;
+      minimumAge?: number;
+      minimumAgeApplied?: boolean;
       subjectIdDisplayLength?: number;
     };
   };
@@ -84,6 +86,40 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
           title: t({
             en: 'Display Settings',
             fr: "Paramètres d'affichage"
+          })
+        },
+        {
+          fields: {
+            minimumAgeApplied: {
+              kind: 'boolean',
+              label: t({
+                en: 'Apply Minimum Age For Subjects',
+                fr: 'Appliquer un âge minimum aux sujets'
+              }),
+              variant: 'radio'
+            },
+            // eslint-disable-next-line perfectionist/sort-objects
+            minimumAge: {
+              deps: ['minimumAgeApplied'],
+              kind: 'dynamic',
+              render: (data) => {
+                if (data.minimumAgeApplied) {
+                  return {
+                    kind: 'number',
+                    label: t({
+                      en: 'Enter minimum age',
+                      fr: "Entrez l'âge minimum"
+                    }),
+                    variant: 'input'
+                  };
+                }
+                return null;
+              }
+            }
+          },
+          title: t({
+            en: 'Age Limit Settings',
+            fr: "Paramètres de l'âge"
           })
         },
         {
@@ -157,6 +193,8 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
         idValidationRegex: $RegexString.optional(),
         idValidationRegexErrorMessageEn: z.string().optional(),
         idValidationRegexErrorMessageFr: z.string().optional(),
+        minimumAge: z.number().int().positive().optional(),
+        minimumAgeApplied: z.boolean().optional(),
         subjectIdDisplayLength: z.number().int().min(1)
       })}
       onSubmit={(data) => {
@@ -169,6 +207,8 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
               en: data.idValidationRegexErrorMessageEn,
               fr: data.idValidationRegexErrorMessageFr
             },
+            minimumAge: data.minimumAge,
+            minimumAgeApplied: data.minimumAgeApplied,
             subjectIdDisplayLength: data.subjectIdDisplayLength
           }
         });

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -107,8 +107,8 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                   return {
                     kind: 'number',
                     label: t({
-                      en: 'Enter Minimum Age',
-                      fr: "Entrez l'âge minimum"
+                      en: 'Minimum Age',
+                      fr: "L'âge minimum"
                     }),
                     variant: 'input'
                   };

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -107,7 +107,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                   return {
                     kind: 'number',
                     label: t({
-                      en: 'Enter minimum age',
+                      en: 'Enter Minimum Age',
                       fr: "Entrez l'âge minimum"
                     }),
                     variant: 'input'
@@ -195,7 +195,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
         idValidationRegexErrorMessageFr: z.string().optional(),
         minimumAge: z.number().int().positive().optional(),
         minimumAgeApplied: z.boolean().optional(),
-        subjectIdDisplayLength: z.number().int().min(1)
+        subjectIdDisplayLength: z.number().int().min(1).optional()
       })}
       onSubmit={(data) => {
         void onSubmit({

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -186,17 +186,32 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
       initialValues={initialValues}
       preventResetValuesOnReset={true}
       readOnly={readOnly}
-      validationSchema={z.object({
-        accessibleFormInstrumentIds: z.set(z.string()),
-        accessibleInteractiveInstrumentIds: z.set(z.string()),
-        defaultIdentificationMethod: $SubjectIdentificationMethod.optional(),
-        idValidationRegex: $RegexString.optional(),
-        idValidationRegexErrorMessageEn: z.string().optional(),
-        idValidationRegexErrorMessageFr: z.string().optional(),
-        minimumAge: z.number().int().positive().optional(),
-        minimumAgeApplied: z.boolean().optional(),
-        subjectIdDisplayLength: z.number().int().min(1).optional()
-      })}
+      validationSchema={z
+        .object({
+          accessibleFormInstrumentIds: z.set(z.string()),
+          accessibleInteractiveInstrumentIds: z.set(z.string()),
+          defaultIdentificationMethod: $SubjectIdentificationMethod.optional(),
+          idValidationRegex: $RegexString.optional(),
+          idValidationRegexErrorMessageEn: z.string().optional(),
+          idValidationRegexErrorMessageFr: z.string().optional(),
+          minimumAge: z.number().int().positive().optional(),
+          minimumAgeApplied: z.boolean().optional(),
+          subjectIdDisplayLength: z.number().int().min(1).optional()
+        })
+        .check((ctx) => {
+          if (ctx.value.minimumAgeApplied && !ctx.value.minimumAge) {
+            ctx.issues.push({
+              code: 'custom',
+              input: ctx.value.minimumAge,
+              message: t({
+                en: 'Please enter an age',
+                fr: "Entrez un âge s'il vous plait"
+              }),
+              path: ['minimumAge']
+            });
+          }
+          return;
+        })}
       onSubmit={(data) => {
         void onSubmit({
           accessibleInstrumentIds: [...data.accessibleFormInstrumentIds, ...data.accessibleInteractiveInstrumentIds],
@@ -207,8 +222,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
               en: data.idValidationRegexErrorMessageEn,
               fr: data.idValidationRegexErrorMessageFr
             },
-            minimumAge: data.minimumAge,
-            minimumAgeApplied: data.minimumAgeApplied,
+            minimumAge: data.minimumAgeApplied ? data.minimumAge : null,
             subjectIdDisplayLength: data.subjectIdDisplayLength
           }
         });
@@ -249,7 +263,7 @@ const RouteComponent = () => {
       idValidationRegexErrorMessageEn: settings?.idValidationRegexErrorMessage?.en,
       idValidationRegexErrorMessageFr: settings?.idValidationRegexErrorMessage?.fr,
       minimumAge: settings?.minimumAge,
-      minimumAgeApplied: settings?.minimumAgeApplied,
+      minimumAgeApplied: typeof settings?.minimumAge === 'number',
       subjectIdDisplayLength: settings?.subjectIdDisplayLength
     };
     for (const instrument of availableInstruments) {

--- a/packages/schemas/src/group/group.ts
+++ b/packages/schemas/src/group/group.ts
@@ -13,6 +13,8 @@ export const $GroupSettings = z.object({
       fr: z.string().nullish()
     })
     .nullish(),
+  minimumAge: z.number().int().positive().nullish(),
+  minimumAgeApplied: z.boolean().nullish(),
   subjectIdDisplayLength: z.number().nullish()
 });
 

--- a/packages/schemas/src/group/group.ts
+++ b/packages/schemas/src/group/group.ts
@@ -14,7 +14,6 @@ export const $GroupSettings = z.object({
     })
     .nullish(),
   minimumAge: z.number().int().positive().nullish(),
-  minimumAgeApplied: z.boolean().nullish(),
   subjectIdDisplayLength: z.number().nullish()
 });
 


### PR DESCRIPTION
Allows group managers to adjust the minimum age requirement for subjects via the group management form

Removes the current default age minimum of 18

closes issue #1314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group administrators can configure an optional minimum age requirement for sessions and enable/disable it per group.
  * Group management UI includes an Age Limit settings section to set or clear the value.
  * Session creation and validation now honor the configured minimum age and display the configured age in validation messages (EN/FR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->