### PR TITLE
Edits to odc-cli and subject services for production usage

### DIFF
--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -133,10 +133,18 @@ describe('SubjectsService', () => {
       subjectModel.findFirst.mockResolvedValueOnce({ id: '123' });
       await subjectsService.deleteById('123', { force: true });
       expect(subjectModel.delete).not.toHaveBeenCalled();
-      expect(prismaClient.session.deleteMany).toHaveBeenCalled();
-      expect(prismaClient.instrumentRecord.deleteMany).toHaveBeenCalled();
-      expect(prismaClient.subject.deleteMany).toHaveBeenCalled();
       expect(prismaClient.$transaction).toHaveBeenCalledOnce();
+    });
+    it('should pass operations to $transaction in order: instrumentRecord, session, subject', async () => {
+      subjectModel.findFirst.mockResolvedValueOnce({ id: '123' });
+      const instrumentRecordOp = 'instrumentRecord-op';
+      const sessionOp = 'session-op';
+      const subjectOp = 'subject-op';
+      prismaClient.instrumentRecord.deleteMany.mockReturnValueOnce(instrumentRecordOp);
+      prismaClient.session.deleteMany.mockReturnValueOnce(sessionOp);
+      prismaClient.subject.deleteMany.mockReturnValueOnce(subjectOp);
+      await subjectsService.deleteById('123', { force: true });
+      expect(prismaClient.$transaction).toHaveBeenCalledWith([instrumentRecordOp, sessionOp, subjectOp]);
     });
     it('should throw NotFoundException when subject does not exist', async () => {
       subjectModel.findFirst.mockResolvedValueOnce(null);

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -102,14 +102,14 @@ export class SubjectsService {
       return { success: true };
     }
     await this.prismaClient.$transaction([
-      this.prismaClient.session.deleteMany({
+      this.prismaClient.instrumentRecord.deleteMany({
         where: {
           subject: {
             id: subject.id
           }
         }
       }),
-      this.prismaClient.instrumentRecord.deleteMany({
+      this.prismaClient.session.deleteMany({
         where: {
           subject: {
             id: subject.id

--- a/cli/odc-cli
+++ b/cli/odc-cli
@@ -19,7 +19,7 @@ from argparse import (
     ArgumentTypeError,
     RawTextHelpFormatter,
 )
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, TypedDict
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse, quote
@@ -409,14 +409,19 @@ class SubjectCommands:
     def find(min_date: datetime | None, subject_id: str | None) -> None:
         if subject_id is not None:
             url = f'{config.base_url}/v1/subjects/{quote(subject_id, safe="")}'
+            response = HttpClient.get(url)
         else:
             url = build_url_with_params(
                 f'{config.base_url}/v1/subjects',
-                {
-                    'minDate': min_date,
-                },
+                {}
             )
-        response = HttpClient.get(url)
+            response = HttpClient.get(url)
+            if min_date is not None and isinstance(response.data, list):
+                min_date_utc = min_date.replace(tzinfo=timezone.utc) if min_date.tzinfo is None else min_date
+                response.data = [
+                    s for s in response.data
+                    if datetime.fromisoformat(s['createdAt'].replace('Z', '+00:00')) >= min_date_utc
+                ]
         print(response)
 
 

--- a/cli/odc-cli
+++ b/cli/odc-cli
@@ -368,7 +368,7 @@ class InstrumentRecordsCommands:
         url = build_url_with_params(
             f'{config.base_url}/v1/instrument-records',
             {
-                'minDate': min_date,
+                'minDate': min_date.isoformat() if min_date is not None else None,
                 'instrumentId': instrument_id,
                 'subjectId': subject_id,
             },
@@ -572,9 +572,9 @@ class CLI:
         find_parser.add_argument(
             '--min-date',
             type=ArgumentTypes.valid_datetime,
-            help='filter records created after this date (format: yyyy-mm-dd or yyyy-mm-dd hh:mm:ss)',
+            help='filter subjects created after this date (format: yyyy-mm-dd or yyyy-mm-dd hh:mm:ss). Cannot be used with --subject-id',
         )
-        find_parser.add_argument('--subject-id', help='filter by subject id')
+        find_parser.add_argument('--subject-id', help='find a single subject by exact id. Cannot be used with --min-date')
         find_parser.set_defaults(fn=SubjectCommands.find)
 
     def _create_instruments_parser(self):
@@ -615,7 +615,7 @@ class CLI:
         app_group.add_argument(
             '--dummy-subject-count',
             type=int,
-            help='.umber of dummy subjects to create for the demo',
+            help='number of dummy subjects to create for the demo',
         )
         app_group.add_argument(
             '--records-per-subject',

--- a/cli/odc-cli
+++ b/cli/odc-cli
@@ -242,15 +242,15 @@ class HttpClient:
 
     @classmethod
     def _request(cls, method: str, url: str, data: Any = None) -> HttpResponse:
-        headers = cls._get_default_headers()
         body = json.dumps(data).encode('utf-8') if data is not None else None
+        headers = cls._get_default_headers(has_body=body is not None)
         request = Request(url, data=body, headers=headers, method=method)
         return cls._send(request)
 
     @classmethod
     def _send(cls, req: Request) -> HttpResponse:
         try:
-            with urlopen(req, timeout=2) as response:
+            with urlopen(req, timeout=30) as response:
                 return cls._build_response(response)
         except HTTPError as err:
             return cls._build_response(err)
@@ -283,8 +283,10 @@ class HttpClient:
         return HttpResponse(data=data, status=response.getcode())
 
     @staticmethod
-    def _get_default_headers() -> dict[str, str]:
-        headers = {'Content-Type': 'application/json'}
+    def _get_default_headers(has_body: bool = False) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if has_body:
+            headers['Content-Type'] = 'application/json'
         if config.access_token:
             headers['Authorization'] = f'Bearer {config.access_token}'
         return headers

--- a/cli/odc-cli
+++ b/cli/odc-cli
@@ -407,13 +407,15 @@ class SubjectCommands:
     @require_token
     @staticmethod
     def find(min_date: datetime | None, subject_id: str | None) -> None:
-        url = build_url_with_params(
-            f'{config.base_url}/v1/subjects',
-            {
-                'minDate': min_date,
-                'subjectId': subject_id,
-            },
-        )
+        if subject_id is not None:
+            url = f'{config.base_url}/v1/subjects/{quote(subject_id, safe="")}'
+        else:
+            url = build_url_with_params(
+                f'{config.base_url}/v1/subjects',
+                {
+                    'minDate': min_date,
+                },
+            )
         response = HttpClient.get(url)
         print(response)
 


### PR DESCRIPTION
Works on issue #1373 
code implemented with usage of claude-sonnet-4-6 on claude code

Bug fixes for cascading subject deletion and the `odc-cli` HTTP client.

## Changes

### Fix: Cascading subject deletion order (`apps/api/src/subjects/subjects.service.ts`)

Reordered the Prisma `$transaction` in `SubjectsService.deleteById` so that
instrument records are deleted before sessions, then the subject itself.

The previous order (sessions → instrument records → subject) caused a
foreign-key violation in production because MongoDB enforced referential
integrity at the session level before instrument records had been cleared.
Local development was unaffected since standalone MongoDB does not enforce
FK constraints without a replica set.

**New order:**
1. Delete instrument records
2. Delete sessions
3. Delete subject

---

### Fix: `odc-cli` sending `Content-Type` on bodyless requests (`cli/odc-cli`)

`DELETE` requests with no body were including a `Content-Type: application/json`
header, causing the API to return `400 Body cannot be empty`. The header is now
only added when a request body is present.

The request timeout was also increased from 2 s to 30 s to accommodate the
longer cascade-delete operation.

---

fix(cli): correct instrument-records minDate serialization and subject find filters

- Serialize minDate as ISO 8601 string before URL encoding to ensure
  correct parsing by the backend's z.coerce.date() schema
- Use GET /v1/subjects/:id (findById) when --subject-id is provided
  instead of passing it as an ignored list query param
- Document that --subject-id and --min-date are mutually exclusive
  in the subjects find help text
- Fix typo in setup init --dummy-subject-count help text

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


## Test Plan

- [ ] Force-delete a subject with existing instrument records and sessions via
      the API — confirm `200` and no FK error in logs
- [ ] Run `python3 odc-cli subjects delete --id '<subject-id>'` against a remote
      instance — confirm `200` and no `400` error
- [ ] Run `python3 odc-cli subjects find` — confirm requests without a body
      still succeed
- [ ] Verify delete completes within the 30 s window for subjects with many
      records


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased HTTP request timeout from 2s to 30s for more reliable CLI operations.
  * Ensured subject deletion removes related records in proper order.

* **Improvements**
  * CLI only sends JSON body and Content-Type when a body is present.
  * Subject lookup uses a direct endpoint when an ID is supplied; listing supports client-side date filtering.

* **Tests**
  * Added test to verify transactional deletion order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->