### PR TITLE
Update preference page

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -243,6 +243,8 @@ model User {
   username              String
   sex                   Sex?
   dateOfBirth           DateTime?            @db.Date
+  phoneNumber           String?
+  email                 String?
 
   @@map("UserModel")
 }

--- a/apps/api/src/auth/__tests__/ability.factory.test.ts
+++ b/apps/api/src/auth/__tests__/ability.factory.test.ts
@@ -47,6 +47,6 @@ describe('AbilityFactory', () => {
 
     const ability = abilityFactory.createForPayload(payload as any);
 
-    expect(ability.can('update', subject('User', { basePermissionLevel: 'ADMIN', id: 'user-1' }) as any)).toBe(false);
+    expect(ability.can('update', subject('User', { id: 'user-1' }) as any, 'basePermissionLevel')).toBe(false);
   });
 });

--- a/apps/api/src/auth/__tests__/ability.factory.test.ts
+++ b/apps/api/src/auth/__tests__/ability.factory.test.ts
@@ -15,38 +15,37 @@ describe('AbilityFactory', () => {
     abilityFactory = new AbilityFactory(loggingService as unknown as LoggingService);
   });
 
-  it('should create an ability for a standard user that can update only itself', () => {
+  it('should allow admin to manage all', () => {
     const payload = {
       additionalPermissions: undefined,
-      basePermissionLevel: 'STANDARD',
+      basePermissionLevel: 'ADMIN',
       firstName: 'Test',
       groups: [{ id: 'group-1' }],
       id: 'user-1',
       lastName: 'User',
       permissions: [] as any,
-      username: 'standard-user'
+      username: 'admin-user'
     };
 
     const ability = abilityFactory.createForPayload(payload as any);
 
-    expect(ability.can('update', subject('User', { id: 'user-1' }) as any)).toBe(true);
-    expect(ability.can('update', subject('User', { id: 'user-2' }) as any)).toBe(false);
+    expect(ability.can('manage', 'all')).toBe(true);
   });
 
-  it('should not allow a standard user to modify its basePermissionLevel', () => {
+  it('should allow group manager to manage group', () => {
     const payload = {
       additionalPermissions: undefined,
-      basePermissionLevel: 'STANDARD',
+      basePermissionLevel: 'GROUP_MANAGER',
       firstName: 'Test',
       groups: [{ id: 'group-1' }],
       id: 'user-1',
       lastName: 'User',
       permissions: [] as any,
-      username: 'standard-user'
+      username: 'admin-user'
     };
 
     const ability = abilityFactory.createForPayload(payload as any);
 
-    expect(ability.can('update', subject('User', { id: 'user-1' }) as any, 'basePermissionLevel')).toBe(false);
+    expect(ability.can('manage', subject('Group', { id: 'group-1' }) as any)).toBe(true);
   });
 });

--- a/apps/api/src/auth/__tests__/ability.factory.test.ts
+++ b/apps/api/src/auth/__tests__/ability.factory.test.ts
@@ -32,4 +32,21 @@ describe('AbilityFactory', () => {
     expect(ability.can('update', subject('User', { id: 'user-1' }) as any)).toBe(true);
     expect(ability.can('update', subject('User', { id: 'user-2' }) as any)).toBe(false);
   });
+
+  it('should not allow a standard user to modify its basePermissionLevel', () => {
+    const payload = {
+      additionalPermissions: undefined,
+      basePermissionLevel: 'STANDARD',
+      firstName: 'Test',
+      groups: [{ id: 'group-1' }],
+      id: 'user-1',
+      lastName: 'User',
+      permissions: [] as any,
+      username: 'standard-user'
+    };
+
+    const ability = abilityFactory.createForPayload(payload as any);
+
+    expect(ability.can('update', subject('User', { basePermissionLevel: 'ADMIN', id: 'user-1' }) as any)).toBe(false);
+  });
 });

--- a/apps/api/src/auth/__tests__/ability.factory.test.ts
+++ b/apps/api/src/auth/__tests__/ability.factory.test.ts
@@ -49,4 +49,21 @@ describe('AbilityFactory', () => {
     expect(ability.can('manage', subject('Group', { id: 'group-1' }) as any)).toBe(true);
     expect(ability.can('manage', subject('Group', { id: 'group-2' }) as any)).toBe(false);
   });
+  it('should allow standard user to read their own user info', () => {
+    const payload = {
+      additionalPermissions: undefined,
+      basePermissionLevel: 'STANDARD',
+      firstName: 'Test',
+      groups: [{ id: 'group-1' }],
+      id: 'user-1',
+      lastName: 'User',
+      permissions: [] as any,
+      username: 'standard-user'
+    };
+
+    const ability = abilityFactory.createForPayload(payload as any);
+
+    expect(ability.can('read', subject('User', { id: 'user-1' }) as any)).toBe(true);
+    expect(ability.can('read', subject('User', { id: 'user-2' }) as any)).toBe(false);
+  });
 });

--- a/apps/api/src/auth/__tests__/ability.factory.test.ts
+++ b/apps/api/src/auth/__tests__/ability.factory.test.ts
@@ -32,7 +32,7 @@ describe('AbilityFactory', () => {
     expect(ability.can('manage', 'all')).toBe(true);
   });
 
-  it('should allow group manager to manage group', () => {
+  it('should allow group manager to manage their group', () => {
     const payload = {
       additionalPermissions: undefined,
       basePermissionLevel: 'GROUP_MANAGER',
@@ -47,5 +47,6 @@ describe('AbilityFactory', () => {
     const ability = abilityFactory.createForPayload(payload as any);
 
     expect(ability.can('manage', subject('Group', { id: 'group-1' }) as any)).toBe(true);
+    expect(ability.can('manage', subject('Group', { id: 'group-2' }) as any)).toBe(false);
   });
 });

--- a/apps/api/src/auth/__tests__/ability.factory.test.ts
+++ b/apps/api/src/auth/__tests__/ability.factory.test.ts
@@ -1,0 +1,35 @@
+import { subject } from '@casl/ability';
+import { LoggingService } from '@douglasneuroinformatics/libnest';
+import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
+import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AbilityFactory } from '../ability.factory.js';
+
+describe('AbilityFactory', () => {
+  let abilityFactory: AbilityFactory;
+  let loggingService: MockedInstance<LoggingService>;
+
+  beforeEach(() => {
+    loggingService = MockFactory.createMock(LoggingService);
+    abilityFactory = new AbilityFactory(loggingService as unknown as LoggingService);
+  });
+
+  it('should create an ability for a standard user that can update only itself', () => {
+    const payload = {
+      additionalPermissions: undefined,
+      basePermissionLevel: 'STANDARD',
+      firstName: 'Test',
+      groups: [{ id: 'group-1' }],
+      id: 'user-1',
+      lastName: 'User',
+      permissions: [] as any,
+      username: 'standard-user'
+    };
+
+    const ability = abilityFactory.createForPayload(payload as any);
+
+    expect(ability.can('update', subject('User', { id: 'user-1' }) as any)).toBe(true);
+    expect(ability.can('update', subject('User', { id: 'user-2' }) as any)).toBe(false);
+  });
+});

--- a/apps/api/src/auth/ability.factory.ts
+++ b/apps/api/src/auth/ability.factory.ts
@@ -43,6 +43,7 @@ export class AbilityFactory {
         ability.can('create', 'Session');
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: groupIds } });
+        ability.can('read', 'User', { id: payload.id });
         break;
     }
     payload.additionalPermissions?.forEach(({ action, subject }) => {

--- a/apps/api/src/auth/ability.factory.ts
+++ b/apps/api/src/auth/ability.factory.ts
@@ -44,7 +44,12 @@ export class AbilityFactory {
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: groupIds } });
         ability.can('read', 'User', { id: payload.id });
-        ability.can('update', 'User', { id: payload.id });
+        ability.can(
+          'update',
+          'User',
+          ['email', 'firstName', 'lastName', 'dateOfBirth', 'phoneNumber', 'sex', 'hashedPassword'],
+          { id: payload.id }
+        );
         break;
     }
     payload.additionalPermissions?.forEach(({ action, subject }) => {

--- a/apps/api/src/auth/ability.factory.ts
+++ b/apps/api/src/auth/ability.factory.ts
@@ -34,12 +34,6 @@ export class AbilityFactory {
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: groupIds } });
         ability.can('read', 'User', { groupIds: { hasSome: groupIds } });
-        ability.can(
-          'update',
-          'User',
-          ['email', 'firstName', 'lastName', 'dateOfBirth', 'phoneNumber', 'sex', 'hashedPassword'],
-          { id: payload.id }
-        );
         break;
       case 'STANDARD':
         ability.can('read', 'Group', { id: { in: groupIds } });
@@ -50,12 +44,6 @@ export class AbilityFactory {
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: groupIds } });
         ability.can('read', 'User', { id: payload.id });
