### PR TITLE
Implement 'Has record' filter into datahub

### DIFF
--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -84,7 +84,7 @@ describe('SubjectsService', () => {
       expect(subjectModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
-            instrumentRecords: { some: {} }
+            AND: expect.arrayContaining([expect.objectContaining({ instrumentRecords: { some: {} } })])
           }
         })
       );

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -79,8 +79,15 @@ describe('SubjectsService', () => {
       await expect(subjectsService.find()).resolves.toMatchObject([{ id: '123' }]);
     });
     it('should return the array of subjects with records', async () => {
-      subjectModel.findMany.mockResolvedValueOnce([{ instrumentRecords: { some: {} } }]);
-      await expect(subjectsService.find()).resolves.toMatchObject([{ instrumentRecords: { some: {} } }]);
+      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
+      await expect(subjectsService.find({ hasRecord: true })).resolves.toMatchObject([{ id: '123' }]);
+      expect(subjectModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            instrumentRecords: { some: {} }
+          }
+        })
+      );
     });
   });
 

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -78,6 +78,10 @@ describe('SubjectsService', () => {
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await expect(subjectsService.find()).resolves.toMatchObject([{ id: '123' }]);
     });
+    it('should return the array or subjects with records', async () => {
+      subjectModel.findMany.mockResolvedValueOnce([{ instrumentRecords: { some: {} } }]);
+      await expect(subjectsService.find()).resolves.toMatchObject([{ instrumentRecords: { some: {} } }]);
+    });
   });
 
   describe('deleteById', () => {

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -78,7 +78,7 @@ describe('SubjectsService', () => {
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await expect(subjectsService.find()).resolves.toMatchObject([{ id: '123' }]);
     });
-    it('should return the array or subjects with records', async () => {
+    it('should return the array of subjects with records', async () => {
       subjectModel.findMany.mockResolvedValueOnce([{ instrumentRecords: { some: {} } }]);
       await expect(subjectsService.find()).resolves.toMatchObject([{ instrumentRecords: { some: {} } }]);
     });

--- a/apps/api/src/subjects/subjects.controller.ts
+++ b/apps/api/src/subjects/subjects.controller.ts
@@ -42,7 +42,7 @@ export class SubjectsController {
     @Query('groupId') groupId?: string,
     @Query('hasRecord', new ParseSchemaPipe({ isOptional: true, schema: $BooleanLike })) hasRecord?: boolean
   ) {
-    return this.subjectsService.find({ groupId }, { hasRecord }, { ability });
+    return this.subjectsService.find({ groupId, hasRecord }, { ability });
   }
 
   @ApiOperation({ summary: 'Get Subject' })

--- a/apps/api/src/subjects/subjects.controller.ts
+++ b/apps/api/src/subjects/subjects.controller.ts
@@ -40,7 +40,7 @@ export class SubjectsController {
   find(
     @CurrentUser('ability') ability: AppAbility,
     @Query('groupId') groupId?: string,
-    @Query('hasRecord') hasRecord?: boolean
+    @Query('hasRecord', new ParseSchemaPipe({ isOptional: true, schema: $BooleanLike })) hasRecord?: boolean
   ) {
     return this.subjectsService.find({ groupId }, { hasRecord }, { ability });
   }

--- a/apps/api/src/subjects/subjects.controller.ts
+++ b/apps/api/src/subjects/subjects.controller.ts
@@ -37,8 +37,12 @@ export class SubjectsController {
   @ApiOperation({ summary: 'Get All Subjects' })
   @Get()
   @RouteAccess({ action: 'read', subject: 'Subject' })
-  find(@CurrentUser('ability') ability: AppAbility, @Query('groupId') groupId?: string) {
-    return this.subjectsService.find({ groupId }, { ability });
+  find(
+    @CurrentUser('ability') ability: AppAbility,
+    @Query('groupId') groupId?: string,
+    @Query('hasRecord') hasRecord?: boolean
+  ) {
+    return this.subjectsService.find({ groupId }, { hasRecord }, { ability });
   }
 
   @ApiOperation({ summary: 'Get Subject' })

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -126,8 +126,7 @@ export class SubjectsService {
   }
 
   async find(
-    { groupId }: { groupId?: string } = {},
-    { hasRecord }: { hasRecord?: boolean } = {},
+    { groupId, hasRecord }: { groupId?: string; hasRecord?: boolean } = {},
     { ability }: EntityOperationOptions = {}
   ) {
     const groupInput = groupId ? { groupIds: { has: groupId } } : {};

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -125,11 +125,16 @@ export class SubjectsService {
     return { success: true };
   }
 
-  async find({ groupId }: { groupId?: string } = {}, { ability }: EntityOperationOptions = {}) {
+  async find(
+    { groupId }: { groupId?: string } = {},
+    { hasRecord }: { hasRecord?: boolean } = {},
+    { ability }: EntityOperationOptions = {}
+  ) {
     const groupInput = groupId ? { groupIds: { has: groupId } } : {};
+    const hasRecordInput = hasRecord ? { instrumentRecords: { some: {} } } : {};
     return await this.subjectModel.findMany({
       where: {
-        AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput]
+        AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput, hasRecordInput]
       }
     });
   }

--- a/apps/playground/src/components/Editor/Editor.tsx
+++ b/apps/playground/src/components/Editor/Editor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { extractInputFileExtension } from '@opendatacapture/instrument-bundler';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { extractInputFileExtension } from '@opendatacapture/instrument-bundler';
 import { Columns3Icon, FilePlusIcon, FileUpIcon } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useShallow } from 'zustand/react/shallow';

--- a/apps/web/src/hooks/useSubjectsQuery.ts
+++ b/apps/web/src/hooks/useSubjectsQuery.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 type SubjectsQueryParams = {
   groupId?: string;
+  hasRecord?: boolean;
 };
 
 export const subjectsQueryOptions = ({ params }: { params?: SubjectsQueryParams } = {}) => {
@@ -12,7 +13,7 @@ export const subjectsQueryOptions = ({ params }: { params?: SubjectsQueryParams 
       const response = await axios.get('/v1/subjects', { params });
       return $Subject.array().parse(response.data);
     },
-    queryKey: ['subjects', params?.groupId]
+    queryKey: ['subjects', params?.groupId, params?.hasRecord]
   });
 };
 

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -22,7 +22,6 @@ import { unparse } from 'papaparse';
 
 import { IdentificationForm } from '@/components/IdentificationForm';
 import { PageHeader } from '@/components/PageHeader';
-import { useInstrumentRecords } from '@/hooks/useInstrumentRecords';
 import { subjectsQueryOptions, useSubjectsQuery } from '@/hooks/useSubjectsQuery';
 import { useAppStore } from '@/store';
 import { downloadExcel } from '@/utils/excel';

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -53,7 +53,7 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
   const sexFilter = sexColumn.getFilterValue() as SexFilter;
 
   const subjectColumn = columns.find((column) => column.id === 'subjectId')!;
-  const HasRecordFilter = subjectColumn.getFilterValue() as HasRecordFilter;
+  const hasRecordFilter = subjectColumn.getFilterValue() as HasRecordFilter;
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -166,11 +166,10 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
             })}
           </DropdownMenu.Label>
           <DropdownMenu.CheckboxItem
-            checked={HasRecordFilter.hasRecords}
+            checked={hasRecordFilter.hasRecords}
             onCheckedChange={(checked) => {
-              subjectColumn.setFilterValue((prevValue: HasRecordFilter): HasRecordFilter => {
+              subjectColumn.setFilterValue((): HasRecordFilter => {
                 return {
-                  ...prevValue,
                   hasRecords: checked
                 };
               });

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -168,7 +168,7 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
           <DropdownMenu.Label>
             {t({
               en: 'Subjects with records',
-              fr: 'Sujets'
+              fr: 'Sujets avec enregistrements'
             })}
           </DropdownMenu.Label>
           <DropdownMenu.CheckboxItem
@@ -183,7 +183,10 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
             }}
             onSelect={(e) => e.preventDefault()}
           >
-            Has Records
+            {t({
+              en: 'With records only',
+              fr: 'Avec enregistrements seulement'
+            })}
           </DropdownMenu.CheckboxItem>
         </DropdownMenu.Group>
       </DropdownMenu.Content>

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -22,6 +22,7 @@ import { unparse } from 'papaparse';
 
 import { IdentificationForm } from '@/components/IdentificationForm';
 import { PageHeader } from '@/components/PageHeader';
+import { useInstrumentRecords } from '@/hooks/useInstrumentRecords';
 import { subjectsQueryOptions, useSubjectsQuery } from '@/hooks/useSubjectsQuery';
 import { useAppStore } from '@/store';
 import { downloadExcel } from '@/utils/excel';
@@ -33,6 +34,10 @@ type DateFilter = {
 };
 
 type SexFilter = (null | Sex)[];
+
+type HasRecordFilter = {
+  hasRecords: boolean;
+};
 
 const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) => {
   const { t } = useTranslation();
@@ -46,6 +51,15 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
 
   const sexColumn = columns.find((column) => column.id === 'sex')!;
   const sexFilter = sexColumn.getFilterValue() as SexFilter;
+
+  const subjectColumn = columns.find((column) => column.id === 'subjectId')!;
+  const HasRecordFilter = subjectColumn.getFilterValue() as HasRecordFilter;
+
+  // const records = useInstrumentRecords()
+  // let idsWithRecords: string[];
+  // if (records.data) {
+  //   idsWithRecords = [...new Set(records.data.map(record => record.id))]
+  // }
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -148,6 +162,28 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
             onSelect={(e) => e.preventDefault()}
           >
             NULL
+          </DropdownMenu.CheckboxItem>
+        </DropdownMenu.Group>
+        <DropdownMenu.Group>
+          <DropdownMenu.Label>
+            {t({
+              en: 'Subjects with records',
+              fr: 'Sujets'
+            })}
+          </DropdownMenu.Label>
+          <DropdownMenu.CheckboxItem
+            checked={HasRecordFilter.hasRecords}
+            onCheckedChange={(checked) => {
+              subjectColumn.setFilterValue((prevValue: HasRecordFilter): HasRecordFilter => {
+                return {
+                  ...prevValue,
+                  hasRecords: checked
+                };
+              });
+            }}
+            onSelect={(e) => e.preventDefault()}
+          >
+            Has Records
           </DropdownMenu.CheckboxItem>
         </DropdownMenu.Group>
       </DropdownMenu.Content>
@@ -301,20 +337,33 @@ const MasterDataTable: React.FC<{
 }> = ({ data, onRowDoubleClick, onSelect }) => {
   const { t } = useTranslation();
   const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
+  const records = useInstrumentRecords();
+  let idsWithRecords: string[];
+  if (records.data) {
+    idsWithRecords = [
+      ...new Set(
+        records.data.map((record) => removeSubjectIdScope(record.subjectId).slice(0, subjectIdDisplaySetting ?? 9))
+      )
+    ];
+  }
 
   return (
     <div>
       <DataTable
         columns={[
           {
-            accessorFn: (subject) => removeSubjectIdScope(subject.id),
-            cell: (ctx) => (
-              <div className="grid">
-                <div className="min-w-0 overflow-x-auto whitespace-nowrap" title={ctx.getValue() as string}>
-                  {(ctx.getValue() as string).slice(0, subjectIdDisplaySetting ?? 9)}
-                </div>
-              </div>
-            ),
+            accessorFn: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
+            filterFn: (row, id, filter: HasRecordFilter) => {
+              const value = row.getValue(id);
+              if (!value) {
+                return false;
+              }
+              if (filter.hasRecords) {
+                return idsWithRecords.includes(value as string);
+              } else {
+                return true;
+              }
+            },
             header: t('datahub.index.table.subject'),
             id: 'subjectId'
           },
@@ -360,6 +409,12 @@ const MasterDataTable: React.FC<{
         data-testid="master-data-table"
         initialState={{
           columnFilters: [
+            {
+              id: 'subjectId',
+              value: {
+                hasRecords: false
+              } satisfies HasRecordFilter
+            },
             {
               id: 'sex',
               value: ['MALE', 'FEMALE', null] satisfies SexFilter

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -333,8 +333,13 @@ const MasterDataTable: React.FC<{
   onSelect: (subject: Subject) => void;
 }> = ({ data, onRowDoubleClick, onSelect }) => {
   const { t } = useTranslation();
-  const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
-  const records = useInstrumentRecords();
+  const currentGroup = useAppStore((store) => store.currentGroup);
+  const subjectIdDisplaySetting = currentGroup?.settings.subjectIdDisplayLength;
+  const records = useInstrumentRecords({
+    params: {
+      groupId: currentGroup?.id
+    }
+  });
   const idsWithRecords = new Set<string>();
   if (records.data) {
     records.data.forEach((record) => {

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -355,7 +355,7 @@ const MasterDataTable: React.FC<{
               if (!value) {
                 return false;
               }
-              if (filter.hasRecords && idsWithRecords.length > 0) {
+              if (filter.hasRecords && idsWithRecords && idsWithRecords.length > 0) {
                 return idsWithRecords.includes(value as string);
               } else {
                 return true;

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { toBasicISOString } from '@douglasneuroinformatics/libjs';
 import {
@@ -39,7 +39,11 @@ type HasRecordFilter = {
   searchString: string;
 };
 
-const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) => {
+const Filters: React.FC<{
+  hasRecords: boolean;
+  setHasRecords: (v: boolean) => void;
+  table: TanstackTable.Table<Subject>;
+}> = ({ hasRecords, setHasRecords, table }) => {
   const { t } = useTranslation();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -51,9 +55,6 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
 
   const sexColumn = columns.find((column) => column.id === 'sex')!;
   const sexFilter = sexColumn.getFilterValue() as SexFilter;
-
-  const subjectColumn = columns.find((column) => column.id === 'subjectId')!;
-  const hasRecordFilter = subjectColumn.getFilterValue() as HasRecordFilter;
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -166,15 +167,8 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
             })}
           </DropdownMenu.Label>
           <DropdownMenu.CheckboxItem
-            checked={hasRecordFilter.hasRecords}
-            onCheckedChange={(checked) => {
-              subjectColumn.setFilterValue((prevValue: HasRecordFilter): HasRecordFilter => {
-                return {
-                  ...prevValue,
-                  hasRecords: checked
-                };
-              });
-            }}
+            checked={hasRecords}
+            onCheckedChange={setHasRecords}
             onSelect={(e) => e.preventDefault()}
           >
             {t({
@@ -188,7 +182,11 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
   );
 };
 
-const Toggles: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) => {
+const Toggles: React.FC<{
+  hasRecords: boolean;
+  setHasRecords: (v: boolean) => void;
+  table: TanstackTable.Table<Subject>;
+}> = ({ hasRecords, setHasRecords, table }) => {
   const navigate = Route.useNavigate();
 
   const { t } = useTranslation();
@@ -312,7 +310,7 @@ const Toggles: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
           <IdentificationForm onSubmit={(data) => void lookupSubject(data)} />
         </Dialog.Content>
       </Dialog>
-      <Filters table={table} />
+      <Filters hasRecords={hasRecords} setHasRecords={setHasRecords} table={table} />
       <ActionDropdown
         widthFull
         align="end"
@@ -336,15 +334,25 @@ const MasterDataTable: React.FC<{
   const currentGroup = useAppStore((store) => store.currentGroup);
   const subjectIdDisplaySetting = currentGroup?.settings.subjectIdDisplayLength;
 
-  const subjectsData = useSubjectsQuery({ params: { groupId: currentGroup?.id, hasRecord: true } });
+  const [hasRecords, setHasRecords] = useState(false);
+  const [searchString, setSearchString] = useState('');
 
-  const idsWithRecords = useMemo(() => {
-    const ids = new Set<string>();
-    if (subjectsData.data) {
-      subjectsData.data.forEach((subject) => ids.add(removeSubjectIdScope(subject.id)));
-    }
-    return ids;
-  }, [subjectsData.data]);
+  const subjectsData = useSubjectsQuery({
+    params: { groupId: currentGroup?.id, hasRecord: hasRecords || undefined }
+  });
+
+  const displayData = hasRecords ? subjectsData.data : data;
+
+  const hasRecordsRef = useRef(hasRecords);
+  hasRecordsRef.current = hasRecords;
+
+  const TogglesWithFilter = useMemo(
+    () =>
+      function TogglesWithFilter(props: { table: TanstackTable.Table<Subject> }) {
+        return <Toggles {...props} hasRecords={hasRecordsRef.current} setHasRecords={setHasRecords} />;
+      },
+    []
+  );
 
   return (
     <div>
@@ -362,16 +370,7 @@ const MasterDataTable: React.FC<{
                 return false;
               }
               if (filter.searchString) {
-                if (filter.hasRecords) {
-                  return (
-                    idsWithRecords.has(value as string) &&
-                    (value as string).toLowerCase().includes(filter.searchString.toLowerCase())
-                  );
-                }
                 return (value as string).toLowerCase().includes(filter.searchString.toLowerCase());
-              }
-              if (filter.hasRecords) {
-                return idsWithRecords.has(value as string);
               }
               return true;
             },
@@ -416,7 +415,7 @@ const MasterDataTable: React.FC<{
             id: 'sex'
           }
         ]}
-        data={data}
+        data={displayData}
         data-testid="master-data-table"
         initialState={{
           columnFilters: [
@@ -424,7 +423,7 @@ const MasterDataTable: React.FC<{
               id: 'subjectId',
               value: {
                 hasRecords: false,
-                searchString: ''
+                searchString
               } satisfies HasRecordFilter
             },
             {
@@ -447,9 +446,10 @@ const MasterDataTable: React.FC<{
             onSelect
           }
         ]}
-        togglesComponent={Toggles}
+        togglesComponent={TogglesWithFilter}
         onRowDoubleClick={onRowDoubleClick}
         onSearchChange={(value, table) => {
+          setSearchString(value);
           const subjectIdColumn = table.getColumn('subjectId')!;
           subjectIdColumn.setFilterValue(
             (prevValue: HasRecordFilter): HasRecordFilter => ({

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -336,15 +336,12 @@ const MasterDataTable: React.FC<{
   const { t } = useTranslation();
   const currentGroup = useAppStore((store) => store.currentGroup);
   const subjectIdDisplaySetting = currentGroup?.settings.subjectIdDisplayLength;
-  const records = useInstrumentRecords({
-    params: {
-      groupId: currentGroup?.id
-    }
-  });
+
   const idsWithRecords = new Set<string>();
-  if (records.data) {
-    records.data.forEach((record) => {
-      idsWithRecords.add(removeSubjectIdScope(record.subjectId));
+  const subjectsData = useSubjectsQuery({ params: { groupId: currentGroup?.id, hasRecord: true } });
+  if (subjectsData.data) {
+    subjectsData.data.forEach((subject) => {
+      idsWithRecords.add(removeSubjectIdScope(subject.id));
     });
   }
 

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { toBasicISOString } from '@douglasneuroinformatics/libjs';
 import {
@@ -336,13 +336,15 @@ const MasterDataTable: React.FC<{
   const currentGroup = useAppStore((store) => store.currentGroup);
   const subjectIdDisplaySetting = currentGroup?.settings.subjectIdDisplayLength;
 
-  const idsWithRecords = new Set<string>();
   const subjectsData = useSubjectsQuery({ params: { groupId: currentGroup?.id, hasRecord: true } });
-  if (subjectsData.data) {
-    subjectsData.data.forEach((subject) => {
-      idsWithRecords.add(removeSubjectIdScope(subject.id));
-    });
-  }
+
+  const idsWithRecords = useMemo(() => {
+    const ids = new Set<string>();
+    if (subjectsData.data) {
+      subjectsData.data.forEach((subject) => ids.add(removeSubjectIdScope(subject.id)));
+    }
+    return ids;
+  }, [subjectsData.data]);
 
   return (
     <div>

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -335,13 +335,11 @@ const MasterDataTable: React.FC<{
   const { t } = useTranslation();
   const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
   const records = useInstrumentRecords();
-  let idsWithRecords: string[];
+  const idsWithRecords = new Set<string>();
   if (records.data) {
-    idsWithRecords = [
-      ...new Set(
-        records.data.map((record) => removeSubjectIdScope(record.subjectId).slice(0, subjectIdDisplaySetting ?? 9))
-      )
-    ];
+    records.data.forEach((record) => {
+      idsWithRecords.add(removeSubjectIdScope(record.subjectId));
+    });
   }
 
   return (
@@ -349,17 +347,20 @@ const MasterDataTable: React.FC<{
       <DataTable
         columns={[
           {
-            accessorFn: (subject) => removeSubjectIdScope(subject.id).slice(0, subjectIdDisplaySetting ?? 9),
+            accessorFn: (subject) => removeSubjectIdScope(subject.id),
+            cell: (ctx) => {
+              const value = ctx.getValue() as string;
+              return value.slice(0, subjectIdDisplaySetting ?? 9);
+            },
             filterFn: (row, id, filter: HasRecordFilter) => {
               const value = row.getValue(id);
               if (!value) {
                 return false;
               }
-              if (filter.hasRecords && idsWithRecords && idsWithRecords.length > 0) {
-                return idsWithRecords.includes(value as string);
-              } else {
-                return true;
+              if (filter.hasRecords) {
+                return idsWithRecords.has(value as string);
               }
+              return true;
             },
             header: t('datahub.index.table.subject'),
             id: 'subjectId'

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -34,8 +34,7 @@ type DateFilter = {
 
 type SexFilter = (null | Sex)[];
 
-type HasRecordFilter = {
-  hasRecords: boolean;
+type HasSearchStringFilter = {
   searchString: string;
 };
 
@@ -364,7 +363,7 @@ const MasterDataTable: React.FC<{
               const value = ctx.getValue() as string;
               return value.slice(0, subjectIdDisplaySetting ?? 9);
             },
-            filterFn: (row, id, filter: HasRecordFilter) => {
+            filterFn: (row, id, filter: HasSearchStringFilter) => {
               const value = row.getValue(id);
               if (!value) {
                 return false;
@@ -422,9 +421,8 @@ const MasterDataTable: React.FC<{
             {
               id: 'subjectId',
               value: {
-                hasRecords: false,
                 searchString
-              } satisfies HasRecordFilter
+              } satisfies HasSearchStringFilter
             },
             {
               id: 'sex',
@@ -452,7 +450,7 @@ const MasterDataTable: React.FC<{
           setSearchString(value);
           const subjectIdColumn = table.getColumn('subjectId')!;
           subjectIdColumn.setFilterValue(
-            (prevValue: HasRecordFilter): HasRecordFilter => ({
+            (prevValue: HasSearchStringFilter): HasSearchStringFilter => ({
               ...prevValue,
               searchString: value
             })

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -346,13 +346,13 @@ const MasterDataTable: React.FC<{
   const hasRecordsRef = useRef(hasRecords);
   hasRecordsRef.current = hasRecords;
 
-  const TogglesWithFilter = useMemo(
-    () =>
-      function TogglesWithFilter(props: { table: TanstackTable.Table<Subject> }) {
-        return <Toggles {...props} hasRecords={hasRecordsRef.current} setHasRecords={setHasRecords} />;
-      },
-    []
-  );
+  const TogglesWithFilter = useMemo(() => {
+    const Component = (props: { table: TanstackTable.Table<Subject> }) => (
+      <Toggles {...props} hasRecords={hasRecordsRef.current} setHasRecords={setHasRecords} />
+    );
+    Component.displayName = 'TogglesWithFilter';
+    return Component;
+  }, []);
 
   return (
     <div>

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -37,6 +37,7 @@ type SexFilter = (null | Sex)[];
 
 type HasRecordFilter = {
   hasRecords: boolean;
+  searchString: string;
 };
 
 const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) => {
@@ -168,8 +169,9 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
           <DropdownMenu.CheckboxItem
             checked={hasRecordFilter.hasRecords}
             onCheckedChange={(checked) => {
-              subjectColumn.setFilterValue((): HasRecordFilter => {
+              subjectColumn.setFilterValue((prevValue: HasRecordFilter): HasRecordFilter => {
                 return {
+                  ...prevValue,
                   hasRecords: checked
                 };
               });
@@ -361,6 +363,15 @@ const MasterDataTable: React.FC<{
               if (!value) {
                 return false;
               }
+              if (filter.searchString) {
+                if (filter.hasRecords) {
+                  return (
+                    idsWithRecords.has(value as string) &&
+                    (value as string).toLowerCase().includes(filter.searchString.toLowerCase())
+                  );
+                }
+                return (value as string).toLowerCase().includes(filter.searchString.toLowerCase());
+              }
               if (filter.hasRecords) {
                 return idsWithRecords.has(value as string);
               }
@@ -414,7 +425,8 @@ const MasterDataTable: React.FC<{
             {
               id: 'subjectId',
               value: {
-                hasRecords: false
+                hasRecords: false,
+                searchString: ''
               } satisfies HasRecordFilter
             },
             {
@@ -441,7 +453,12 @@ const MasterDataTable: React.FC<{
         onRowDoubleClick={onRowDoubleClick}
         onSearchChange={(value, table) => {
           const subjectIdColumn = table.getColumn('subjectId')!;
-          subjectIdColumn.setFilterValue(value);
+          subjectIdColumn.setFilterValue(
+            (prevValue: HasRecordFilter): HasRecordFilter => ({
+              ...prevValue,
+              searchString: value
+            })
+          );
         }}
       />
     </div>

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -55,12 +55,6 @@ const Filters: React.FC<{ table: TanstackTable.Table<Subject> }> = ({ table }) =
   const subjectColumn = columns.find((column) => column.id === 'subjectId')!;
   const HasRecordFilter = subjectColumn.getFilterValue() as HasRecordFilter;
 
-  // const records = useInstrumentRecords()
-  // let idsWithRecords: string[];
-  // if (records.data) {
-  //   idsWithRecords = [...new Set(records.data.map(record => record.id))]
-  // }
-
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenu.Trigger asChild>
@@ -361,7 +355,7 @@ const MasterDataTable: React.FC<{
               if (!value) {
                 return false;
               }
-              if (filter.hasRecords) {
+              if (filter.hasRecords && idsWithRecords.length > 0) {
                 return idsWithRecords.includes(value as string);
               } else {
                 return true;


### PR DESCRIPTION
Adds a filter to display subjects that have records only

closes issue #1282 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Subjects with records" checkbox to the Datahub table to show only subjects that have instrument records (default: off).
  * Subject identifiers in the table are now consistently truncated per the subject ID display setting for a stable layout.
  * The checkbox is synced with the table filter state so it reflects and updates the active subject filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->