### PR TITLE
Add comment to disable linter ordering of form fields

### DIFF
--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -121,17 +121,18 @@ const RouteComponent = () => {
         content={[
           {
             fields: {
-              confirmPassword: {
-                kind: 'string',
-                label: t('common.confirmPassword'),
-                variant: 'password'
-              },
               password: {
                 calculateStrength: (password) => {
                   return estimatePasswordStrength(password).score;
                 },
                 kind: 'string',
                 label: t('common.password'),
+                variant: 'password'
+              },
+              // eslint-disable-next-line perfectionist/sort-objects
+              confirmPassword: {
+                kind: 'string',
+                label: t('common.confirmPassword'),
                 variant: 'password'
               },
               // eslint-disable-next-line perfectionist/sort-objects


### PR DESCRIPTION
fix confirm password in user preference form coming before the actual password field :triumph: 