### PR TITLE
fix service worker assets not loading on gateway with help of Claude

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendatacapture",
   "type": "module",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "private": true,
   "packageManager": "pnpm@10.7.0",
   "license": "Apache-2.0",

--- a/packages/runtime-internal/src/interactive/bootstrap.js
+++ b/packages/runtime-internal/src/interactive/bootstrap.js
@@ -50,11 +50,26 @@ if (!bundle) {
     await navigator.serviceWorker.register('./worker.js', {
       scope: './'
     });
-    await navigator.serviceWorker.ready.then((registration) => {
-      registration.active?.postMessage({
-        staticAssets: instrument.content.staticAssets,
-        type: 'STATIC_ASSETS'
+    const registration = await navigator.serviceWorker.ready;
+    if (!navigator.serviceWorker.controller) {
+      await new Promise((resolve) => {
+        navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
       });
+    }
+    const { port1, port2 } = new MessageChannel();
+    await new Promise((resolve) => {
+      port1.onmessage = (event) => {
+        if (event.data?.type === 'STATIC_ASSETS_READY') {
+          resolve(undefined);
+        }
+      };
+      registration.active?.postMessage(
+        {
+          staticAssets: instrument.content.staticAssets,
+          type: 'STATIC_ASSETS'
+        },
+        [port2]
+      );
     });
   }
 

--- a/packages/runtime-internal/src/interactive/worker.js
+++ b/packages/runtime-internal/src/interactive/worker.js
@@ -1,7 +1,17 @@
 /// <reference lib="webworker" />
 
+const worker = /** @type {ServiceWorkerGlobalScope} */ (/** @type {unknown} */ (self));
+
 /** @type {Map<string, string>} */
 const staticAssets = new Map();
+
+worker.addEventListener('install', () => {
+  worker.skipWaiting();
+});
+
+worker.addEventListener('activate', (event) => {
+  event.waitUntil(worker.clients.claim());
+});
 
 /**
  * Converts a data URL (base64 or plain) into a Fetch API Response object.
@@ -49,9 +59,10 @@ addEventListener('message', (event) => {
   Object.entries(data.staticAssets).forEach(([key, value]) => {
     staticAssets.set(key, value);
   });
+  event.ports[0]?.postMessage({ type: 'STATIC_ASSETS_READY' });
 });
 
-self.addEventListener('fetch', (_event) => {
+worker.addEventListener('fetch', (_event) => {
   if (!staticAssets) {
     console.error('staticAssets is not defined');
     return;


### PR DESCRIPTION
Interactive instruments use a Service Worker to serve static assets. On first load, the SW was registered but not yet controlling the page, so fetch events weren't intercepted and static assets failed to load. A refresh was required to make them work.

  Fixed by:
  - Adding skipWaiting() and clients.claim() in the worker so it takes control of the page immediately on activation
  - Waiting for the controllerchange event in the bootstrap to ensure the SW is controlling the page before rendering
  - Using a MessageChannel to confirm the worker has stored the static assets before proceeding with render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.13.6

* **Improvements**
  * Enhanced service worker initialization with improved controller detection
  * Strengthened service worker lifecycle management through install and activate handlers
  * Improved static asset communication using message-based protocols between the app and service worker

<!-- end of auto-generated comment: release notes by coderabbit.ai -->