### PR TITLE
Add the $PROJECT_NAME variable to the .env file to customize the docker container'…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,9 @@
 ## PRODUCTION
 ## ---------------------------------
 
+# Project Name that will be prefixed to docker containers
+PROJECT_NAME=open-data-capture
+
 # The domain name to use for your site in the production compose stack
 SITE_ADDRESS=:80
 # The domain name to use for the gateway service in the production compose stack

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-name: open-data-capture
+name: ${PROJECT_NAME:-open-data-capture}
 volumes:
   caddy_data:
 services:


### PR DESCRIPTION
When setting up an ODC, it's easy to forgot to modify the docker-compose.yaml (and only focus on the .env), so by having this variable in the .env, you can completely ignore the docker-compose.yaml.  When managing multiple ODCs, this variable needs to be different for each instance, so it's useful to have