### PR TITLE
Add --all mode to serve-instrument package

### DIFF
--- a/packages/serve-instrument/package.json
+++ b/packages/serve-instrument/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendatacapture/serve-instrument",
   "type": "module",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "Apache-2.0",
   "bin": {
     "serve-instrument": "./dist/cli.js"

--- a/packages/serve-instrument/src/cli.ts
+++ b/packages/serve-instrument/src/cli.ts
@@ -6,13 +6,20 @@ import { Command, InvalidArgumentError } from 'commander';
 import { name, version } from '../package.json';
 import { Server } from './server';
 
-function parseTarget(target: string): string {
+function parseTarget(target: string, all: boolean): string {
   const resolved = path.resolve(target);
   if (!fs.existsSync(resolved)) {
     throw new InvalidArgumentError('Directory does not exist');
   }
   if (!fs.lstatSync(resolved).isDirectory()) {
     throw new InvalidArgumentError('Not a directory');
+  }
+  if (all) {
+    const hasFormsDir = fs.existsSync(path.join(resolved, 'forms'));
+    const hasInteractiveDir = fs.existsSync(path.join(resolved, 'interactive'));
+    if (!hasFormsDir && !hasInteractiveDir) {
+      throw new InvalidArgumentError('In --all mode, directory must contain a forms/ and/or interactive/ subdirectory');
+    }
   }
   return resolved;
 }
@@ -31,12 +38,19 @@ program
   .name(name)
   .version(version)
   .allowExcessArguments(false)
-  .argument('<target>', 'the directory containing the instrument', parseTarget)
+  .argument('<target>', 'the directory containing the instrument')
+  .option('-a, --all', 'serve all instruments from forms/ and interactive/ subdirectories')
   .option('-p --port <number>', 'the port to run the dev server on', parsePort, 3000)
   .option('-v, --verbose', 'enable verbose logging (includes request logs and build timing)')
   .action(async (target: string) => {
-    const { port, verbose } = program.opts<{ port: number; verbose: boolean }>();
-    const server = await Server.create({ port, target, verbose: verbose ?? false });
+    const { all, port, verbose } = program.opts<{ all: boolean; port: number; verbose: boolean }>();
+    const resolved = parseTarget(target, all);
+    const server = await Server.create({
+      mode: all ? 'all' : 'single',
+      port,
+      target: resolved,
+      verbose: verbose ?? false
+    });
     await server.start();
   });
 

--- a/packages/serve-instrument/src/root.tsx
+++ b/packages/serve-instrument/src/root.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { i18n } from '@douglasneuroinformatics/libui/i18n';
 import { ScalarInstrumentRenderer } from '@opendatacapture/react-core';
@@ -6,16 +6,124 @@ import { decodeBase64ToUnicode } from '@opendatacapture/runtime-internal';
 
 i18n.init({ translations: {} });
 
-export type RootProps = {
-  encodedBundle: string;
+const LanguageSwitcher: React.FC = () => {
+  const [lang, setLang] = useState<'en' | 'fr'>(i18n.resolvedLanguage as 'en' | 'fr');
+  useEffect(() => {
+    const handler = (l: 'en' | 'fr') => setLang(l);
+    i18n.addEventListener('languageChange', handler);
+    return () => {
+      i18n.removeEventListener('languageChange', handler);
+    };
+  }, []);
+  return (
+    <div className="flex gap-2">
+      {(['en', 'fr'] as const).map((l) => (
+        <button
+          className={`text-sm uppercase ${lang === l ? 'font-bold underline' : 'text-gray-500 hover:text-gray-900'}`}
+          key={l}
+          onClick={() => i18n.changeLanguage(l)}
+        >
+          {l}
+        </button>
+      ))}
+    </div>
+  );
 };
 
-export const Root: React.FC<RootProps> = ({ encodedBundle }) => {
+type InstrumentEntry = {
+  name: string;
+  type: 'forms' | 'interactive';
+};
+
+export type RootProps =
+  | { encodedBundle: string; page: 'single' }
+  | { encodedBundle: string; instrumentName: string; instrumentType: string; page: 'instrument' }
+  | { instruments: InstrumentEntry[]; page: 'index' };
+
+const IndexPage: React.FC<{ instruments: InstrumentEntry[] }> = ({ instruments }) => {
+  const forms = instruments.filter((i) => i.type === 'forms');
+  const interactive = instruments.filter((i) => i.type === 'interactive');
+
   return (
-    <div className="container h-screen py-16">
+    <div className="container mx-auto max-w-3xl px-4 py-16">
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Instruments</h1>
+        <LanguageSwitcher />
+      </div>
+      {forms.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold">Forms</h2>
+          <ul className="space-y-2">
+            {forms.map((inst) => (
+              <li key={inst.name}>
+                <a
+                  className="text-blue-600 underline hover:text-blue-800"
+                  href={`/forms/${encodeURIComponent(inst.name)}`}
+                >
+                  {inst.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {interactive.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold">Interactive</h2>
+          <ul className="space-y-2">
+            {interactive.map((inst) => (
+              <li key={inst.name}>
+                <a
+                  className="text-blue-600 underline hover:text-blue-800"
+                  href={`/interactive/${encodeURIComponent(inst.name)}`}
+                >
+                  {inst.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export const Root: React.FC<RootProps> = (props) => {
+  if (props.page === 'single') {
+    return (
+      <div className="container h-screen py-16">
+        <ScalarInstrumentRenderer
+          key={props.encodedBundle}
+          target={{ bundle: decodeBase64ToUnicode(props.encodedBundle), id: null! }}
+          onSubmit={({ data }) => {
+            // eslint-disable-next-line no-alert
+            alert(JSON.stringify({ _message: 'The following data will be submitted', data }, null, 2));
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (props.page === 'index') {
+    return <IndexPage instruments={props.instruments} />;
+  }
+
+  return (
+    <div className="container h-screen py-8">
+      <div className="mb-4 flex items-start justify-between">
+        <div>
+          <a className="text-sm text-blue-600 underline hover:text-blue-800" href="/">
+            &larr; Back to list
+          </a>
+          <h1 className="mt-2 text-lg font-semibold">
+            {props.instrumentType}/{props.instrumentName}
+          </h1>
+        </div>
+        <LanguageSwitcher />
+      </div>
       <ScalarInstrumentRenderer
-        key={encodedBundle}
-        target={{ bundle: decodeBase64ToUnicode(encodedBundle), id: null! }}
+        key={props.encodedBundle}
+        target={{ bundle: decodeBase64ToUnicode(props.encodedBundle), id: null! }}
         onSubmit={({ data }) => {
           // eslint-disable-next-line no-alert
           alert(JSON.stringify({ _message: 'The following data will be submitted', data }, null, 2));
@@ -24,3 +132,5 @@ export const Root: React.FC<RootProps> = ({ encodedBundle }) => {
     </div>
   );
 };
+
+export type { InstrumentEntry };

--- a/packages/serve-instrument/src/server.tsx
+++ b/packages/serve-instrument/src/server.tsx
@@ -16,7 +16,7 @@ import chalk from 'chalk';
 
 import { Root } from './root';
 
-import type { RootProps } from './root';
+import type { InstrumentEntry, RootProps } from './root';
 
 declare const __TAILWIND_STYLES__: string;
 
@@ -37,11 +37,12 @@ class InstrumentLoader {
 
   constructor(
     private readonly target: string,
+    private readonly label: string,
     private readonly verbose: boolean
   ) {
     this.encodedBundle = null;
     fs.watch(target, { recursive: false }, () => {
-      log(chalk.yellow('↺') + chalk.dim(' File changed, rebuilding...'));
+      log(chalk.yellow('↺') + chalk.dim(` [${this.label}] File changed, rebuilding...`));
       void this.updateEncodedBundle();
     });
   }
@@ -64,7 +65,6 @@ class InstrumentLoader {
       const loader = inferLoader(filepath);
       const content: string | Uint8Array = await fs.promises.readFile(filepath, loader === 'dataurl' ? null : 'utf-8');
       inputs.push({
-        // https://github.com/microsoft/TypeScript/issues/62546
         content: content instanceof Uint8Array ? new Uint8Array(content) : content,
         name: path.basename(filepath)
       });
@@ -74,16 +74,62 @@ class InstrumentLoader {
       this.encodedBundle = encodeUnicodeToBase64(await bundle({ inputs }));
       const elapsed = Date.now() - start;
       const timing = this.verbose ? chalk.dim(` (${elapsed}ms)`) : '';
-      log(chalk.green('✓') + chalk.dim(' Bundle ready') + timing);
+      const labelPart = this.label ? chalk.dim(` [${this.label}]`) : '';
+      log(chalk.green('✓') + labelPart + chalk.dim(' Bundle ready') + timing);
     } catch (err) {
       const formattedError = err instanceof Error ? formatError(err) : err;
       logError(chalk.dim(String(formattedError)) + '\n');
-      logError(chalk.red('✘') + chalk.bold.red(' Error: Failed to compile instrument'));
+      const labelPart = this.label ? ` ${this.label}` : ' instrument';
+      logError(chalk.red('✘') + chalk.bold.red(` Error: Failed to compile${labelPart}`));
     }
   }
 }
 
-class RequestHandler {
+class InstrumentLoaderMap {
+  private instruments: InstrumentEntry[] = [];
+  private loaders = new Map<string, InstrumentLoader>();
+
+  constructor(
+    private readonly target: string,
+    private readonly verbose: boolean
+  ) {}
+
+  async getEncodedBundle(type: string, name: string): Promise<null | string> {
+    const loader = this.loaders.get(`${type}/${name}`);
+    if (!loader) {
+      return null;
+    }
+    return loader.getEncodedBundle();
+  }
+
+  getInstrumentList(): InstrumentEntry[] {
+    return this.instruments;
+  }
+
+  async init(): Promise<void> {
+    for (const type of ['forms', 'interactive'] as const) {
+      const typeDir = path.join(this.target, type);
+      if (!fs.existsSync(typeDir)) {
+        continue;
+      }
+      const entries = await fs.promises.readdir(typeDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const key = `${type}/${entry.name}`;
+        this.instruments.push({ name: entry.name, type });
+        this.loaders.set(key, new InstrumentLoader(path.join(typeDir, entry.name), key, this.verbose));
+      }
+    }
+    this.instruments.sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name));
+    log(chalk.green('✓') + chalk.dim(` Found ${this.instruments.length} instruments`));
+  }
+}
+
+type ServerMode = 'all' | 'single';
+
+class SingleModeHandler {
   private instrumentLoader: InstrumentLoader;
   private runtimeMetadata: RuntimeMetadataMap;
   private verbose: boolean;
@@ -102,7 +148,7 @@ class RequestHandler {
       const encodedBundle = await this.instrumentLoader.getEncodedBundle();
       if (encodedBundle) {
         res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end('<!DOCTYPE html>' + (await this.renderPage({ encodedBundle })));
+        res.end('<!DOCTYPE html>' + (await this.renderPage({ encodedBundle, page: 'single' })));
       } else {
         res.writeHead(503, { 'Content-Type': 'text/plain' });
         res.end('Bundle Loading or Error (See Console)');
@@ -146,22 +192,135 @@ class RequestHandler {
   }
 }
 
+class AllModeHandler {
+  private loaderMap: InstrumentLoaderMap;
+  private runtimeMetadata: RuntimeMetadataMap;
+  private verbose: boolean;
+
+  constructor(params: { loaderMap: InstrumentLoaderMap; runtimeMetadata: RuntimeMetadataMap; verbose: boolean }) {
+    this.loaderMap = params.loaderMap;
+    this.runtimeMetadata = params.runtimeMetadata;
+    this.verbose = params.verbose;
+  }
+
+  async handle(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    if (this.verbose) {
+      res.on('finish', () => {
+        log(`${chalk.dim(req.method)} ${req.url} ${chalk.dim(res.statusCode)}`);
+      });
+    }
+
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'Content-Type': 'text/plain' });
+      res.end('Method Not Allowed');
+      return;
+    }
+
+    if (req.url === '/') {
+      const props: RootProps = { instruments: this.loaderMap.getInstrumentList(), page: 'index' };
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<!DOCTYPE html>' + (await this.renderPage(props)));
+      return;
+    }
+
+    const instrumentMatch = req.url?.match(/^\/(forms|interactive)\/([^/]+)\/?$/);
+    if (instrumentMatch) {
+      const [, type, name] = instrumentMatch;
+      const decodedName = decodeURIComponent(name!);
+      const encodedBundle = await this.loaderMap.getEncodedBundle(type!, decodedName);
+      if (!encodedBundle) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Instrument Not Found');
+        return;
+      }
+      const props: RootProps = {
+        encodedBundle,
+        instrumentName: decodedName,
+        instrumentType: type!,
+        page: 'instrument'
+      };
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<!DOCTYPE html>' + (await this.renderPage(props)));
+      return;
+    }
+
+    if (req.url?.startsWith('/runtime')) {
+      const asset = await resolveRuntimeAsset(req.url.replace(/^\/?runtime\//, ''), this.runtimeMetadata);
+      if (!asset) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+      } else {
+        res.writeHead(200, { 'Content-Type': asset.contentType });
+        res.end(asset.content);
+      }
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not Found');
+  }
+
+  private async renderPage(props: RootProps): Promise<string> {
+    const clientBundle = await fs.promises
+      .readFile(path.resolve(import.meta.dirname, 'client.js'), 'utf-8')
+      .then((text) => `const __ROOT_PROPS__ = ${JSON.stringify(props)}; ${text}`);
+
+    return renderToString(
+      <html lang="en">
+        <head>
+          <meta charSet="UTF-8" />
+          <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+          <title>Open Data Capture</title>
+          <style>{atob(__TAILWIND_STYLES__)}</style>
+        </head>
+        <body>
+          <div id="root">
+            <Root {...props} />
+          </div>
+        </body>
+        <script dangerouslySetInnerHTML={{ __html: clientBundle }} type="module" />
+      </html>
+    );
+  }
+}
+
 export class Server {
-  private handler: RequestHandler;
+  private handler: SingleModeHandler | AllModeHandler;
   private port: number;
   private server: http.Server;
 
-  private constructor(params: { handler: RequestHandler; port: number }) {
+  private constructor(params: { handler: SingleModeHandler | AllModeHandler; port: number }) {
     this.handler = params.handler;
     this.port = params.port;
     this.server = http.createServer((...args) => void this.handler.handle(...args));
   }
 
-  static async create({ port, target, verbose }: { port: number; target: string; verbose: boolean }) {
+  static async create({
+    mode,
+    port,
+    target,
+    verbose
+  }: {
+    mode: ServerMode;
+    port: number;
+    target: string;
+    verbose: boolean;
+  }) {
+    const runtimeMetadata = await generateMetadata({ rootDir: import.meta.dirname });
+
+    if (mode === 'all') {
+      const loaderMap = new InstrumentLoaderMap(target, verbose);
+      await loaderMap.init();
+      return new this({
+        handler: new AllModeHandler({ loaderMap, runtimeMetadata, verbose }),
+        port
+      });
+    }
+
     return new this({
-      handler: new RequestHandler({
-        instrumentLoader: new InstrumentLoader(target, verbose),
-        runtimeMetadata: await generateMetadata({ rootDir: import.meta.dirname }),
+      handler: new SingleModeHandler({
+        instrumentLoader: new InstrumentLoader(target, '', verbose),
+        runtimeMetadata,
         verbose
       }),
       port


### PR DESCRIPTION
## Summary

Merges the multi-instrument serving capability directly into `serve-instrument` via a new `--all` CLI flag.

### Usage

**Single instrument (default, unchanged):**
```
serve-instrument ./my-instrument
```

**All instruments (new `--all` mode):**
```
serve-instrument --all ./instruments-dir
```

With `--all`, the target directory must contain `forms/` and/or `interactive/` subdirectories. The server provides:
- An **index page** linking to all discovered instruments
- **Per-instrument pages** with hot-rebuild on file change (`fs.watch`)
- An **en/fr language switcher** wired to the libui i18n translator
- **Verbose request logging** (with `-v`)

### Changes
- `src/cli.ts`: Added `--all` / `-a` flag; validates that target has `forms/`/`interactive/` subdirs in all mode
- `src/root.tsx`: Merged UI — `RootProps` is now a discriminated union (`single` | `index` | `instrument` pages); added `LanguageSwitcher` and `IndexPage` components
- `src/server.tsx`: Added `InstrumentLoaderMap` class and `AllModeHandler` alongside existing `SingleModeHandler`; `Server.create` branches on `mode`
- `package.json`: Bumped version to `0.0.13`