### PR TITLE
Raw query for hasRecord find method

### DIFF
--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -74,20 +74,42 @@ describe('SubjectsService', () => {
   });
 
   describe('find', () => {
-    it('should return the array returned by the subject model', async () => {
+    it('should use findMany when hasRecord is not set', async () => {
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await expect(subjectsService.find()).resolves.toMatchObject([{ id: '123' }]);
+      expect(subjectModel.findMany).toHaveBeenCalledOnce();
+      expect(subjectModel.aggregateRaw).not.toHaveBeenCalled();
     });
-    it('should return the array of subjects with records', async () => {
-      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
-      await expect(subjectsService.find({ hasRecord: true })).resolves.toMatchObject([{ id: '123' }]);
-      expect(subjectModel.findMany).toHaveBeenCalledWith(
+    it('should use aggregateRaw when hasRecord is true', async () => {
+      subjectModel.aggregateRaw.mockResolvedValueOnce([{ groupIds: [], id: '123' }]);
+      await expect(subjectsService.find({ hasRecord: true })).resolves.toMatchObject([{ groupIds: [], id: '123' }]);
+      expect(subjectModel.aggregateRaw).toHaveBeenCalledOnce();
+      expect(subjectModel.findMany).not.toHaveBeenCalled();
+    });
+    it('should pass groupId to the $match stage when provided', async () => {
+      subjectModel.aggregateRaw.mockResolvedValueOnce([]);
+      await subjectsService.find({ groupId: 'group-1', hasRecord: true });
+      expect(subjectModel.aggregateRaw).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: {
-            AND: expect.arrayContaining([expect.objectContaining({ instrumentRecords: { some: {} } })])
-          }
+          pipeline: expect.arrayContaining([
+            expect.objectContaining({
+              $match: expect.objectContaining({ groupIds: 'group-1' })
+            })
+          ])
         })
       );
+    });
+    it('should convert groupIds ObjectId objects to strings', async () => {
+      subjectModel.aggregateRaw.mockResolvedValueOnce([
+        { groupIds: [{ $oid: 'abc123' }, { $oid: 'def456' }], id: '123' }
+      ]);
+      const result = await subjectsService.find({ hasRecord: true });
+      expect(result[0]).toMatchObject({ groupIds: ['abc123', 'def456'] });
+    });
+    it('should default groupIds to an empty array when absent', async () => {
+      subjectModel.aggregateRaw.mockResolvedValueOnce([{ id: '123' }]);
+      const result = await subjectsService.find({ hasRecord: true });
+      expect(result[0]).toMatchObject({ groupIds: [] });
     });
   });
 

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -130,12 +130,63 @@ export class SubjectsService {
     { ability }: EntityOperationOptions = {}
   ) {
     const groupInput = groupId ? { groupIds: { has: groupId } } : {};
-    const hasRecordInput = hasRecord ? { instrumentRecords: { some: {} } } : {};
-    return await this.subjectModel.findMany({
-      where: {
-        AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput, hasRecordInput]
+    if (!hasRecord) {
+      return this.subjectModel.findMany({
+        where: {
+          AND: [accessibleQuery(ability, 'read', 'Subject'), groupInput]
+        }
+      });
+    }
+
+    const pipeline: object[] = [
+      {
+        $lookup: {
+          as: '_instrumentRecords',
+          foreignField: 'subjectId',
+          from: 'InstrumentRecordModel',
+          localField: '_id',
+          pipeline: [{ $limit: 1 }]
+        }
+      },
+      {
+        $match: {
+          ...(groupId ? { groupIds: groupId } : {}),
+          _instrumentRecords: { $ne: [] }
+        }
+      },
+      {
+        $addFields: {
+          createdAt: { $toLong: '$createdAt' },
+          dateOfBirth: { $toLong: '$dateOfBirth' },
+          id: { $toString: '$_id' },
+          updatedAt: { $toLong: '$updatedAt' }
+        }
+      },
+      {
+        $project: {
+          _id: 0,
+          _instrumentRecords: 0
+        }
       }
-    });
+    ];
+
+    type RawSubject = { [key: string]: unknown; groupIds?: unknown[] };
+    const subjects = (await this.subjectModel.aggregateRaw({ pipeline })) as unknown as RawSubject[];
+    return subjects
+      .filter(
+        (subject) =>
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          !ability || ability.can('read', subject as any)
+      )
+      .map((subject) => ({
+        ...subject,
+        groupIds: Array.isArray(subject.groupIds)
+          ? subject.groupIds.map((gid) => {
+              const g = gid as null | { $oid?: string };
+              return g?.$oid ?? String(gid);
+            })
+          : []
+      }));
   }
 
   async findById(id: string, { ability }: EntityOperationOptions = {}) {


### PR DESCRIPTION
raw query implementation of the hasRecord filter code.

Filters through subjects to find ones with at least 1 record. uses prismas aggregateRaw method with a raw mongoDB query

Method implemented with claude 4.6

**This is simply a draft pr for performance testing purposes if pr #1347 consistently provides better performance this pr will be deleted*

related to issue #1346 