### PR TITLE
Fix subject Id overflow in datahub table

### DIFF
--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -307,11 +307,11 @@ const MasterDataTable: React.FC<{
       <DataTable
         columns={[
           {
-            accessorFn: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
+            accessorFn: (subject) => removeSubjectIdScope(subject.id),
             cell: (ctx) => (
               <div className="grid">
                 <div className="min-w-0 overflow-x-auto whitespace-nowrap" title={ctx.getValue() as string}>
-                  {ctx.getValue() as string}
+                  {(ctx.getValue() as string).slice(0, subjectIdDisplaySetting ?? 9)}
                 </div>
               </div>
             ),

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -308,6 +308,13 @@ const MasterDataTable: React.FC<{
         columns={[
           {
             accessorFn: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
+            cell: (ctx) => (
+              <div className="grid">
+                <div className="min-w-0 overflow-x-auto whitespace-nowrap" title={ctx.getValue() as string}>
+                  {ctx.getValue() as string}
+                </div>
+              </div>
+            ),
             header: t('datahub.index.table.subject'),
             id: 'subjectId'
           },


### PR DESCRIPTION
Use antigravity (gemini 3.1) to fix subject id overflow

implements a within cell scroll bar for overflowing subject ids. 

closes issue #1318 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Table now displays truncated subject IDs for readability while exposing the full ID via native browser tooltip on hover, improving copy/inspect behavior for long values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->