-        ability.can(
-          'update',
-          'User',
-          ['email', 'firstName', 'lastName', 'dateOfBirth', 'phoneNumber', 'sex', 'hashedPassword'],
-          { id: payload.id }
-        );
         break;
     }
     payload.additionalPermissions?.forEach(({ action, subject }) => {

--- a/apps/api/src/auth/ability.factory.ts
+++ b/apps/api/src/auth/ability.factory.ts
@@ -44,6 +44,7 @@ export class AbilityFactory {
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: groupIds } });
         ability.can('read', 'User', { id: payload.id });
+        ability.can('update', 'User', { id: payload.id });
         break;
     }
     payload.additionalPermissions?.forEach(({ action, subject }) => {

--- a/apps/api/src/auth/ability.factory.ts
+++ b/apps/api/src/auth/ability.factory.ts
@@ -34,6 +34,12 @@ export class AbilityFactory {
         ability.can('create', 'Subject');
         ability.can('read', 'Subject', { groupIds: { hasSome: groupIds } });
         ability.can('read', 'User', { groupIds: { hasSome: groupIds } });
+        ability.can(
+          'update',
+          'User',
+          ['email', 'firstName', 'lastName', 'dateOfBirth', 'phoneNumber', 'sex', 'hashedPassword'],
+          { id: payload.id }
+        );
         break;
       case 'STANDARD':
         ability.can('read', 'Group', { id: { in: groupIds } });

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,6 +1,8 @@
 import { CurrentUser } from '@douglasneuroinformatics/libnest';
+import type { RequestUser } from '@douglasneuroinformatics/libnest';
 import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { $SelfUpdateUserData } from '@opendatacapture/schemas/user';
 
 import type { AppAbility } from '@/auth/auth.types';
 import { RouteAccess } from '@/core/decorators/route-access.decorator';
@@ -8,6 +10,7 @@ import { RouteAccess } from '@/core/decorators/route-access.decorator';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UsersService } from './users.service';
+
 @ApiTags('Users')
 @Controller({ path: 'users' })
 export class UsersController {
@@ -53,5 +56,17 @@ export class UsersController {
   @RouteAccess({ action: 'update', subject: 'User' })
   updateById(@Param('id') id: string, @Body() update: UpdateUserDto, @CurrentUser('ability') ability: AppAbility) {
     return this.usersService.updateById(id, update, { ability });
+  }
+
+  @ApiOperation({ summary: 'Self Update User' })
+  @Patch('/self-update/:id')
+  //This an exception to are regular api pattern. It is handled in the user service.
+  @RouteAccess({ action: 'read', subject: 'User' })
+  updateSelfById(
+    @Param('id') id: string,
+    @Body() update: $SelfUpdateUserData,
+    @CurrentUser() currentUser: RequestUser
+  ) {
+    return this.usersService.updateSelfById(id, update, currentUser);
   }
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -60,7 +60,7 @@ export class UsersController {
 
   @ApiOperation({ summary: 'Self Update User' })
   @Patch('/self-update/:id')
-  //This an exception to are regular api pattern. It is handled in the user service.
+  // This is an exception to our regular API pattern. It is handled in the user service.
   @RouteAccess({ action: 'read', subject: 'User' })
   updateSelfById(
     @Param('id') id: string,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -171,6 +171,8 @@ export class UsersService {
       throw new ForbiddenException();
     }
 
+    const { dateOfBirth, email, firstName, lastName, phoneNumber, sex } = data;
+
     let hashedPassword: string | undefined;
     if (password) {
       hashedPassword = await this.cryptoService.hashPassword(password);
@@ -178,8 +180,13 @@ export class UsersService {
 
     return this.userModel.update({
       data: {
-        ...data,
-        hashedPassword
+        dateOfBirth,
+        email,
+        firstName,
+        hashedPassword,
+        lastName,
+        phoneNumber,
+        sex
       },
       omit: {
         hashedPassword: true

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -167,7 +167,7 @@ export class UsersService {
   }
 
   async updateSelfById(id: string, { password, ...data }: $SelfUpdateUserData, currentUser: RequestUser) {
-    if (id !== currentUser.Id) {
+    if (id !== currentUser.id) {
       throw new ForbiddenException();
     }
 

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,7 +1,13 @@
 import { CryptoService, InjectModel } from '@douglasneuroinformatics/libnest';
 import type { Model, RequestUser } from '@douglasneuroinformatics/libnest';
 import { estimatePasswordStrength } from '@douglasneuroinformatics/libpasswd';
-import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException
+} from '@nestjs/common';
 import { $SelfUpdateUserData } from '@opendatacapture/schemas/user';
 
 import { accessibleQuery } from '@/auth/ability.utils';
@@ -173,7 +179,7 @@ export class UsersService {
     }
 
     if (password && !estimatePasswordStrength(password).success) {
-      throw new Error('Insufficient password strength');
+      throw new BadRequestException('Insufficient password strength');
     }
 
     const { dateOfBirth, email, firstName, lastName, phoneNumber, sex } = data;

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,6 +1,7 @@
 import { CryptoService, InjectModel } from '@douglasneuroinformatics/libnest';
-import type { Model } from '@douglasneuroinformatics/libnest';
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import type { Model, RequestUser } from '@douglasneuroinformatics/libnest';
+import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import type { $SelfUpdateUserData } from '@opendatacapture/schemas/user';
 
 import { accessibleQuery } from '@/auth/ability.utils';
 import type { EntityOperationOptions } from '@/core/types';
@@ -162,6 +163,28 @@ export class UsersService {
         hashedPassword: true
       },
       where: { AND: [accessibleQuery(ability, 'update', 'User')], id }
+    });
+  }
+
+  async updateSelfById(id: string, { password, ...data }: $SelfUpdateUserData, currentUser: RequestUser) {
+    if (id !== currentUser.Id) {
+      throw new ForbiddenException();
+    }
+
+    let hashedPassword: string | undefined;
+    if (password) {
+      hashedPassword = await this.cryptoService.hashPassword(password);
+    }
+
+    return this.userModel.update({
+      data: {
+        ...data,
+        hashedPassword
+      },
+      omit: {
+        hashedPassword: true
+      },
+      where: { id }
     });
   }
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,7 +1,8 @@
 import { CryptoService, InjectModel } from '@douglasneuroinformatics/libnest';
 import type { Model, RequestUser } from '@douglasneuroinformatics/libnest';
+import { estimatePasswordStrength } from '@douglasneuroinformatics/libpasswd';
 import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import type { $SelfUpdateUserData } from '@opendatacapture/schemas/user';
+import { $SelfUpdateUserData } from '@opendatacapture/schemas/user';
 
 import { accessibleQuery } from '@/auth/ability.utils';
 import type { EntityOperationOptions } from '@/core/types';
@@ -169,6 +170,10 @@ export class UsersService {
   async updateSelfById(id: string, { password, ...data }: $SelfUpdateUserData, currentUser: RequestUser) {
     if (id !== currentUser.id) {
       throw new ForbiddenException();
+    }
+
+    if (password && !estimatePasswordStrength(password).success) {
+      throw new Error('Insufficient password strength');
     }
 
     const { dateOfBirth, email, firstName, lastName, phoneNumber, sex } = data;

--- a/apps/web/src/hooks/useFindUserQuery.ts
+++ b/apps/web/src/hooks/useFindUserQuery.ts
@@ -1,0 +1,19 @@
+import { $User } from '@opendatacapture/schemas/user';
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { USERS_QUERY_KEY } from './useUsersQuery';
+
+export const useFindUserQueryOptions = (id: string) => {
+  return queryOptions({
+    queryFn: async () => {
+      const response = await axios.get(`/v1/users/${id}`);
+      return $User.parse(response.data);
+    },
+    queryKey: [USERS_QUERY_KEY]
+  });
+};
+
+export function useFindUserQuery(id: string) {
+  return useSuspenseQuery(useFindUserQueryOptions(id));
+}

--- a/apps/web/src/hooks/useFindUserQuery.ts
+++ b/apps/web/src/hooks/useFindUserQuery.ts
@@ -10,7 +10,7 @@ export const useFindUserQueryOptions = (id: string) => {
       const response = await axios.get(`/v1/users/${id}`);
       return $User.parse(response.data);
     },
-    queryKey: [USERS_QUERY_KEY]
+    queryKey: [USERS_QUERY_KEY, id]
   });
 };
 

--- a/apps/web/src/hooks/useSelfUpdateUserMutation.ts
+++ b/apps/web/src/hooks/useSelfUpdateUserMutation.ts
@@ -1,5 +1,5 @@
 import { useNotificationsStore } from '@douglasneuroinformatics/libui/hooks';
-import type { SelfUpdateUserData } from '@opendatacapture/schemas/user';
+import { $SelfUpdateUserData } from '@opendatacapture/schemas/user';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -9,14 +9,8 @@ export function useSelfUpdateUserMutation() {
   const queryClient = useQueryClient();
   const addNotification = useNotificationsStore((store) => store.addNotification);
   return useMutation({
-    mutationFn: async ({ data, id }: { data: SelfUpdateUserData; id: string }) => {
-      const submitData = { ...data };
-      if (submitData.email === '') delete submitData.email;
-      if (submitData.phoneNumber === '') delete submitData.phoneNumber;
-      if (submitData.password === '') {
-        delete submitData.password;
-      }
-      await axios.patch(`/v1/users/self-update/${id}`, submitData);
+    mutationFn: async ({ data, id }: { data: $SelfUpdateUserData; id: string }) => {
+      await axios.patch(`/v1/users/self-update/${id}`, data);
     },
     onSuccess() {
       addNotification({ type: 'success' });

--- a/apps/web/src/hooks/useSelfUpdateUserMutation.ts
+++ b/apps/web/src/hooks/useSelfUpdateUserMutation.ts
@@ -1,0 +1,26 @@
+import { useNotificationsStore } from '@douglasneuroinformatics/libui/hooks';
+import type { SelfUpdateUserData } from '@opendatacapture/schemas/user';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { USERS_QUERY_KEY } from './useUsersQuery';
+
+export function useSelfUpdateUserMutation() {
+  const queryClient = useQueryClient();
+  const addNotification = useNotificationsStore((store) => store.addNotification);
+  return useMutation({
+    mutationFn: async ({ data, id }: { data: SelfUpdateUserData; id: string }) => {
+      const submitData = { ...data };
+      if (submitData.email === '') delete submitData.email;
+      if (submitData.phoneNumber === '') delete submitData.phoneNumber;
+      if (submitData.password === '') {
+        delete submitData.password;
+      }
+      await axios.patch(`/v1/users/self-update/${id}`, submitData);
+    },
+    onSuccess() {
+      addNotification({ type: 'success' });
+      void queryClient.invalidateQueries({ queryKey: [USERS_QUERY_KEY] });
+    }
+  });
+}

--- a/apps/web/src/hooks/useUpdateUserMutation.ts
+++ b/apps/web/src/hooks/useUpdateUserMutation.ts
@@ -10,13 +10,7 @@ export function useUpdateUserMutation() {
   const addNotification = useNotificationsStore((store) => store.addNotification);
   return useMutation({
     mutationFn: async ({ data, id }: { data: UpdateUserData; id: string }) => {
-      const submitData = { ...data };
-      if (submitData.email === '') delete submitData.email;
-      if (submitData.phoneNumber === '') delete submitData.phoneNumber;
-      if (submitData.password === '') {
-        delete submitData.password;
-      }
-      await axios.patch(`/v1/users/${id}`, submitData);
+      await axios.patch(`/v1/users/${id}`, data);
     },
     onSuccess() {
       addNotification({ type: 'success' });

--- a/apps/web/src/hooks/useUpdateUserMutation.ts
+++ b/apps/web/src/hooks/useUpdateUserMutation.ts
@@ -10,7 +10,13 @@ export function useUpdateUserMutation() {
   const addNotification = useNotificationsStore((store) => store.addNotification);
   return useMutation({
     mutationFn: async ({ data, id }: { data: UpdateUserData; id: string }) => {
-      await axios.patch(`/v1/users/${id}`, data);
+      const submitData = { ...data };
+      if (submitData.email === '') delete submitData.email;
+      if (submitData.phoneNumber === '') delete submitData.phoneNumber;
+      if (submitData.password === '') {
+        delete submitData.password;
+      }
+      await axios.patch(`/v1/users/${id}`, submitData);
     },
     onSuccess() {
       addNotification({ type: 'success' });

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -41,15 +41,15 @@ const RouteComponent = () => {
   const $UpdateUserFormData = useMemo(() => {
     return z
       .object({
+        email: z.union([z.literal(''), z.email()]).optional(),
         firstName: z.string().min(1).optional(),
-        lastName: z.string().min(1).optional(),
         // eslint-disable-next-line perfectionist/sort-objects
         dateOfBirth: z.date().optional(),
-        password: z.string().min(1).optional(),
+        lastName: z.string().min(1).optional(),
         // eslint-disable-next-line perfectionist/sort-objects
         confirmPassword: z.string().min(1).optional(),
-        email: z.email().optional(),
-        phoneNumber: z.string().regex(phoneRegex).optional(),
+        password: z.string().min(1).optional(),
+        phoneNumber: z.union([z.literal(''), z.string().regex(phoneRegex)]).optional(),
         sex: $Sex
       })
       .check((ctx) => {
@@ -92,12 +92,16 @@ const RouteComponent = () => {
         <p className="text-sm">{currentUser?.username ?? fullName}</p>
       </div>
       <Form
-        key={userInfo.dataUpdatedAt}
         className="mx-auto max-w-3xl"
         content={[
           {
             fields: {
               // eslint-disable-next-line perfectionist/sort-objects
+              confirmPassword: {
+                kind: 'string',
+                label: t('common.confirmPassword'),
+                variant: 'password'
+              },
               password: {
                 calculateStrength: (password) => {
                   return estimatePasswordStrength(password).score;
@@ -106,25 +110,19 @@ const RouteComponent = () => {
                 label: t('common.password'),
                 variant: 'password'
               },
-              // eslint-disable-next-line perfectionist/sort-objects
-              confirmPassword: {
+              phoneNumber: {
                 kind: 'string',
-                label: t('common.confirmPassword'),
-                variant: 'password'
+                label: t({
+                  en: 'Phone Number',
+                  fr: 'Numéro de téléphone'
+                }),
+                variant: 'input'
               },
               email: {
                 kind: 'string',
                 label: t({
                   en: 'Email',
                   fr: 'Courriel'
-                }),
-                variant: 'input'
-              },
-              phoneNumber: {
-                kind: 'string',
-                label: t({
-                  en: 'Phone Number',
-                  fr: 'Numéro de téléphone'
                 }),
                 variant: 'input'
               }
@@ -168,10 +166,13 @@ const RouteComponent = () => {
         ]}
         initialValues={{
           dateOfBirth: userInfo.data.dateOfBirth ?? undefined,
+          email: userInfo.data.email ?? '',
           firstName: userInfo.data.firstName ?? '',
           lastName: userInfo.data.lastName ?? '',
+          phoneNumber: userInfo.data.phoneNumber ?? '',
           sex: userInfo.data.sex ?? undefined
         }}
+        key={userInfo.dataUpdatedAt}
         validationSchema={$UpdateUserFormData}
         onSubmit={(data) => {
           void updateUserMutation.mutateAsync({

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -9,8 +9,8 @@ import { z } from 'zod/v4';
 
 import { PageHeader } from '@/components/PageHeader';
 import { UserIcon } from '@/components/UserIcon';
+import { useFindUserQuery } from '@/hooks/useFindUserQuery';
 import { useUpdateUserMutation } from '@/hooks/useUpdateUserMutation';
-import { useUsersQuery } from '@/hooks/useUsersQuery';
 import { useAppStore } from '@/store';
 
 type UpdateUserFormData = {
@@ -25,12 +25,7 @@ const RouteComponent = () => {
 
   const updateUserMutation = useUpdateUserMutation();
   const { resolvedLanguage, t } = useTranslation();
-  const userList = useUsersQuery();
-  let userInfo;
-
-  if (userList.data) {
-    userInfo = userList.data.find((record) => record.id === currentUser?.id);
-  }
+  const userInfo = useFindUserQuery(currentUser!.id);
 
   let fullName: string;
   if (currentUser?.firstName && currentUser.lastName) {
@@ -157,10 +152,10 @@ const RouteComponent = () => {
           }
         ]}
         initialValues={{
-          dateOfBirth: userInfo?.dateOfBirth ?? undefined,
+          dateOfBirth: userInfo.data.dateOfBirth ?? undefined,
           firstName: currentUser?.firstName ?? 'N/A',
           lastName: currentUser?.lastName ?? 'N/A',
-          sex: userInfo?.sex ?? undefined
+          sex: userInfo.data.sex ?? undefined
         }}
         validationSchema={$UpdateUserFormData}
         onSubmit={(data) => {

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -1,14 +1,33 @@
-import { Heading } from '@douglasneuroinformatics/libui/components';
+import { useMemo } from 'react';
+
+import { estimatePasswordStrength } from '@douglasneuroinformatics/libpasswd';
+import { Form, Heading } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { $Sex } from '@opendatacapture/schemas/subject';
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod/v4';
 
 import { PageHeader } from '@/components/PageHeader';
 import { UserIcon } from '@/components/UserIcon';
+import { useUsersQuery } from '@/hooks/useUsersQuery';
 import { useAppStore } from '@/store';
+
+type UpdateUserFormData = {
+  confirmPassword?: string | undefined;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  password?: string | undefined;
+};
 
 const RouteComponent = () => {
   const currentUser = useAppStore((store) => store.currentUser);
-  const { t } = useTranslation();
+  const { resolvedLanguage, t } = useTranslation();
+  const userList = useUsersQuery();
+  let userInfo;
+
+  if (userList.data) {
+    userInfo = userList.data.find((record) => record.id === currentUser?.id);
+  }
 
   let fullName: string;
   if (currentUser?.firstName && currentUser.lastName) {
@@ -18,6 +37,32 @@ const RouteComponent = () => {
   } else {
     fullName = 'Unnamed User';
   }
+
+  const $UpdateUserFormData = useMemo(() => {
+    return z
+      .object({
+        firstName: z.string().min(1).optional(),
+        lastName: z.string().min(1).optional(),
+        // eslint-disable-next-line perfectionist/sort-objects
+        dateOfBirth: z.date().optional(),
+        password: z.string().min(1).optional(),
+        // eslint-disable-next-line perfectionist/sort-objects
+        confirmPassword: z.string().min(1).optional(),
+        sex: $Sex
+      })
+      .check((ctx) => {
+        if (ctx.value.password && !estimatePasswordStrength(ctx.value.password).success) {
+          ctx.issues.push({
+            code: 'custom',
+            fatal: true,
+            input: ctx.value.password,
+            message: t('common.insufficientPasswordStrength'),
+            path: ['password']
+          });
+          return z.NEVER;
+        }
+      }) satisfies z.ZodType<UpdateUserFormData>;
+  }, [resolvedLanguage]);
 
   return (
     <div>
@@ -34,6 +79,77 @@ const RouteComponent = () => {
         <Heading variant="h2">{fullName}</Heading>
         <p className="text-sm">{currentUser?.username ?? fullName}</p>
       </div>
+      <Form
+        className="mx-auto max-w-3xl"
+        content={[
+          {
+            fields: {
+              // username: {
+              //   kind: 'string',
+              //   label: t('common.username'),
+              //   variant: 'input'
+              // },
+
+              // eslint-disable-next-line perfectionist/sort-objects
+              password: {
+                calculateStrength: (password) => {
+                  return estimatePasswordStrength(password).score;
+                },
+                kind: 'string',
+                label: t('common.password'),
+                variant: 'password'
+              },
+              // eslint-disable-next-line perfectionist/sort-objects
+              confirmPassword: {
+                kind: 'string',
+                label: t('common.confirmPassword'),
+                variant: 'password'
+              }
+            },
+            title: t({
+              en: 'Login Credentials',
+              fr: 'Identifiants de connexion'
+            })
+          },
+          {
+            fields: {
+              dateOfBirth: {
+                kind: 'date',
+                label: t('core.identificationData.dateOfBirth.label')
+              },
+              firstName: {
+                kind: 'string',
+                label: t('core.identificationData.firstName.label'),
+                variant: 'input'
+              },
+              lastName: {
+                kind: 'string',
+                label: t('core.identificationData.lastName.label'),
+                variant: 'input'
+              },
+              sex: {
+                kind: 'string',
+                label: t('core.identificationData.sex.label'),
+                options: {
+                  FEMALE: t('core.identificationData.sex.female'),
+                  MALE: t('core.identificationData.sex.male')
+                },
+                variant: 'select'
+              }
+            },
+            title: t({
+              en: 'Personal Information',
+              fr: 'Informations individuel'
+            })
+          }
+        ]}
+        initialValues={{
+          dateOfBirth: userInfo?.dateOfBirth,
+          firstName: currentUser?.firstName ?? 'N/A',
+          lastName: currentUser?.lastName ?? 'N/A'
+        }}
+        validationSchema={$UpdateUserFormData}
+      />
     </div>
   );
 };

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -29,6 +29,23 @@ const RouteComponent = () => {
   const { resolvedLanguage, t } = useTranslation();
   const userInfo = useFindUserQuery(currentUser!.id);
 
+  const userType: { [key: string]: string } = {
+    ADMIN: t({
+      en: 'Admin',
+      fr: 'Admin'
+    }),
+    GROUP_MANAGER: t({
+      en: 'Group Manager',
+      fr: 'Responsable de groupe'
+    }),
+    STANDARD_USER: t({
+      en: 'Standard User',
+      fr: 'Utilisateur standard'
+    })
+  };
+
+  const userTypes = ['ADMIN', 'GROUP_MANAGER', 'STANDARD_USER'];
+
   let fullName: string;
   if (userInfo.data.firstName && userInfo.data.lastName) {
     fullName = `${userInfo.data.firstName} ${userInfo.data.lastName}`;
@@ -90,17 +107,29 @@ const RouteComponent = () => {
         <UserIcon className="h-16 w-16" />
         <Heading variant="h2">{fullName}</Heading>
         <p className="text-sm">{currentUser?.username ?? fullName}</p>
+        <p className="text-sm">
+          {userTypes.includes(userInfo.data.basePermissionLevel as string)
+            ? userType[userInfo.data.basePermissionLevel as string]
+            : undefined}
+        </p>
       </div>
       <Form
         className="mx-auto max-w-3xl"
         content={[
           {
             fields: {
-              // eslint-disable-next-line perfectionist/sort-objects
               confirmPassword: {
                 kind: 'string',
                 label: t('common.confirmPassword'),
                 variant: 'password'
+              },
+              email: {
+                kind: 'string',
+                label: t({
+                  en: 'Email',
+                  fr: 'Courriel'
+                }),
+                variant: 'input'
               },
               password: {
                 calculateStrength: (password) => {
@@ -115,14 +144,6 @@ const RouteComponent = () => {
                 label: t({
                   en: 'Phone Number',
                   fr: 'Numéro de téléphone'
-                }),
-                variant: 'input'
-              },
-              email: {
-                kind: 'string',
-                label: t({
-                  en: 'Email',
-                  fr: 'Courriel'
                 }),
                 variant: 'input'
               }

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -159,7 +159,10 @@ const RouteComponent = () => {
         }}
         validationSchema={$UpdateUserFormData}
         onSubmit={(data) => {
-          void updateUserMutation.mutateAsync({ data: data, id: currentUser!.id });
+          void updateUserMutation.mutateAsync({
+            data: { groupIds: Array.from(userInfo.data.groupIds), ...data },
+            id: currentUser!.id
+          });
         }}
       />
     </div>

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -64,6 +64,16 @@ const RouteComponent = () => {
           });
           return z.NEVER;
         }
+      })
+      .check((ctx) => {
+        if (ctx.value.confirmPassword !== ctx.value.password) {
+          ctx.issues.push({
+            code: 'custom',
+            input: ctx.value.confirmPassword,
+            message: t('common.passwordsMustMatch'),
+            path: ['confirmPassword']
+          });
+        }
       }) satisfies z.ZodType<UpdateUserFormData>;
   }, [resolvedLanguage]);
 

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -196,8 +196,14 @@ const RouteComponent = () => {
         key={userInfo.dataUpdatedAt}
         validationSchema={$UpdateUserFormData}
         onSubmit={(data) => {
+          const { confirmPassword, password, ...restData } = data;
+
           void updateUserMutation.mutateAsync({
-            data: { groupIds: Array.from(userInfo.data.groupIds), ...data },
+            data: {
+              groupIds: Array.from(userInfo.data.groupIds),
+              ...restData,
+              ...(password && password === confirmPassword ? { password } : {})
+            },
             id: currentUser!.id
           });
         }}

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -20,6 +20,8 @@ type UpdateUserFormData = {
   password?: string | undefined;
 };
 
+const phoneRegex = new RegExp(/^([+]?[\s0-9]+)?(\d{3}|[(]?[0-9]+[)])?([-]?[\s]?[0-9])+$/);
+
 const RouteComponent = () => {
   const currentUser = useAppStore((store) => store.currentUser);
 
@@ -47,6 +49,7 @@ const RouteComponent = () => {
         // eslint-disable-next-line perfectionist/sort-objects
         confirmPassword: z.string().min(1).optional(),
         email: z.email().optional(),
+        phoneNumber: z.string().regex(phoneRegex).optional(),
         sex: $Sex
       })
       .check((ctx) => {
@@ -114,6 +117,14 @@ const RouteComponent = () => {
                 label: t({
                   en: 'Email',
                   fr: 'Courriel'
+                }),
+                variant: 'input'
+              },
+              phoneNumber: {
+                kind: 'string',
+                label: t({
+                  en: 'Phone Number',
+                  fr: 'Numéro de téléphone'
                 }),
                 variant: 'input'
               }

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod/v4';
 
 import { PageHeader } from '@/components/PageHeader';
 import { UserIcon } from '@/components/UserIcon';
+import { useUpdateUserMutation } from '@/hooks/useUpdateUserMutation';
 import { useUsersQuery } from '@/hooks/useUsersQuery';
 import { useAppStore } from '@/store';
 
@@ -21,6 +22,8 @@ type UpdateUserFormData = {
 
 const RouteComponent = () => {
   const currentUser = useAppStore((store) => store.currentUser);
+
+  const updateUserMutation = useUpdateUserMutation();
   const { resolvedLanguage, t } = useTranslation();
   const userList = useUsersQuery();
   let userInfo;
@@ -149,6 +152,9 @@ const RouteComponent = () => {
           lastName: currentUser?.lastName ?? 'N/A'
         }}
         validationSchema={$UpdateUserFormData}
+        onSubmit={(data) => {
+          void updateUserMutation.mutateAsync({ data: data, id: currentUser!.id });
+        }}
       />
     </div>
   );

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -1,11 +1,14 @@
 import { Heading } from '@douglasneuroinformatics/libui/components';
+import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { createFileRoute } from '@tanstack/react-router';
 
+import { PageHeader } from '@/components/PageHeader';
 import { UserIcon } from '@/components/UserIcon';
 import { useAppStore } from '@/store';
 
 const RouteComponent = () => {
   const currentUser = useAppStore((store) => store.currentUser);
+  const { t } = useTranslation();
 
   let fullName: string;
   if (currentUser?.firstName && currentUser.lastName) {
@@ -17,10 +20,20 @@ const RouteComponent = () => {
   }
 
   return (
-    <div className="mt-4 flex flex-col items-center justify-center">
-      <UserIcon className="h-16 w-16" />
-      <Heading variant="h2">{fullName}</Heading>
-      <p className="text-sm">{currentUser?.username ?? fullName}</p>
+    <div>
+      <PageHeader>
+        <Heading className="text-center" variant="h2">
+          {t({
+            en: 'User Info',
+            fr: 'Informations utilisateur'
+          })}
+        </Heading>
+      </PageHeader>
+      <div className="mt-4 flex flex-col items-center justify-center">
+        <UserIcon className="h-16 w-16" />
+        <Heading variant="h2">{fullName}</Heading>
+        <p className="text-sm">{currentUser?.username ?? fullName}</p>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -20,7 +20,7 @@ type UpdateUserFormData = {
   password?: string | undefined;
 };
 
-const phoneRegex = new RegExp(/^([+]?[\s0-9]+)?(\d{3}|[(]?[0-9]+[)])?([-]?[\s]?[0-9])+$/);
+const phoneRegex = new RegExp(/^\+?\(?\d{1,4}\)?[\s.-]?\d{1,4}[\s.-]?\d{1,9}$/);
 
 const RouteComponent = () => {
   const currentUser = useAppStore((store) => store.currentUser);

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -181,7 +181,7 @@ const RouteComponent = () => {
             },
             title: t({
               en: 'Personal Information',
-              fr: 'Informations individuel'
+              fr: 'Informations personnelles'
             })
           }
         ]}

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -50,7 +50,7 @@ const RouteComponent = () => {
         confirmPassword: z.string().min(1).optional(),
         password: z.string().min(1).optional(),
         phoneNumber: z.union([z.literal(''), z.string().regex(phoneRegex)]).optional(),
-        sex: $Sex
+        sex: $Sex.optional()
       })
       .check((ctx) => {
         if (ctx.value.password && !estimatePasswordStrength(ctx.value.password).success) {

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -147,9 +147,10 @@ const RouteComponent = () => {
           }
         ]}
         initialValues={{
-          dateOfBirth: userInfo?.dateOfBirth,
+          dateOfBirth: userInfo?.dateOfBirth ?? undefined,
           firstName: currentUser?.firstName ?? 'N/A',
-          lastName: currentUser?.lastName ?? 'N/A'
+          lastName: currentUser?.lastName ?? 'N/A',
+          sex: userInfo?.sex ?? undefined
         }}
         validationSchema={$UpdateUserFormData}
         onSubmit={(data) => {

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -28,10 +28,10 @@ const RouteComponent = () => {
   const userInfo = useFindUserQuery(currentUser!.id);
 
   let fullName: string;
-  if (currentUser?.firstName && currentUser.lastName) {
-    fullName = `${currentUser.firstName} ${currentUser.lastName}`;
-  } else if (currentUser?.firstName) {
-    fullName = currentUser.firstName;
+  if (userInfo.data.firstName && userInfo.data.lastName) {
+    fullName = `${userInfo.data.firstName} ${userInfo.data.lastName}`;
+  } else if (userInfo.data.firstName) {
+    fullName = userInfo.data.firstName;
   } else {
     fullName = 'Unnamed User';
   }
@@ -88,6 +88,7 @@ const RouteComponent = () => {
         <p className="text-sm">{currentUser?.username ?? fullName}</p>
       </div>
       <Form
+        key={userInfo.dataUpdatedAt}
         className="mx-auto max-w-3xl"
         content={[
           {
@@ -153,8 +154,8 @@ const RouteComponent = () => {
         ]}
         initialValues={{
           dateOfBirth: userInfo.data.dateOfBirth ?? undefined,
-          firstName: currentUser?.firstName ?? 'N/A',
-          lastName: currentUser?.lastName ?? 'N/A',
+          firstName: userInfo.data.firstName ?? '',
+          lastName: userInfo.data.lastName ?? '',
           sex: userInfo.data.sex ?? undefined
         }}
         validationSchema={$UpdateUserFormData}

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -10,14 +10,16 @@ import { z } from 'zod/v4';
 import { PageHeader } from '@/components/PageHeader';
 import { UserIcon } from '@/components/UserIcon';
 import { useFindUserQuery } from '@/hooks/useFindUserQuery';
-import { useUpdateUserMutation } from '@/hooks/useUpdateUserMutation';
+import { useSelfUpdateUserMutation } from '@/hooks/useSelfUpdateUserMutation';
 import { useAppStore } from '@/store';
 
 type UpdateUserFormData = {
   confirmPassword?: string | undefined;
+  email?: string | undefined;
   firstName?: string | undefined;
   lastName?: string | undefined;
   password?: string | undefined;
+  phoneNumber?: string | undefined;
 };
 
 const phoneRegex = new RegExp(/^\+?\(?\d{1,4}\)?[\s.-]?\d{1,4}[\s.-]?\d{1,9}$/);
@@ -25,7 +27,7 @@ const phoneRegex = new RegExp(/^\+?\(?\d{1,4}\)?[\s.-]?\d{1,4}[\s.-]?\d{1,9}$/);
 const RouteComponent = () => {
   const currentUser = useAppStore((store) => store.currentUser);
 
-  const updateUserMutation = useUpdateUserMutation();
+  const updateSelfUserMutation = useSelfUpdateUserMutation();
   const { resolvedLanguage, t } = useTranslation();
   const userInfo = useFindUserQuery(currentUser!.id);
 
@@ -123,14 +125,6 @@ const RouteComponent = () => {
                 label: t('common.confirmPassword'),
                 variant: 'password'
               },
-              email: {
-                kind: 'string',
-                label: t({
-                  en: 'Email',
-                  fr: 'Courriel'
-                }),
-                variant: 'input'
-              },
               password: {
                 calculateStrength: (password) => {
                   return estimatePasswordStrength(password).score;
@@ -138,6 +132,15 @@ const RouteComponent = () => {
                 kind: 'string',
                 label: t('common.password'),
                 variant: 'password'
+              },
+              // eslint-disable-next-line perfectionist/sort-objects
+              email: {
+                kind: 'string',
+                label: t({
+                  en: 'Email',
+                  fr: 'Courriel'
+                }),
+                variant: 'input'
               },
               phoneNumber: {
                 kind: 'string',
@@ -198,9 +201,8 @@ const RouteComponent = () => {
         onSubmit={(data) => {
           const { confirmPassword, password, ...restData } = data;
 
-          void updateUserMutation.mutateAsync({
+          void updateSelfUserMutation.mutateAsync({
             data: {
-              groupIds: Array.from(userInfo.data.groupIds),
               ...restData,
               ...(password && password === confirmPassword ? { password } : {})
             },

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -15,11 +15,13 @@ import { useAppStore } from '@/store';
 
 type UpdateUserFormData = {
   confirmPassword?: string | undefined;
+  dateOfBirth?: Date | undefined;
   email?: string | undefined;
   firstName?: string | undefined;
   lastName?: string | undefined;
   password?: string | undefined;
   phoneNumber?: string | undefined;
+  sex?: z.infer<typeof $Sex> | undefined;
 };
 
 const phoneRegex = new RegExp(/^\+?\(?\d{1,4}\)?[\s.-]?\d{1,4}[\s.-]?\d{1,9}$/);
@@ -40,13 +42,13 @@ const RouteComponent = () => {
       en: 'Group Manager',
       fr: 'Responsable de groupe'
     }),
-    STANDARD_USER: t({
+    STANDARD: t({
       en: 'Standard User',
       fr: 'Utilisateur standard'
     })
   };
 
-  const userTypes = ['ADMIN', 'GROUP_MANAGER', 'STANDARD_USER'];
+  const userTypes = ['ADMIN', 'GROUP_MANAGER', 'STANDARD'];
 
   let fullName: string;
   if (userInfo.data.firstName && userInfo.data.lastName) {

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -46,6 +46,7 @@ const RouteComponent = () => {
         password: z.string().min(1).optional(),
         // eslint-disable-next-line perfectionist/sort-objects
         confirmPassword: z.string().min(1).optional(),
+        email: z.email().optional(),
         sex: $Sex
       })
       .check((ctx) => {
@@ -93,12 +94,6 @@ const RouteComponent = () => {
         content={[
           {
             fields: {
-              // username: {
-              //   kind: 'string',
-              //   label: t('common.username'),
-              //   variant: 'input'
-              // },
-
               // eslint-disable-next-line perfectionist/sort-objects
               password: {
                 calculateStrength: (password) => {
@@ -113,6 +108,14 @@ const RouteComponent = () => {
                 kind: 'string',
                 label: t('common.confirmPassword'),
                 variant: 'password'
+              },
+              email: {
+                kind: 'string',
+                label: t({
+                  en: 'Email',
+                  fr: 'Courriel'
+                }),
+                variant: 'input'
               }
             },
             title: t({

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -200,10 +200,13 @@ const RouteComponent = () => {
         validationSchema={$UpdateUserFormData}
         onSubmit={(data) => {
           const { confirmPassword, password, ...restData } = data;
+          const filteredData = Object.fromEntries(
+            Object.entries(restData).filter(([, value]) => value != null && value !== '')
+          );
 
           void updateSelfUserMutation.mutateAsync({
             data: {
-              ...restData,
+              ...filteredData,
               ...(password && password === confirmPassword ? { password } : {})
             },
             id: currentUser!.id

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -20,7 +20,7 @@ const RouteComponent = () => {
     <div className="mt-4 flex flex-col items-center justify-center">
       <UserIcon className="h-16 w-16" />
       <Heading variant="h2">{fullName}</Heading>
-      <p className="text-sm">{fullName}</p>
+      <p className="text-sm">{currentUser?.username ?? fullName}</p>
     </div>
   );
 };

--- a/packages/schemas/src/user/user.ts
+++ b/packages/schemas/src/user/user.ts
@@ -43,9 +43,15 @@ export const $UpdateUserData = $CreateUserData.partial().extend({
   additionalPermissions: $Permissions.optional()
 });
 
-export type SelfUpdateUserData = z.infer<typeof $SelfUpdateUserData>;
-export const $SelfUpdateUserData = $UpdateUserData.partial().omit({
-  additionalPermissions: true,
-  basePermissionLevel: true,
-  groupIds: true
-});
+export type $SelfUpdateUserData = z.infer<typeof $SelfUpdateUserData>;
+export const $SelfUpdateUserData = $UpdateUserData
+  .pick({
+    dateOfBirth: true,
+    email: true,
+    firstName: true,
+    lastName: true,
+    password: true,
+    phoneNumber: true,
+    sex: true
+  })
+  .partial();

--- a/packages/schemas/src/user/user.ts
+++ b/packages/schemas/src/user/user.ts
@@ -42,3 +42,10 @@ export type UpdateUserData = z.infer<typeof $UpdateUserData>;
 export const $UpdateUserData = $CreateUserData.partial().extend({
   additionalPermissions: $Permissions.optional()
 });
+
+export type SelfUpdateUserData = z.infer<typeof $SelfUpdateUserData>;
+export const $SelfUpdateUserData = $UpdateUserData.partial().omit({
+  additionalPermissions: true,
+  basePermissionLevel: true,
+  groupIds: true
+});

--- a/packages/schemas/src/user/user.ts
+++ b/packages/schemas/src/user/user.ts
@@ -12,9 +12,11 @@ export const $User = $BaseModel.extend({
   additionalPermissions: $Permissions,
   basePermissionLevel: $BasePermissionLevel.nullable(),
   dateOfBirth: z.coerce.date().nullish(),
+  email: z.email().nullish(),
   firstName: z.string().min(1),
   groupIds: z.array(z.string()),
   lastName: z.string().min(1),
+  phoneNumber: z.string().nullish(),
   sex: $Sex.nullish(),
   username: z.string().min(1)
 });
@@ -30,7 +32,9 @@ export const $CreateUserData = $User
   })
   .extend({
     dateOfBirth: z.coerce.date().optional(),
+    email: z.email().optional(),
     password: z.string().min(1),
+    phoneNumber: z.string().optional(),
     sex: $Sex.optional()
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@douglasneuroinformatics/eslint-config':
         specifier: ^6.0.0
-        version: 6.0.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+        version: 6.0.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       '@douglasneuroinformatics/prettier-config':
         specifier: ^0.3.0
         version: 0.3.0(husky@9.1.7)(prettier-plugin-astro@0.14.1)(prettier-plugin-tailwindcss@0.6.14(prettier-plugin-astro@0.14.1)(prettier@3.8.1))(prettier@3.8.1)
       '@douglasneuroinformatics/tsconfig':
         specifier: ^2.0.0
-        version: 2.0.0(typescript@6.0.2)
+        version: 2.0.0(typescript@6.0.3)
       '@swc-node/register':
         specifier: ^1.10.9
-        version: 1.11.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.2)
+        version: 1.11.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3)
       '@swc/cli':
         specifier: ^0.6.0
         version: 0.6.0(@swc/core@1.15.11(@swc/helpers@0.5.18))(chokidar@4.0.3)
@@ -163,7 +163,7 @@ importers:
         version: 4.1.1
       knip:
         specifier: ^5.46.0
-        version: 5.84.1(@types/node@22.19.11)(typescript@6.0.2)
+        version: 5.84.1(@types/node@22.19.11)(typescript@6.0.3)
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
@@ -184,7 +184,7 @@ importers:
         version: 2.8.10
       typescript:
         specifier: 6.0.x
-        version: 6.0.2
+        version: 6.0.3
       unplugin-swc:
         specifier: ^1.5.1
         version: 1.5.9(@swc/core@1.15.11(@swc/helpers@0.5.18))(rollup@4.58.0)
@@ -199,7 +199,7 @@ importers:
         version: 6.8.0
       '@casl/prisma':
         specifier: ^1.5.1
-        version: 1.6.1(@casl/ability@6.8.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))
+        version: 1.6.1(@casl/ability@6.8.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))
       '@douglasneuroinformatics/libcrypto':
         specifier: 'catalog:'
         version: 0.0.5
@@ -208,10 +208,10 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libnest':
         specifier: ^8.2.0
-        version: 8.2.1(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-fastify@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14))(@nestjs/testing@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14))(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))(@swc/types@0.1.25)(fastify@5.7.4)(neverthrow@8.2.0)(reflect-metadata@0.1.14)(rollup@4.58.0)(rxjs@7.8.2)(typescript@6.0.2)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(zod@vendor+zod@3.x)
+        version: 8.2.1(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-fastify@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14))(@nestjs/testing@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14))(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))(@swc/types@0.1.25)(fastify@5.7.4)(neverthrow@8.2.0)(reflect-metadata@0.1.14)(rollup@4.58.0)(rxjs@7.8.2)(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libpasswd':
         specifier: 'catalog:'
-        version: 0.0.3(typescript@6.0.2)
+        version: 0.0.3(typescript@6.0.3)
       '@douglasneuroinformatics/libstats':
         specifier: 'catalog:'
         version: 0.2.0
@@ -271,7 +271,7 @@ importers:
         version: link:../../packages/subject-utils
       '@prisma/client':
         specifier: 'catalog:'
-        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
       axios:
         specifier: 'catalog:'
         version: 1.15.0
@@ -329,10 +329,10 @@ importers:
         version: 10.4.3(socks@2.8.7)
       prisma:
         specifier: 'catalog:'
-        version: 6.19.2(magicast@0.3.5)(typescript@6.0.2)
+        version: 6.19.2(magicast@0.3.5)(typescript@6.0.3)
       prisma-json-types-generator:
         specifier: ^3.2.2
-        version: 3.6.2(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+        version: 3.6.2(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
 
   apps/gateway:
     dependencies:
@@ -356,7 +356,7 @@ importers:
         version: link:../../packages/schemas
       '@prisma/client':
         specifier: 'catalog:'
-        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
       axios:
         specifier: 'catalog:'
         version: 1.15.0
@@ -396,7 +396,7 @@ importers:
     devDependencies:
       '@douglasneuroinformatics/esbuild-plugin-prisma':
         specifier: 'catalog:'
-        version: 1.0.1(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))(@prisma/engines@6.19.2)(esbuild@0.23.1)(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))
+        version: 1.0.1(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))(@prisma/engines@6.19.2)(esbuild@0.23.1)(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))
       '@opendatacapture/release-info':
         specifier: workspace:*
         version: link:../../packages/release-info
@@ -423,7 +423,7 @@ importers:
         version: 3.1.13
       prisma:
         specifier: 'catalog:'
-        version: 6.19.2(magicast@0.3.5)(typescript@6.0.2)
+        version: 6.19.2(magicast@0.3.5)(typescript@6.0.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.0
@@ -469,16 +469,16 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)
+        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.3)
       '@astrojs/sitemap':
         specifier: ^3.2.1
         version: 3.7.0
       '@astrojs/starlight':
         specifier: ^0.34.3
-        version: 0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2))
+        version: 0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2))
       '@astrojs/starlight-tailwind':
         specifier: 4.0.1
-        version: 4.0.1(@astrojs/starlight@0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)))(tailwindcss@4.2.0)
+        version: 4.0.1(@astrojs/starlight@0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)))(tailwindcss@4.2.0)
       '@opendatacapture/runtime-core':
         specifier: workspace:*
         version: link:../../packages/runtime-core
@@ -493,7 +493,7 @@ importers:
         version: 4.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       astro:
         specifier: ^5.15.9
-        version: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)
+        version: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -508,10 +508,10 @@ importers:
         version: link:../../vendor/type-fest@4.x
       typedoc:
         specifier: 0.27.x
-        version: 0.27.9(typescript@6.0.2)
+        version: 0.27.9(typescript@6.0.3)
       typedoc-plugin-markdown:
         specifier: 4.4.x
-        version: 4.4.2(typedoc@0.27.9(typescript@6.0.2))
+        version: 4.4.2(typedoc@0.27.9(typescript@6.0.3))
 
   apps/playground:
     dependencies:
@@ -620,7 +620,7 @@ importers:
         version: link:../../packages/vite-plugin-runtime
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -647,7 +647,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libpasswd':
         specifier: 'catalog:'
-        version: 0.0.3(typescript@6.0.2)
+        version: 0.0.3(typescript@6.0.3)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
         version: 6.2.1(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.2.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
@@ -771,7 +771,7 @@ importers:
         version: link:../../packages/vite-plugin-runtime
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -996,7 +996,7 @@ importers:
         version: link:../instrument-stubs
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       type-fest:
         specifier: workspace:type-fest__4.x@*
         version: link:../../vendor/type-fest@4.x
@@ -1077,7 +1077,7 @@ importers:
     devDependencies:
       '@casl/prisma':
         specifier: ^1.5.1
-        version: 1.6.1(@casl/ability@6.8.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))
+        version: 1.6.1(@casl/ability@6.8.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))
       '@opendatacapture/instrument-stubs':
         specifier: workspace:*
         version: link:../instrument-stubs
@@ -1339,7 +1339,7 @@ importers:
         version: 9.0.0-beta.3(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -7646,9 +7646,9 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-perfectionist@5.8.0:
+  eslint-plugin-perfectionist@5.9.0:
     resolution:
-      { integrity: sha512-k8uIptWIxkUclonCFGyDzgYs9NI+Qh0a7cUXS3L7IYZDEsjXuimFBVbxXPQQngWqMiaxJRwbtYB4smMGMqF+cw== }
+      { integrity: sha512-8TWzg02zmnBdZwCkWLi8jhzqXI+fE7Z/RwV8SL6xD45tJ8Bp3wGuYL2XtQgfe/Wd0eBqOUX+s6ey73IyszvKTA== }
     engines: { node: ^20.0.0 || >=22.0.0 }
     peerDependencies:
       eslint: ^8.45.0 || ^9.0.0 || ^10.0.0
@@ -12268,9 +12268,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: 6.0.x
 
-  typescript@6.0.2:
+  typescript@6.0.3:
     resolution:
-      { integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ== }
+      { integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw== }
     engines: { node: '>=14.17' }
     hasBin: true
 
@@ -13113,12 +13113,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@astrojs/check@0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)':
+  '@astrojs/check@0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)
+      '@astrojs/language-server': 2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
-      typescript: 6.0.2
+      typescript: 6.0.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - prettier
@@ -13128,12 +13128,12 @@ snapshots:
 
   '@astrojs/internal-helpers@0.7.5': {}
 
-  '@astrojs/language-server@2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.2)':
+  '@astrojs/language-server@2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.2
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@volar/kit': 2.4.28(typescript@6.0.2)
+      '@volar/kit': 2.4.28(typescript@6.0.3)
       '@volar/language-core': 2.4.28
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
@@ -13180,12 +13180,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.13(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2))':
+  '@astrojs/mdx@4.3.13(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)
+      astro: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -13209,22 +13209,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)))(tailwindcss@4.2.0)':
+  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)))(tailwindcss@4.2.0)':
     dependencies:
-      '@astrojs/starlight': 0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2))
+      '@astrojs/starlight': 0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2))
       tailwindcss: 4.2.0
 
-  '@astrojs/starlight@0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2))':
+  '@astrojs/starlight@0.34.8(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
-      '@astrojs/mdx': 4.3.13(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2))
+      '@astrojs/mdx': 4.3.13(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2))
       '@astrojs/sitemap': 3.7.0
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)
-      astro-expressive-code: 0.41.6(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2))
+      astro: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      astro-expressive-code: 0.41.6(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -13389,10 +13389,10 @@ snapshots:
     dependencies:
       '@ucast/mongo2js': 1.4.1
 
-  '@casl/prisma@1.6.1(@casl/ability@6.8.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))':
+  '@casl/prisma@1.6.1(@casl/ability@6.8.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))':
     dependencies:
       '@casl/ability': 6.8.0
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
       '@ucast/core': 1.10.2
       '@ucast/js': 3.1.0
 
@@ -13429,31 +13429,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@douglasneuroinformatics/esbuild-plugin-prisma@1.0.1(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))(@prisma/engines@6.19.2)(esbuild@0.23.1)(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))':
+  '@douglasneuroinformatics/esbuild-plugin-prisma@1.0.1(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))(@prisma/engines@6.19.2)(esbuild@0.23.1)(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))':
     dependencies:
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
       '@prisma/engines': 6.19.2
       '@prisma/get-platform': 5.22.0
       esbuild: 0.23.1
-      prisma: 6.19.2(magicast@0.3.5)(typescript@6.0.2)
+      prisma: 6.19.2(magicast@0.3.5)(typescript@6.0.3)
 
-  '@douglasneuroinformatics/eslint-config@6.0.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@douglasneuroinformatics/eslint-config@6.0.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint/js': 9.39.3
       eslint: 9.23.0(jiti@2.6.1)
       eslint-plugin-astro: 1.7.0(eslint@9.23.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.23.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint@9.23.0(jiti@2.6.1))
       eslint-plugin-jsdoc: 50.8.0(eslint@9.23.0(jiti@2.6.1))
       eslint-plugin-jsonc: 2.21.1(eslint@9.23.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.23.0(jiti@2.6.1))
-      eslint-plugin-perfectionist: 5.8.0(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      eslint-plugin-perfectionist: 5.9.0(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       eslint-plugin-react: 7.37.5(eslint@9.23.0(jiti@2.6.1))
       eslint-plugin-svelte: 2.46.1(eslint@9.23.0(jiti@2.6.1))
       globals: 15.15.0
       jsonc-eslint-parser: 2.4.2
-      typescript-eslint: 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      typescript-eslint: 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@eslint/json'
       - '@typescript-eslint/parser'
@@ -13497,7 +13497,7 @@ snapshots:
       type-fest: 4.41.0
       zod: link:vendor/zod@3.x
 
-  '@douglasneuroinformatics/libnest@8.2.1(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-fastify@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14))(@nestjs/testing@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14))(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))(@swc/types@0.1.25)(fastify@5.7.4)(neverthrow@8.2.0)(reflect-metadata@0.1.14)(rollup@4.58.0)(rxjs@7.8.2)(typescript@6.0.2)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(zod@vendor+zod@3.x)':
+  '@douglasneuroinformatics/libnest@8.2.1(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-fastify@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14))(@nestjs/testing@11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14))(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))(@swc/types@0.1.25)(fastify@5.7.4)(neverthrow@8.2.0)(reflect-metadata@0.1.14)(rollup@4.58.0)(rxjs@7.8.2)(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(zod@vendor+zod@3.x)':
     dependencies:
       '@douglasneuroinformatics/libjs': 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@nestjs/common': 11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -13506,10 +13506,10 @@ snapshots:
       '@nestjs/swagger': 11.2.6(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(reflect-metadata@0.1.14)
       '@nestjs/testing': 11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14)
       '@nestjs/throttler': 6.5.0(@nestjs/common@11.1.14(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.14)(reflect-metadata@0.1.14)
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
       '@prisma/engines': 6.19.2
       '@prisma/get-platform': 6.19.2
-      '@swc-node/register': 1.11.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.2)
+      '@swc-node/register': 1.11.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3)
       '@swc/core': 1.15.11(@swc/helpers@0.5.18)
       '@swc/helpers': 0.5.18
       '@types/nodemailer': 7.0.11
@@ -13541,14 +13541,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@douglasneuroinformatics/libpasswd@0.0.3(typescript@6.0.2)':
+  '@douglasneuroinformatics/libpasswd@0.0.3(typescript@6.0.3)':
     dependencies:
       '@zxcvbn-ts/core': 3.0.4
       '@zxcvbn-ts/language-common': 3.0.4
       '@zxcvbn-ts/language-en': 3.0.2
       '@zxcvbn-ts/language-fr': 3.0.2
       type-fest: 4.41.0
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   '@douglasneuroinformatics/libstats-darwin-arm64@0.2.0':
     optional: true
@@ -13707,9 +13707,9 @@ snapshots:
       prettier-plugin-astro: 0.14.1
       prettier-plugin-tailwindcss: 0.6.14(prettier-plugin-astro@0.14.1)(prettier@3.8.1)
 
-  '@douglasneuroinformatics/tsconfig@2.0.0(typescript@6.0.2)':
+  '@douglasneuroinformatics/tsconfig@2.0.0(typescript@6.0.3)':
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -14421,14 +14421,14 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       glob: 10.5.0
       magic-string: 0.27.0
-      react-docgen-typescript: 2.4.0(typescript@6.0.2)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -14569,7 +14569,7 @@ snapshots:
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -14926,10 +14926,10 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)':
+  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)':
     optionalDependencies:
-      prisma: 6.19.2(magicast@0.3.5)(typescript@6.0.2)
-      typescript: 6.0.2
+      prisma: 6.19.2(magicast@0.3.5)(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@prisma/config@6.19.2(magicast@0.3.5)':
     dependencies:
@@ -16164,12 +16164,12 @@ snapshots:
       react-dom: link:vendor/react-dom@19.x
       storybook: 9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@storybook/react-vite@9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/react-vite@9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.58.0)
       '@storybook/builder-vite': 9.0.0-beta.3(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/react': 9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)
+      '@storybook/react': 9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 19.1.0
@@ -16184,12 +16184,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react-vite@9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/react-vite@9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(rollup@4.58.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@6.0.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.58.0)
       '@storybook/builder-vite': 9.0.0-beta.3(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/react': 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)
+      '@storybook/react': 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: link:vendor/react@19.x
@@ -16204,7 +16204,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)':
+  '@storybook/react@9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 9.0.0-beta.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))
@@ -16212,9 +16212,9 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  '@storybook/react@9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.2)':
+  '@storybook/react@9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 9.0.0-beta.3(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(storybook@9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)))
@@ -16222,14 +16222,14 @@ snapshots:
       react-dom: link:vendor/react-dom@19.x
       storybook: 9.1.19(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   '@swc-node/core@1.14.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)':
     dependencies:
       '@swc/core': 1.15.11(@swc/helpers@0.5.18)
       '@swc/types': 0.1.25
 
-  '@swc-node/register@1.11.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.2)':
+  '@swc-node/register@1.11.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3)':
     dependencies:
       '@swc-node/core': 1.14.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(@swc/types@0.1.25)
       '@swc-node/sourcemap-support': 0.6.1
@@ -16239,7 +16239,7 @@ snapshots:
       oxc-resolver: 11.17.1
       pirates: 4.0.7
       tslib: 2.8.1
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@swc/types'
       - supports-color
@@ -16826,40 +16826,40 @@ snapshots:
       '@types/node': 22.19.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/type-utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.58.2
       eslint: 9.23.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.23.0(jiti@2.6.1)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.2(typescript@6.0.2)':
+  '@typescript-eslint/project-service@8.58.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.58.2
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16873,19 +16873,19 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
 
-  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@6.0.2)':
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@6.0.3)':
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.23.0(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16893,29 +16893,29 @@ snapshots:
 
   '@typescript-eslint/types@8.58.2': {}
 
-  '@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.2)':
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.2(typescript@6.0.2)
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/project-service': 8.58.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.2
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.23.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.3)
       eslint: 9.23.0(jiti@2.6.1)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17081,12 +17081,12 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@volar/kit@2.4.28(typescript@6.0.2)':
+  '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: 6.0.2
+      typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -17493,12 +17493,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-expressive-code@0.41.6(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)):
+  astro-expressive-code@0.41.6(astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)):
     dependencies:
-      astro: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2)
+      astro: 5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       rehype-expressive-code: 0.41.6
 
-  astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.2):
+  astro@5.17.3(@types/node@22.19.11)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.58.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.5
@@ -17549,7 +17549,7 @@ snapshots:
       svgo: 4.0.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@6.0.2)
+      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -17562,7 +17562,7 @@ snapshots:
       yocto-spinner: 0.2.3
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@6.0.2)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@6.0.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -18775,11 +18775,11 @@ snapshots:
       esquery: 1.7.0
       jsonc-eslint-parser: 2.4.2
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.23.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -18799,7 +18799,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.23.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint@9.23.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18810,7 +18810,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.23.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@9.23.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18822,7 +18822,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -18878,9 +18878,9 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-perfectionist@5.8.0(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2):
+  eslint-plugin-perfectionist@5.9.0(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.23.0(jiti@2.6.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -20361,7 +20361,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@5.84.1(@types/node@22.19.11)(typescript@6.0.2):
+  knip@5.84.1(@types/node@22.19.11)(typescript@6.0.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 22.19.11
@@ -20375,7 +20375,7 @@ snapshots:
       picomatch: 4.0.3
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
-      typescript: 6.0.2
+      typescript: 6.0.3
       zod: 4.3.6
 
   known-css-properties@0.35.0: {}
@@ -21863,21 +21863,21 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  prisma-json-types-generator@3.6.2(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2))(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2):
+  prisma-json-types-generator@3.6.2(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2))(typescript@6.0.2)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)
       '@prisma/generator-helper': 6.19.2
-      prisma: 6.19.2(magicast@0.3.5)(typescript@6.0.2)
+      prisma: 6.19.2(magicast@0.3.5)(typescript@6.0.3)
       semver: 7.7.4
       tslib: 2.8.1
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  prisma@6.19.2(magicast@0.3.5)(typescript@6.0.2):
+  prisma@6.19.2(magicast@0.3.5)(typescript@6.0.3):
     dependencies:
       '@prisma/config': 6.19.2(magicast@0.3.5)
       '@prisma/engines': 6.19.2
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - magicast
 
@@ -21986,9 +21986,9 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-docgen-typescript@2.4.0(typescript@6.0.2):
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   react-docgen@7.1.1:
     dependencies:
@@ -23300,9 +23300,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.2):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   ts-dedent@2.2.0: {}
 
@@ -23315,9 +23315,9 @@ snapshots:
 
   ts-pattern@5.9.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.2):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -23445,17 +23445,17 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@6.0.2)):
+  typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@6.0.3)):
     dependencies:
-      typedoc: 0.27.9(typescript@6.0.2)
+      typedoc: 0.27.9(typescript@6.0.3)
 
-  typedoc@0.27.9(typescript@6.0.2):
+  typedoc@0.27.9(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 1.27.2
       lunr: 2.3.9
       markdown-it: 14.1.1
       minimatch: 9.0.5
-      typescript: 6.0.2
+      typescript: 6.0.3
       yaml: 2.8.2
 
   typesafe-path@0.2.2: {}
@@ -23464,18 +23464,18 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  typescript-eslint@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2):
+  typescript-eslint@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3))(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.23.0(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.23.0(jiti@2.6.1)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -24246,9 +24246,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-ts@1.2.0(typescript@6.0.2)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@6.0.3)(zod@3.25.76):
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
       zod: 3.25.76
 
   zod-validation-error@3.5.4(zod@vendor+zod@3.x):


### PR DESCRIPTION
Closes issue #1326 #1327 #1313  and works on #1312 through the user end

Enhances the user preferences page by providing a user info form.

User can now change password, DOB, and name.
Added email and phone number as possible additions to the users info.

Adjustments to user prisma schema and added useFindUserQuery hook. 
Adjusted standard user credentials in the auth model to be able to read their info only. 

Creation of code assisted by antigravity model: gemini 3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can view and edit their profile (personal info, email, phone, password with confirmation)
  * Client-side data fetching and mutation for self-update with success notifications
  * Added validation for email, phone, and password strength

* **Tests**
  * Added tests for user self-edit permissions and access controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->