### PR TITLE
Improve filter performance

### DIFF
--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -29,7 +29,8 @@ describe('SubjectsService', () => {
           useValue: {
             $transaction: vi.fn(),
             instrumentRecord: {
-              deleteMany: vi.fn()
+              deleteMany: vi.fn(),
+              findMany: vi.fn()
             },
             session: {
               deleteMany: vi.fn()
@@ -79,13 +80,14 @@ describe('SubjectsService', () => {
       await expect(subjectsService.find()).resolves.toMatchObject([{ id: '123' }]);
     });
     it('should return the array of subjects with records', async () => {
+      prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }]);
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await expect(subjectsService.find({ hasRecord: true })).resolves.toMatchObject([{ id: '123' }]);
       expect(subjectModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: {
-            AND: expect.arrayContaining([expect.objectContaining({ instrumentRecords: { some: {} } })])
-          }
+          where: expect.objectContaining({
+            id: { in: ['123'] }
+          })
         })
       );
     });

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -93,7 +93,7 @@ describe('SubjectsService', () => {
       expect(subjectModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            id: { in: ['123'] }
+            AND: [{}, {}, { id: { in: ['123'] } }]
           })
         })
       );
@@ -115,7 +115,7 @@ describe('SubjectsService', () => {
       expect(subjectModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            id: { in: ['123', '456'] }
+            AND: [{}, {}, { id: { in: ['123', '456'] } }]
           })
         })
       );

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -83,10 +83,39 @@ describe('SubjectsService', () => {
       prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }]);
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await expect(subjectsService.find({ hasRecord: true })).resolves.toMatchObject([{ id: '123' }]);
+      expect(prismaClient.instrumentRecord.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distinct: ['subjectId'],
+          select: { subjectId: true },
+          where: {}
+        })
+      );
       expect(subjectModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             id: { in: ['123'] }
+          })
+        })
+      );
+    });
+    it('should filter instrument records by groupId when provided', async () => {
+      prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }]);
+      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
+      await subjectsService.find({ groupId: 'group-1', hasRecord: true });
+      expect(prismaClient.instrumentRecord.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { groupId: 'group-1' }
+        })
+      );
+    });
+    it('should pass all subject IDs returned by instrument records to the subject query', async () => {
+      prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }, { subjectId: '456' }]);
+      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }, { id: '456' }]);
+      await subjectsService.find({ hasRecord: true });
+      expect(subjectModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: { in: ['123', '456'] }
           })
         })
       );

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -158,9 +158,10 @@ export class SubjectsService {
 
   private async querySubjectIdsWithRecords(groupId?: string): Promise<string[]> {
     const records = await this.prismaClient.instrumentRecord.findMany({
+      distinct: ['subjectId'],
       select: { subjectId: true },
       where: groupId ? { groupId } : {}
     });
-    return [...new Set(records.map((r) => r.subjectId))];
+    return records.map((r) => r.subjectId);
   }
 }

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -133,8 +133,11 @@ export class SubjectsService {
     if (hasRecord) {
       return this.subjectModel.findMany({
         where: {
-          AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput],
-          id: { in: await this.querySubjectIdsWithRecords(groupId) }
+          AND: [
+            accessibleQuery(ability, 'read', 'Subject'),
+            groupInput,
+            { id: { in: await this.querySubjectIdsWithRecords(groupId) } }
+          ]
         }
       });
     }

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -131,11 +131,10 @@ export class SubjectsService {
   ) {
     const groupInput = groupId ? { groupIds: { has: groupId } } : {};
     if (hasRecord) {
-      const subjectIds = await this.querySubjectIdsWithRecords(groupId);
       return this.subjectModel.findMany({
         where: {
           AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput],
-          id: { in: subjectIds }
+          id: { in: await this.querySubjectIdsWithRecords(groupId) }
         }
       });
     }

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -134,7 +134,7 @@ export class SubjectsService {
       const subjectIds = await this.querySubjectIdsWithRecords(groupId);
       return this.subjectModel.findMany({
         where: {
-          AND: [accessibleQuery(ability, 'read', 'Subject')],
+          AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput],
           id: { in: subjectIds }
         }
       });

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -130,10 +130,18 @@ export class SubjectsService {
     { ability }: EntityOperationOptions = {}
   ) {
     const groupInput = groupId ? { groupIds: { has: groupId } } : {};
-    const hasRecordInput = hasRecord ? { instrumentRecords: { some: {} } } : {};
-    return await this.subjectModel.findMany({
+    if (hasRecord) {
+      const subjectIds = await this.querySubjectIdsWithRecords(groupId);
+      return this.subjectModel.findMany({
+        where: {
+          AND: [accessibleQuery(ability, 'read', 'Subject')],
+          id: { in: subjectIds }
+        }
+      });
+    }
+    return this.subjectModel.findMany({
       where: {
-        AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput, hasRecordInput]
+        AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput]
       }
     });
   }
@@ -146,5 +154,13 @@ export class SubjectsService {
       throw new NotFoundException(`Failed to find subject with id: ${id}`);
     }
     return subject;
+  }
+
+  private async querySubjectIdsWithRecords(groupId?: string): Promise<string[]> {
+    const records = await this.prismaClient.instrumentRecord.findMany({
+      select: { subjectId: true },
+      where: groupId ? { groupId } : {}
+    });
+    return [...new Set(records.map((r) => r.subjectId))];
   }
 }

--- a/apps/web/src/services/axios.ts
+++ b/apps/web/src/services/axios.ts
@@ -16,7 +16,8 @@ axios.interceptors.request.use((config) => {
   if (
     config.url !== '/v1/setup' &&
     config.url !== '/v1/instrument-records/upload' &&
-    config.url !== '/v1/instrument-records/export'
+    config.url !== '/v1/instrument-records/export' &&
+    config.url !== '/v1/subjects'
   ) {
     config.timeout = 10000; // abort request after 10 seconds
     config.timeoutErrorMessage = i18n.t({

--- a/apps/web/src/services/axios.ts
+++ b/apps/web/src/services/axios.ts
@@ -16,8 +16,7 @@ axios.interceptors.request.use((config) => {
   if (
     config.url !== '/v1/setup' &&
     config.url !== '/v1/instrument-records/upload' &&
-    config.url !== '/v1/instrument-records/export' &&
-    config.url !== '/v1/subjects'
+    config.url !== '/v1/instrument-records/export'
   ) {
     config.timeout = 10000; // abort request after 10 seconds
     config.timeoutErrorMessage = i18n.t({


### PR DESCRIPTION
Closes issue #1346 

in subject service look through unique subject ids in records instead of vastly improve speed of the query.

querySubjectIdsWithRecords function assisted with claude opus 4.6

6s -> 150 ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for subject filtering with group and record constraints.

* **Refactor**
  * Optimized subject query filtering logic for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->