### PR TITLE
Attach username to upload dropdown

### DIFF
--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -2,7 +2,7 @@ import type { Model } from '@douglasneuroinformatics/libnest';
 import { getModelToken } from '@douglasneuroinformatics/libnest';
 import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
 import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -117,6 +117,32 @@ describe('InstrumentRecordsService', () => {
 
       expect(usersService.findByUsername).toHaveBeenCalledWith('validuser', undefined);
       expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'validuser' }));
+    });
+
+    it('should throw a ForbiddenException when a non-admin user uploads without a group', async () => {
+      usersService.findByUsername.mockResolvedValueOnce({
+        basePermissionLevel: 'STANDARD',
+        username: 'validuser'
+      } as any);
+
+      await expect(
+        instrumentRecordsService.upload({ ...baseUploadData, username: 'validuser' })
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(sessionsService.create).not.toHaveBeenCalled();
+    });
+
+    it('should throw a ForbiddenException when a user uploads to a group they are not a member of', async () => {
+      usersService.findByUsername.mockResolvedValueOnce({
+        groups: [{ id: 'other-group' }],
+        username: 'validuser'
+      } as any);
+
+      await expect(
+        instrumentRecordsService.upload({ ...baseUploadData, groupId: 'group-1', username: 'validuser' })
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(sessionsService.create).not.toHaveBeenCalled();
     });
 
     it('should reject and not create any sessions when an unknown username is provided', async () => {

--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -6,6 +6,8 @@ import { NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { UsersService } from '@/users/users.service';
+
 import { GroupsService } from '../../groups/groups.service';
 import { InstrumentsService } from '../../instruments/instruments.service';
 import { SessionsService } from '../../sessions/sessions.service';
@@ -26,6 +28,7 @@ describe('InstrumentRecordsService', () => {
         InstrumentRecordsService,
         MockFactory.createForModelToken(getModelToken('InstrumentRecord')),
         MockFactory.createForService(GroupsService),
+        MockFactory.createForService(UsersService),
         MockFactory.createForService(InstrumentMeasuresService),
         MockFactory.createForService(InstrumentsService),
         MockFactory.createForService(SessionsService),

--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -111,9 +111,9 @@ describe('InstrumentRecordsService', () => {
     });
 
     it('should call sessionsService.create with the provided username', async () => {
-      usersService.findByUsername.mockResolvedValueOnce({ username: 'validuser' } as any);
+      usersService.findByUsername.mockResolvedValueOnce({ groups: [{ id: 'group-1' }], username: 'validuser' } as any);
 
-      await instrumentRecordsService.upload({ ...baseUploadData, username: 'validuser' });
+      await instrumentRecordsService.upload({ ...baseUploadData, groupId: 'group-1', username: 'validuser' });
 
       expect(usersService.findByUsername).toHaveBeenCalledWith('validuser', undefined);
       expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'validuser' }));

--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -21,6 +21,9 @@ describe('InstrumentRecordsService', () => {
   let instrumentRecordsService: InstrumentRecordsService;
   let instrumentRecordModel: MockedInstance<Model<'InstrumentRecord'>>;
   let instrumentsService: MockedInstance<InstrumentsService>;
+  let sessionsService: MockedInstance<SessionsService>;
+  let subjectsService: MockedInstance<SubjectsService>;
+  let usersService: MockedInstance<UsersService>;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -39,6 +42,9 @@ describe('InstrumentRecordsService', () => {
     instrumentRecordModel = moduleRef.get(getModelToken('InstrumentRecord'));
     instrumentRecordsService = moduleRef.get(InstrumentRecordsService);
     instrumentsService = moduleRef.get(InstrumentsService);
+    sessionsService = moduleRef.get(SessionsService);
+    subjectsService = moduleRef.get(SubjectsService);
+    usersService = moduleRef.get(UsersService);
   });
 
   describe('findById', () => {
@@ -69,6 +75,67 @@ describe('InstrumentRecordsService', () => {
         subjectId: 'test-subject-id'
       });
       expect(result.date).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('upload', () => {
+    const mockInstrument = {
+      id: 'instrument-1',
+      kind: 'FORM',
+      measures: null,
+      validationSchema: {
+        safeParse: (data: unknown) => ({ data, success: true })
+      }
+    };
+
+    const mockSession = {
+      date: new Date(),
+      groupId: null,
+      id: 'session-1',
+      type: 'RETROSPECTIVE',
+      userId: null
+    };
+
+    const baseUploadData = {
+      instrumentId: 'instrument-1',
+      records: [{ data: { answer: 1 }, date: new Date(), subjectId: 'subject-1' }]
+    };
+
+    beforeEach(() => {
+      instrumentsService.findById.mockResolvedValue(mockInstrument as any);
+      subjectsService.createMany.mockResolvedValue([] as any);
+      sessionsService.create.mockResolvedValue(mockSession as any);
+      sessionsService.deleteByIds.mockResolvedValue(undefined as any);
+      instrumentRecordModel.createMany.mockResolvedValue([] as any);
+      instrumentRecordModel.findMany.mockResolvedValue([] as any);
+    });
+
+    it('should call sessionsService.create with the provided username', async () => {
+      usersService.findByUsername.mockResolvedValueOnce({ username: 'validuser' } as any);
+
+      await instrumentRecordsService.upload({ ...baseUploadData, username: 'validuser' });
+
+      expect(usersService.findByUsername).toHaveBeenCalledWith('validuser', undefined);
+      expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'validuser' }));
+    });
+
+    it('should reject and not create any sessions when an unknown username is provided', async () => {
+      usersService.findByUsername.mockRejectedValueOnce(
+        new NotFoundException('Failed to find user with username: spoofed')
+      );
+
+      await expect(instrumentRecordsService.upload({ ...baseUploadData, username: 'spoofed' })).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+
+      expect(sessionsService.create).not.toHaveBeenCalled();
+    });
+
+    it('should call sessionsService.create with username undefined when no username is provided', async () => {
+      await instrumentRecordsService.upload({ ...baseUploadData });
+
+      expect(usersService.findByUsername).not.toHaveBeenCalled();
+      expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: undefined }));
     });
   });
 

--- a/apps/api/src/instrument-records/instrument-records.module.ts
+++ b/apps/api/src/instrument-records/instrument-records.module.ts
@@ -4,6 +4,7 @@ import { GroupsModule } from '@/groups/groups.module';
 import { InstrumentsModule } from '@/instruments/instruments.module';
 import { SessionsModule } from '@/sessions/sessions.module';
 import { SubjectsModule } from '@/subjects/subjects.module';
+import { UsersModule } from '@/users/users.module';
 
 import { InstrumentMeasuresService } from './instrument-measures.service';
 import { InstrumentRecordsController } from './instrument-records.controller';
@@ -12,7 +13,7 @@ import { InstrumentRecordsService } from './instrument-records.service';
 @Module({
   controllers: [InstrumentRecordsController],
   exports: [InstrumentRecordsService],
-  imports: [GroupsModule, InstrumentsModule, SessionsModule, SubjectsModule],
+  imports: [GroupsModule, InstrumentsModule, SessionsModule, SubjectsModule, UsersModule],
   providers: [InstrumentMeasuresService, InstrumentRecordsService]
 })
 export class InstrumentRecordsModule {}

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -347,7 +347,12 @@ export class InstrumentRecordsService {
     }
 
     if (username) {
-      await this.usersService.findByUsername(username, options);
+      const user = await this.usersService.findByUsername(username, options);
+      if (groupId && !user.groups.some((g) => g.id === groupId)) {
+        throw new ForbiddenException(
+          `User '${username}' is not a member of group '${groupId}'`
+        );
+      }
     }
 
     const createdSessionsArray: Session[] = [];

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -357,6 +357,9 @@ export class InstrumentRecordsService {
       if (groupId && !user.groups.some((g) => g.id === groupId)) {
         throw new ForbiddenException(`User '${username}' is not a member of group '${groupId}'`);
       }
+      if (!groupId && user.basePermissionLevel !== 'ADMIN') {
+        throw new ForbiddenException(`The Non-Admin User '${username}' must be part of a group`);
+      }
     }
 
     const createdSessionsArray: Session[] = [];

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -330,7 +330,7 @@ export class InstrumentRecordsService {
   }
 
   async upload(
-    { groupId, instrumentId, records }: UploadInstrumentRecordsData,
+    { groupId, instrumentId, records, username }: UploadInstrumentRecordsData,
     options?: EntityOperationOptions
   ): Promise<InstrumentRecord[]> {
     if (groupId) {
@@ -372,7 +372,8 @@ export class InstrumentRecordsService {
             date: date,
             groupId: groupId ?? null,
             subjectData: { id: subjectId },
-            type: 'RETROSPECTIVE'
+            type: 'RETROSPECTIVE',
+            username: username ?? undefined
           });
 
           createdSessionsArray.push(session);

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -6,7 +6,13 @@ import { replacer, reviver } from '@douglasneuroinformatics/libjs';
 import { InjectModel } from '@douglasneuroinformatics/libnest';
 import type { Model } from '@douglasneuroinformatics/libnest';
 import { linearRegression } from '@douglasneuroinformatics/libstats';
-import { BadRequestException, Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException
+} from '@nestjs/common';
 import type { Json, ScalarInstrument } from '@opendatacapture/runtime-core';
 import type {
   CreateInstrumentRecordData,
@@ -349,9 +355,7 @@ export class InstrumentRecordsService {
     if (username) {
       const user = await this.usersService.findByUsername(username, options);
       if (groupId && !user.groups.some((g) => g.id === groupId)) {
-        throw new ForbiddenException(
-          `User '${username}' is not a member of group '${groupId}'`
-        );
+        throw new ForbiddenException(`User '${username}' is not a member of group '${groupId}'`);
       }
     }
 

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -28,6 +28,7 @@ import { InstrumentsService } from '@/instruments/instruments.service';
 import { SessionsService } from '@/sessions/sessions.service';
 import { CreateSubjectDto } from '@/subjects/dto/create-subject.dto';
 import { SubjectsService } from '@/subjects/subjects.service';
+import { UsersService } from '@/users/users.service';
 
 import { InstrumentMeasuresService } from './instrument-measures.service';
 
@@ -45,6 +46,7 @@ export class InstrumentRecordsService {
   constructor(
     @InjectModel('InstrumentRecord') private readonly instrumentRecordModel: Model<'InstrumentRecord'>,
     private readonly groupsService: GroupsService,
+    private readonly usersService: UsersService,
     private readonly instrumentMeasuresService: InstrumentMeasuresService,
     private readonly instrumentsService: InstrumentsService,
     private readonly sessionsService: SessionsService,
@@ -342,6 +344,10 @@ export class InstrumentRecordsService {
       throw new UnprocessableEntityException(
         `Cannot create instrument record for series instrument '${instrument.id}'`
       );
+    }
+
+    if (username) {
+      await this.usersService.findByUsername(username, options);
     }
 
     const createdSessionsArray: Session[] = [];

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -177,7 +177,7 @@ export class UsersService {
       data: {
         ...data,
         groups: {
-          connect: groupIds?.map((id) => ({ id }))
+          set: groupIds?.map((id) => ({ id }))
         },
         hashedPassword
       },

--- a/apps/web/src/hooks/useUsersQuery.ts
+++ b/apps/web/src/hooks/useUsersQuery.ts
@@ -14,7 +14,7 @@ export const usersQueryOptions = ({ params }: { params?: UsersQueryParams } = {}
       const response = await axios.get('/v1/users', { params });
       return $User.array().parse(response.data);
     },
-    queryKey: [USERS_QUERY_KEY]
+    queryKey: [USERS_QUERY_KEY, params?.groupId]
   });
 };
 

--- a/apps/web/src/hooks/useUsersQuery.ts
+++ b/apps/web/src/hooks/useUsersQuery.ts
@@ -2,18 +2,22 @@ import { $User } from '@opendatacapture/schemas/user';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
+type UsersQueryParams = {
+  groupId?: string;
+};
+
 export const USERS_QUERY_KEY = 'users';
 
-export const usersQueryOptions = () => {
+export const usersQueryOptions = ({ params }: { params?: UsersQueryParams } = {}) => {
   return queryOptions({
     queryFn: async () => {
-      const response = await axios.get('/v1/users');
+      const response = await axios.get('/v1/users', { params });
       return $User.array().parse(response.data);
     },
     queryKey: [USERS_QUERY_KEY]
   });
 };
 
-export function useUsersQuery() {
-  return useSuspenseQuery(usersQueryOptions());
+export function useUsersQuery({ params }: { params?: UsersQueryParams } = {}) {
+  return useSuspenseQuery(usersQueryOptions({ params }));
 }

--- a/apps/web/src/routes/_app/admin/users/index.tsx
+++ b/apps/web/src/routes/_app/admin/users/index.tsx
@@ -37,6 +37,7 @@ type UpdateUserFormInputData = {
     [id: string]: string;
   };
   initialValues?: FormTypes.PartialNullableData<UpdateUserFormData>;
+  selectedUserBasePermission?: User['basePermissionLevel'];
 };
 
 const UpdateUserForm: React.FC<{
@@ -90,6 +91,19 @@ const UpdateUserForm: React.FC<{
             }
           });
         });
+      })
+      .check((ctx) => {
+        if (ctx.value.groupIds.size <= 0 && data.selectedUserBasePermission !== 'ADMIN') {
+          ctx.issues.push({
+            code: 'custom',
+            input: ctx.value.confirmPassword,
+            message: t({
+              en: 'Standard user must be part of a group',
+              fr: "Un utilisateur standard doit faire partie d'un groupe"
+            }),
+            path: ['groupIds']
+          });
+        }
       })
       .check((ctx) => {
         if (ctx.value.confirmPassword !== ctx.value.password) {
@@ -335,6 +349,7 @@ const RouteComponent = () => {
       setData({
         disableDelete: selectedUser?.username === currentUser?.username,
         groupOptions: Object.fromEntries(groups.map((group) => [group.id, group.name])),
+        selectedUserBasePermission: selectedUser.basePermissionLevel,
         initialValues: selectedUser?.additionalPermissions.length
           ? {
               additionalPermissions: selectedUser.additionalPermissions,

--- a/apps/web/src/routes/_app/dashboard.tsx
+++ b/apps/web/src/routes/_app/dashboard.tsx
@@ -28,7 +28,11 @@ const RouteComponent = () => {
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
   const [isRecordModalOpen, setIsRecordModalOpen] = useState(false);
   const instrumentInfoQuery = useInstrumentInfoQuery();
-  const userInfoQuery = useUsersQuery();
+  const userInfoQuery = useUsersQuery({
+    params: {
+      groupId: currentGroup?.id
+    }
+  });
 
   const recordsQuery = useInstrumentRecords({
     enabled: true,

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { serializeError } from '@douglasneuroinformatics/libjs';
-import { Button, FileDropzone, Heading, Spinner } from '@douglasneuroinformatics/libui/components';
+import { Button, Checkbox, FileDropzone, Heading, Spinner } from '@douglasneuroinformatics/libui/components';
 import { useDownload, useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { AnyUnilingualFormInstrument } from '@opendatacapture/runtime-core';
 import { createFileRoute } from '@tanstack/react-router';
@@ -17,6 +17,7 @@ import { createUploadTemplateCSV, processInstrumentCSV, reformatInstrumentData, 
 const RouteComponent = () => {
   const [file, setFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isUploaderChecked, setIsUploaderChecked] = useState(false);
   const download = useDownload();
   const addNotification = useNotificationsStore((store) => store.addNotification);
   const currentGroup = useAppStore((store) => store.currentGroup);
@@ -57,7 +58,7 @@ const RouteComponent = () => {
       const processedDataResult = await processInstrumentCSV(file!, instrument!);
       const reformattedData = reformatInstrumentData({
         currentGroup,
-        currentUsername: currentUser?.username,
+        currentUsername: isUploaderChecked ? currentUser?.username : undefined,
         data: processedDataResult,
         instrument: instrument!
       });
@@ -153,9 +154,26 @@ const RouteComponent = () => {
             setFile={setFile}
           />
           <div className="mt-4 flex justify-between space-x-2">
-            <Button disabled={!(file && instrument)} variant={'primary'} onClick={() => void handleInstrumentCSV()}>
-              {t('core.submit')}
-            </Button>
+            <div className="flex items-center gap-3">
+              <Button disabled={!(file && instrument)} variant={'primary'} onClick={() => void handleInstrumentCSV()}>
+                {t('core.submit')}
+              </Button>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  defaultChecked={false}
+                  id="attach-uploader"
+                  onCheckedChange={() => {
+                    setIsUploaderChecked(!isUploaderChecked);
+                  }}
+                />
+                <label className="text-sm" htmlFor="attach-uploader">
+                  {t({
+                    en: 'Attach Uploader Username',
+                    fr: 'Attacher le nom utilisateur'
+                  })}
+                </label>
+              </div>
+            </div>
             <div className="flex justify-between space-x-1">
               <Button className="gap-1" disabled={!instrument} variant={'primary'} onClick={handleTemplateDownload}>
                 <DownloadIcon />

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -144,73 +144,71 @@ const RouteComponent = () => {
         </Heading>
       </PageHeader>
       {!isLoading ? (
-        <div className="mx-auto flex w-full max-w-3xl grow flex-col justify-center">
-          <FileDropzone
-            acceptedFileTypes={{
-              'text/csv': ['.csv']
-            }}
-            className="flex h-80 w-full flex-col"
-            file={file}
-            setFile={setFile}
-          />
-          <div className="mt-4 flex justify-between space-x-2">
-            <div className="flex items-center gap-3">
-              <Button disabled={!(file && instrument)} variant={'primary'} onClick={() => void handleInstrumentCSV()}>
-                {t('core.submit')}
-              </Button>
-              <div className="flex items-center gap-2">
+        <div className="mx-auto flex w-full max-w-3xl grow flex-col justify-center gap-6">
+          <div className="space-y-4">
+            <FileDropzone
+              acceptedFileTypes={{ 'text/csv': ['.csv'] }}
+              className="flex h-80 w-full flex-col"
+              file={file}
+              setFile={setFile}
+            />
+            <div className="bg-muted/30 border-muted rounded-lg border p-3 transition-colors">
+              <div className="flex items-start gap-3">
                 <Checkbox
-                  defaultChecked={false}
+                  checked={isUploaderChecked}
                   id="attach-uploader"
-                  onCheckedChange={() => {
-                    setIsUploaderChecked(!isUploaderChecked);
-                  }}
+                  onCheckedChange={(checked) => setIsUploaderChecked(!!checked)}
                 />
-                <label className="text-sm" htmlFor="attach-uploader">
-                  {t({
-                    en: 'Attach Uploader Username',
-                    fr: 'Attacher le nom utilisateur'
-                  })}
-                </label>
+                <div className="grid gap-1.5 leading-none">
+                  <label className="cursor-pointer text-sm font-semibold tracking-tight" htmlFor="attach-uploader">
+                    {t({
+                      en: 'Include uploader username',
+                      fr: "Inclure le nom d'utilisateur du téléverseur"
+                    })}
+                  </label>
+                  <p className="text-muted-foreground text-xs">
+                    {t({
+                      en: 'Your username will be associated with these records for audit and traceability.',
+                      fr: 'Votre nom d’utilisateur sera associé à ces entrées pour l’audit et la traçabilité.'
+                    })}
+                  </p>
+                </div>
               </div>
             </div>
-            <div className="flex justify-between space-x-1">
-              <Button className="gap-1" disabled={!instrument} variant={'primary'} onClick={handleTemplateDownload}>
-                <DownloadIcon />
-                {t({
-                  en: 'Download Template',
-                  fr: 'Télécharger le modèle'
-                })}
+          </div>
+
+          <div className="flex items-center justify-between border-t pt-4">
+            <Button disabled={!(file && instrument)} variant="primary" onClick={() => void handleInstrumentCSV()}>
+              {t('core.submit')}
+            </Button>
+
+            <div className="flex gap-2">
+              <Button className="gap-2" size="sm" variant="outline" onClick={handleTemplateDownload}>
+                <DownloadIcon size={16} />
+                {t({ en: 'Template', fr: 'Modèle' })}
               </Button>
               <Button
-                className="gap-1"
-                disabled={!instrument}
-                variant={'primary'}
-                onClick={() => {
-                  window.open('https://opendatacapture.org/en/docs/guides/how-to-upload-data/');
-                }}
+                className="gap-2"
+                size="sm"
+                variant="outline"
+                onClick={() => window.open('https://opendatacapture.org/en/docs/guides/how-to-upload-data/')}
               >
-                <BadgeHelpIcon />
-                {t({
-                  en: 'Help',
-                  fr: 'Aide'
-                })}
+                <BadgeHelpIcon size={16} />
+                {t({ en: 'Help', fr: 'Aide' })}
               </Button>
             </div>
           </div>
         </div>
       ) : (
-        <>
-          <div className="mx-auto flex w-full max-w-3xl grow flex-col justify-center">
-            <Spinner className="mx-auto size-1/2"></Spinner>
-            <Heading className="text-center" variant="h3">
-              {t({
-                en: 'Data currently uploading...',
-                fr: 'Données en cours de téléversement...'
-              })}
-            </Heading>
-          </div>
-        </>
+        <div className="mx-auto flex w-full max-w-3xl grow flex-col justify-center">
+          <Spinner className="mx-auto size-24" />
+          <Heading className="mt-4 text-center" variant="h3">
+            {t({
+              en: 'Data currently uploading...',
+              fr: 'Données en cours de téléversement...'
+            })}
+          </Heading>
+        </div>
       )}
     </React.Fragment>
   );

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -20,6 +20,7 @@ const RouteComponent = () => {
   const download = useDownload();
   const addNotification = useNotificationsStore((store) => store.addNotification);
   const currentGroup = useAppStore((store) => store.currentGroup);
+  const currentUser = useAppStore((store) => store.currentUser);
   const uploadInstrumentRecordsMutation = useUploadInstrumentRecordsMutation();
 
   const params = Route.useParams();
@@ -56,6 +57,7 @@ const RouteComponent = () => {
       const processedDataResult = await processInstrumentCSV(file!, instrument!);
       const reformattedData = reformatInstrumentData({
         currentGroup,
+        currentUsername: currentUser?.username,
         data: processedDataResult,
         instrument: instrument!
       });

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { serializeError } from '@douglasneuroinformatics/libjs';
-import { Button, Checkbox, FileDropzone, Heading, Spinner } from '@douglasneuroinformatics/libui/components';
+import { Button, FileDropzone, Heading, Spinner } from '@douglasneuroinformatics/libui/components';
 import { useDownload, useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { AnyUnilingualFormInstrument } from '@opendatacapture/runtime-core';
 import { createFileRoute } from '@tanstack/react-router';
@@ -17,7 +17,6 @@ import { createUploadTemplateCSV, processInstrumentCSV, reformatInstrumentData, 
 const RouteComponent = () => {
   const [file, setFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [isUploaderChecked, setIsUploaderChecked] = useState(false);
   const download = useDownload();
   const addNotification = useNotificationsStore((store) => store.addNotification);
   const currentGroup = useAppStore((store) => store.currentGroup);
@@ -58,7 +57,7 @@ const RouteComponent = () => {
       const processedDataResult = await processInstrumentCSV(file!, instrument!);
       const reformattedData = reformatInstrumentData({
         currentGroup,
-        currentUsername: isUploaderChecked ? currentUser?.username : undefined,
+        currentUsername: currentUser?.username ?? undefined,
         data: processedDataResult,
         instrument: instrument!
       });
@@ -144,7 +143,7 @@ const RouteComponent = () => {
         </Heading>
       </PageHeader>
       {!isLoading ? (
-        <div className="mx-auto flex w-full max-w-3xl grow flex-col justify-center gap-6">
+        <div className="mx-auto flex w-full max-w-3xl grow flex-col justify-center gap-2">
           <div className="space-y-4">
             <FileDropzone
               acceptedFileTypes={{ 'text/csv': ['.csv'] }}
@@ -152,32 +151,9 @@ const RouteComponent = () => {
               file={file}
               setFile={setFile}
             />
-            <div className="bg-muted/30 border-muted rounded-lg border p-3 transition-colors">
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  checked={isUploaderChecked}
-                  id="attach-uploader"
-                  onCheckedChange={(checked) => setIsUploaderChecked(!!checked)}
-                />
-                <div className="grid gap-1.5 leading-none">
-                  <label className="cursor-pointer text-sm font-semibold tracking-tight" htmlFor="attach-uploader">
-                    {t({
-                      en: 'Include uploader username',
-                      fr: "Inclure le nom d'utilisateur du téléverseur"
-                    })}
-                  </label>
-                  <p className="text-muted-foreground text-xs">
-                    {t({
-                      en: 'Your username will be associated with these records for audit and traceability.',
-                      fr: 'Votre nom d’utilisateur sera associé à ces entrées pour l’audit et la traçabilité.'
-                    })}
-                  </p>
-                </div>
-              </div>
-            </div>
           </div>
 
-          <div className="flex items-center justify-between border-t pt-4">
+          <div className="flex items-center justify-between pt-4">
             <Button disabled={!(file && instrument)} variant="primary" onClick={() => void handleInstrumentCSV()}>
               {t('core.submit')}
             </Button>

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -23,11 +23,12 @@ const RouteComponent = () => {
   const currentGroup = useAppStore((store) => store.currentGroup);
   const currentUser = useAppStore((store) => store.currentUser);
   const uploadInstrumentRecordsMutation = useUploadInstrumentRecordsMutation();
+  const [selectedGroupId, setSelectedGroupId] = useState<string | undefined>(currentGroup?.id);
   const [selectedUsername, setSelectedUsername] = useState<null | string | undefined>(undefined);
 
   const groupUsers = useUsersQuery({
     params: {
-      groupId: currentGroup?.id
+      groupId: selectedGroupId
     }
   });
 
@@ -161,30 +162,57 @@ const RouteComponent = () => {
             />
           </div>
           <div className="bg-muted/30 border-muted rounded-lg border p-4 transition-colors">
-            <div className="flex flex-col gap-2">
-              <p className="text-muted-foreground text-xs">
-                {t({
-                  en: 'Select the username to associate with these records for audit and traceability.',
-                  fr: 'Sélectionnez le nom d’utilisateur à associer à ces entrées pour l’audit et la traçabilité.'
-                })}
-              </p>
-              <Select value={selectedUsername ?? currentUser?.username} onValueChange={setSelectedUsername}>
-                <Select.Trigger>
-                  <Select.Value placeholder={currentUser?.username} />
-                </Select.Trigger>
-                <Select.Content>
-                  <Select.Group>
-                    {groupUsers.data.map((user) => (
-                      <Select.Item key={user.username} value={user.username}>
-                        {user.username}
-                      </Select.Item>
-                    ))}
-                    <Select.Item key={'N/A'} value={'N/A'}>
-                      {'N/A'}
-                    </Select.Item>
-                  </Select.Group>
-                </Select.Content>
-              </Select>
+            <div className="flex flex-row gap-4">
+              {(currentUser?.groups.length ?? 0) > 0 && (
+                <div className="flex flex-col gap-1">
+                  <p className="text-muted-foreground text-xs">
+                    {t({ en: 'Filter users by group.', fr: 'Filtrer les utilisateurs par groupe.' })}
+                  </p>
+                  <Select
+                    value={selectedGroupId}
+                    onValueChange={(id) => {
+                      setSelectedGroupId(id);
+                      setSelectedUsername(undefined);
+                    }}
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder={t({ en: 'Select group', fr: 'Sélectionner un groupe' })} />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Group>
+                        {currentUser?.groups.map((group) => (
+                          <Select.Item key={group.id} value={group.id}>
+                            {group.name}
+                          </Select.Item>
+                        ))}
+                      </Select.Group>
+                    </Select.Content>
+                  </Select>
+                </div>
+              )}
+              <div className="flex flex-1 flex-col gap-1">
+                <p className="text-muted-foreground text-xs">
+                  {t({
+                    en: 'Select the username to associate with these records for audit and traceability.',
+                    fr: "Sélectionnez le nom d'utilisateur à associer à ces entrées pour l'audit et la traçabilité."
+                  })}
+                </p>
+                <Select value={selectedUsername ?? currentUser?.username} onValueChange={setSelectedUsername}>
+                  <Select.Trigger>
+                    <Select.Value placeholder={currentUser?.username} />
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Group>
+                      {groupUsers.data.map((user) => (
+                        <Select.Item key={user.username} value={user.username}>
+                          {user.username}
+                        </Select.Item>
+                      ))}
+                      <Select.Item value="N/A">N/A</Select.Item>
+                    </Select.Group>
+                  </Select.Content>
+                </Select>
+              </div>
             </div>
           </div>
 

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -162,9 +162,9 @@ const RouteComponent = () => {
             />
           </div>
           <div className="bg-muted/30 border-muted rounded-lg border p-4 transition-colors">
-            <div className="flex flex-row gap-4">
+            <div className="flex flex-col gap-4 sm:flex-row">
               {(currentUser?.groups.length ?? 0) > 0 && (
-                <div className="flex flex-col gap-1">
+                <div className="flex w-full shrink-0 flex-col gap-1 sm:w-48">
                   <p className="text-muted-foreground text-xs">
                     {t({ en: 'Filter users by group.', fr: 'Filtrer les utilisateurs par groupe.' })}
                   </p>

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { serializeError } from '@douglasneuroinformatics/libjs';
-import { Button, FileDropzone, Heading, Spinner } from '@douglasneuroinformatics/libui/components';
+import { Button, FileDropzone, Heading, Select, Spinner } from '@douglasneuroinformatics/libui/components';
 import { useDownload, useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { AnyUnilingualFormInstrument } from '@opendatacapture/runtime-core';
 import { createFileRoute } from '@tanstack/react-router';
@@ -11,17 +11,25 @@ import z from 'zod/v4';
 import { PageHeader } from '@/components/PageHeader';
 import { useInstrument } from '@/hooks/useInstrument';
 import { useUploadInstrumentRecordsMutation } from '@/hooks/useUploadInstrumentRecordsMutation';
+import { useUsersQuery } from '@/hooks/useUsersQuery';
 import { useAppStore } from '@/store';
 import { createUploadTemplateCSV, processInstrumentCSV, reformatInstrumentData, UploadError } from '@/utils/upload';
 
 const RouteComponent = () => {
   const [file, setFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedUsername, setSelectedUsername] = useState<null | string | undefined>(undefined);
   const download = useDownload();
   const addNotification = useNotificationsStore((store) => store.addNotification);
   const currentGroup = useAppStore((store) => store.currentGroup);
   const currentUser = useAppStore((store) => store.currentUser);
   const uploadInstrumentRecordsMutation = useUploadInstrumentRecordsMutation();
+
+  const groupUsers = useUsersQuery({
+    params: {
+      groupId: currentGroup?.id
+    }
+  });
 
   const params = Route.useParams();
   const { error } = Route.useSearch();
@@ -57,7 +65,7 @@ const RouteComponent = () => {
       const processedDataResult = await processInstrumentCSV(file!, instrument!);
       const reformattedData = reformatInstrumentData({
         currentGroup,
-        currentUsername: currentUser?.username ?? undefined,
+        currentUsername: selectedUsername ?? currentUser?.username,
         data: processedDataResult,
         instrument: instrument!
       });
@@ -152,8 +160,35 @@ const RouteComponent = () => {
               setFile={setFile}
             />
           </div>
+          <div className="bg-muted/30 border-muted rounded-lg border p-4 transition-colors">
+            <div className="flex flex-col gap-2">
+              <p className="text-muted-foreground text-xs">
+                {t({
+                  en: 'Select the username to associate with these records for audit and traceability.',
+                  fr: 'Sélectionnez le nom d’utilisateur à associer à ces entrées pour l’audit et la traçabilité.'
+                })}
+              </p>
+              <Select value={selectedUsername ?? currentUser?.username} onValueChange={setSelectedUsername}>
+                <Select.Trigger>
+                  <Select.Value placeholder={currentUser?.username} />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Group>
+                    {groupUsers.data.map((user) => (
+                      <Select.Item key={user.username} value={user.username}>
+                        {user.username}
+                      </Select.Item>
+                    ))}
+                    <Select.Item key={'N/A'} value={'N/A'}>
+                      {'N/A'}
+                    </Select.Item>
+                  </Select.Group>
+                </Select.Content>
+              </Select>
+            </div>
+          </div>
 
-          <div className="flex items-center justify-between pt-4">
+          <div className="flex items-center justify-between pt-2">
             <Button disabled={!(file && instrument)} variant="primary" onClick={() => void handleInstrumentCSV()}>
               {t('core.submit')}
             </Button>

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -18,12 +18,12 @@ import { createUploadTemplateCSV, processInstrumentCSV, reformatInstrumentData, 
 const RouteComponent = () => {
   const [file, setFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedUsername, setSelectedUsername] = useState<null | string | undefined>(undefined);
   const download = useDownload();
   const addNotification = useNotificationsStore((store) => store.addNotification);
   const currentGroup = useAppStore((store) => store.currentGroup);
   const currentUser = useAppStore((store) => store.currentUser);
   const uploadInstrumentRecordsMutation = useUploadInstrumentRecordsMutation();
+  const [selectedUsername, setSelectedUsername] = useState<null | string | undefined>(undefined);
 
   const groupUsers = useUsersQuery({
     params: {
@@ -65,7 +65,7 @@ const RouteComponent = () => {
       const processedDataResult = await processInstrumentCSV(file!, instrument!);
       const reformattedData = reformatInstrumentData({
         currentGroup,
-        currentUsername: selectedUsername ?? currentUser?.username,
+        currentUsername: selectedUsername === 'N/A' ? undefined : (selectedUsername ?? currentUser?.username),
         data: processedDataResult,
         instrument: instrument!
       });

--- a/apps/web/src/utils/upload.ts
+++ b/apps/web/src/utils/upload.ts
@@ -1027,7 +1027,7 @@ export function reformatInstrumentData({
     groupId: currentGroup?.id,
     instrumentId: instrument.id,
     records: recordsList,
-    username: currentUsername ?? 'N/A'
+    username: currentUsername ?? undefined
   };
   return reformatForSending;
 }

--- a/apps/web/src/utils/upload.ts
+++ b/apps/web/src/utils/upload.ts
@@ -1002,10 +1002,12 @@ export function processInstrumentCSV(input: File, instrument: AnyUnilingualFormI
 
 export function reformatInstrumentData({
   currentGroup,
+  currentUsername,
   data,
   instrument
 }: {
   currentGroup: Group | null;
+  currentUsername?: null | string;
   data: FormTypes.Data[];
   instrument: UnilingualInstrumentInfo;
 }): UploadInstrumentRecordsData {
@@ -1024,7 +1026,8 @@ export function reformatInstrumentData({
   const reformatForSending: UploadInstrumentRecordsData = {
     groupId: currentGroup?.id,
     instrumentId: instrument.id,
-    records: recordsList
+    records: recordsList,
+    username: currentUsername ?? 'N/A'
   };
   return reformatForSending;
 }

--- a/packages/schemas/src/instrument-records/instrument-records.ts
+++ b/packages/schemas/src/instrument-records/instrument-records.ts
@@ -32,7 +32,8 @@ export const $UploadInstrumentRecordsData = z.object({
       date: z.coerce.date(),
       subjectId: z.string()
     })
-  )
+  ),
+  username: z.string().optional()
 });
 
 export type CreateInstrumentRecordData = z.infer<typeof $CreateInstrumentRecordData>;


### PR DESCRIPTION
The other option to close issue #1342 

This  pr removes the optional checkbox and make it always attach the user to the uploaded data whenever possible. 

If we select this option the pr #1344 will be removed

The new implementation now includes a dropdown of all the usernames in the group, which allows the user to select which username to attach to the upload. The dropdown defaults to the current user's username and also provides an 'N/A' option if needed. 

small change to update user backend that fixes issue #1354 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to select which username to associate with imported instrument records during upload.

* **Improvements**
  * User list is scoped to the active group so the dropdown shows relevant members.
  * Upload payload now includes the chosen username and the client forwards the selection.
  * Upload UI refined with a cleaner centered layout and loading presentation.

* **Bug Fixes**
  * Upload enforces that a chosen username belongs to the selected group.

* **Tests**
  * Added tests covering username handling during upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->