### PR TITLE
feat(series): conditional early termination and custom completion message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Open Data Capture is an electronic data capture platform for administering remote and in-person clinical instruments. It's a pnpm/Turborepo monorepo written in TypeScript.
+
+## Commands
+
+Package manager is pnpm (>=10). Node >= v24.15.0 (see `.nvmrc`, currently `lts/krypton`).
+
+```sh
+pnpm install                # install deps
+pnpm dev                    # run core apps (api, gateway, web) via turbo
+pnpm build                  # turbo build (all packages/apps)
+pnpm lint                   # turbo lint (tsc + eslint per package)
+pnpm format                 # turbo format (prettier per package)
+pnpm test                   # run vitest across the whole workspace (root vitest.config.ts references apps/*/vitest.config.ts and
+```
+
+Run a single test file with vitest directly, e.g. `pnpm exec vitest apps/api/src/auth/__tests__/ability.factory.test.ts`. Each app/package has its own `vitest.config.ts` (a vitest "project") that extends the root config; scope a run to one project with `pnpm exec vitest --project api` (project names match the `name` field in that config, e.g. `api`).
+
+Per-package scripts (run from repo root via turbo filters, or `cd` into the package): `build`, `dev`, `lint` (`tsc && eslint --fix src`), `format`, `test`. Use `pnpm --filter @opendatacapture/<pkg> <script>` or turbo's `--filter=<pkg>` to target one workspace package.
+
+`apps/web` uses TanStack Router with a generated `src/route-tree.ts`. **Do not run the route-tree generator yourself** — the user runs it manually after route changes.
+
+## Architecture
+
+### Workspace layout
+
+- `apps/api` — NestJS backend, built on `@douglasneuroinformatics/libnest` (custom Nest wrapper: `libnest.config.ts`, `libnest dev`/`libnest build`).
+- `apps/gateway` — SSR app that lets patients self-administer remote assignments.
+- `apps/outreach` — Astro marketing/docs-adjacent site.
+- `apps/playground` — in-browser instrument build/edit environment (WebAssembly-based bundling).
+- `apps/web` — the main clinician-facing React SPA.
+- `packages/*` — shared libraries published under `@opendatacapture/*` and consumed via `workspace:*`:
+  - `demo` — seed data (demo groups/users) used to populate demo instances.
+  - `instrument-bundler` — compiles/bundles instrument source (TS/JS) into runtime-loadable bundles via a parse/transform/resolve/preprocess pipeline.
+  - `instrument-guidelines` — instrument-authoring guidelines written to be read by an AI coding agent.
+  - `instrument-interpreter` — evaluates a bundled instrument at runtime and validates it against the instrument schemas.
+  - `instrument-library` — a built-in catalog of ready-made instruments (forms, interactive tasks, series, file instruments).
+  - `instrument-stubs` — minimal stub instrument implementations used for testing/examples.
+  - `instrument-utils` — shared helpers for working with instrument definitions (forms, guards, measures, translation).
+  - `licenses` — license metadata (SPDX + custom) used for license selection/display.
+  - `playground-url` — encodes/decodes shareable playground URLs and editor file state.
+  - `react-core` — shared React components/hooks used across web and gateway (branding, error boundaries, instrument renderer, etc.).
+  - `release-info` — resolves build/release metadata (version, git branch, commit) at build time.
+  - `runtime-bundler` — bundles the instrument runtime (i.e., shared libraries that instruments can use) itself (distinct from `instrument-bundler`, which bundles instrument code).
+  - `runtime-core` — public runtime types/constants/definitions (`defineInstrument`, i18n, notifications) shared by instrument authors and consumers.
+  - `runtime-internal` — internal runtime execution primitives (e.g. interactive-task iframe/worker bootstrap) not meant for direct consumption.
+  - `runtime-meta` — runtime metadata used to describe/version the runtime.
+  - `schemas` — Zod schemas/types shared across apps and packages, organized by domain (`src/instrument`, `src/auth`, `src/group`, `src/subject`, etc.); the source of truth for cross-cutting types.
+  - `serve-instrument` — CLI/server for previewing a single instrument locally outside the full app.
+  - `subject-utils` — subject identification helpers (e.g. deriving/hashing clinical subject IDs).
+  - `vite-plugin-runtime` — Vite plugin that wires the instrument runtime into an app's build.
+- `runtime/v1` — versioned instrument runtime package (imported by the API as `@opendatacapture/runtime-v1` and resolved at `#runtime/v1` for virtualized instrument execution).
+- `cli/` — standalone CLI for making requests to the API.
+- `testing/` — end-to-end tests.
+- `storybook/` — shared Storybook config.
+
+## Conventions
+
+- Make small, incremental, easily reviewable changes — avoid sweeping refactors unless explicitly requested.
+- Favor type safety over convenience; avoid type casting unless necessary. Never silently swallow errors.
+- No new dependencies without approval.
+- Prefer descriptive variable names over terse or cryptic ones.
+- Avoid excessive comments; don't comment obvious behavior. Use comments only to explain non-obvious behavior or pitfalls.
+- Once all changes are complete, run `pnpm lint` and `pnpm test` from the repo root to verify them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,4 @@ Per-package scripts (run from repo root via turbo filters, or `cd` into the pack
 - Prefer descriptive variable names over terse or cryptic ones.
 - Avoid excessive comments; don't comment obvious behavior. Use comments only to explain non-obvious behavior or pitfalls.
 - Once all changes are complete, run `pnpm lint` and `pnpm test` from the repo root to verify them.
+- All frontend user-facing strings need to be translated using the `useTranslation` hook (prefer inline translations with `t({ en: '...', fr: '...' })` unless translation is used multiple times).

--- a/apps/api/src/gateway/gateway.synchronizer.ts
+++ b/apps/api/src/gateway/gateway.synchronizer.ts
@@ -6,6 +6,7 @@ import { getSeriesInstrumentItems } from '@opendatacapture/instrument-utils';
 import type { ScalarInstrumentInternal } from '@opendatacapture/runtime-core';
 import type { RemoteAssignment } from '@opendatacapture/schemas/assignment';
 import { $Json } from '@opendatacapture/schemas/core';
+import type { Json } from '@opendatacapture/schemas/core';
 
 import { AssignmentsService } from '@/assignments/assignments.service';
 import { InstrumentRecordsService } from '@/instrument-records/instrument-records.service';
@@ -97,45 +98,53 @@ export class GatewaySynchronizer implements OnApplicationBootstrap {
       for (let i = 0; i < cipherTexts.length; i++) {
         const cipherText = cipherTexts[i]!;
         const symmetricKey = symmetricKeys[i]!;
-        const data = await $Json.parseAsync(
-          JSON.parse(
-            await HybridCrypto.decrypt({
-              cipherText: Buffer.from(cipherText, 'base64'),
-              privateKey: await HybridCrypto.deserializePrivateKey(assignment.encryptionKeyPair.privateKey),
-              symmetricKey: Buffer.from(symmetricKey, 'base64')
-            })
-          )
-        );
-        const record = await this.instrumentRecordsService.create({
-          assignmentId: assignment.id,
-          data,
-          date: remoteAssignment.completedAt,
-          groupId: assignment.groupId ?? undefined,
-          instrumentId:
-            instrument.kind === 'SERIES'
-              ? this.instrumentsService.generateScalarInstrumentId({ internal: seriesItems![i]! })
-              : instrument.id,
-          sessionId: session.id,
-          subjectId: assignment.subjectId
-        });
-        this.loggingService.log(`Created record with ID: ${record.id}`);
-        createdRecordIds.push(record.id);
+        const instrumentId =
+          instrument.kind === 'SERIES'
+            ? this.instrumentsService.generateScalarInstrumentId({ internal: seriesItems![i]! })
+            : instrument.id;
+        let decryptedData: string;
+        try {
+          decryptedData = await HybridCrypto.decrypt({
+            cipherText: Buffer.from(cipherText, 'base64'),
+            privateKey: await HybridCrypto.deserializePrivateKey(assignment.encryptionKeyPair.privateKey),
+            symmetricKey: Buffer.from(symmetricKey, 'base64')
+          });
+        } catch (err) {
+          this.loggingService.error({ instrumentId, message: 'Failed to decrypt data' });
+          throw err;
+        }
+
+        let data: Json;
+        try {
+          data = await $Json.parseAsync(JSON.parse(decryptedData));
+        } catch (err) {
+          this.loggingService.error({ decryptedData, instrumentId, message: 'Failed to parse decrypted data' });
+          throw err;
+        }
+
+        try {
+          const record = await this.instrumentRecordsService.create({
+            assignmentId: assignment.id,
+            data,
+            date: remoteAssignment.completedAt,
+            groupId: assignment.groupId ?? undefined,
+            instrumentId,
+            sessionId: session.id,
+            subjectId: assignment.subjectId
+          });
+          this.loggingService.log(`Created record with ID: ${record.id}`);
+          createdRecordIds.push(record.id);
+        } catch (err) {
+          this.loggingService.error({ data, instrumentId, message: 'Failed to create instrument record' });
+          throw err;
+        }
       }
       await this.gatewayService.deleteRemoteAssignment(assignment.id);
     } catch (err) {
-      this.loggingService.error({
-        data: {
-          assignment,
-          cipherTexts,
-          remoteAssignment,
-          symmetricKeys
-        },
-        message: 'Failed to Process Data'
-      });
       this.loggingService.error(err);
       for (const id of createdRecordIds) {
         await this.instrumentRecordsService.deleteById(id);
-        this.loggingService.log(`Deleted Record with ID: ${id}`);
+        this.loggingService.log(`Deleted record with ID: ${id}`);
       }
       throw err;
     }

--- a/apps/api/src/gateway/gateway.synchronizer.ts
+++ b/apps/api/src/gateway/gateway.synchronizer.ts
@@ -73,13 +73,15 @@ export class GatewaySynchronizer implements OnApplicationBootstrap {
       cipherTexts.push(...remoteAssignment.encryptedData.slice(1).split('$'));
       symmetricKeys.push(...remoteAssignment.symmetricKey.slice(1).split('$'));
       seriesItems = getSeriesInstrumentItems(instrument.content);
-      if (cipherTexts.length !== seriesItems.length) {
+      // A series may end early (e.g. via `terminate`), so the submitted items are a non-empty
+      // prefix of the series content: fewer records than items is valid, more is malformed.
+      if (cipherTexts.length !== symmetricKeys.length) {
         throw new InternalServerErrorException(
-          `Expected length of cypher texts '${cipherTexts.length}' to match length of series instrument content '${symmetricKeys.length}'`
+          `Expected length of cypher texts '${cipherTexts.length}' to match length of symmetric keys '${symmetricKeys.length}'`
         );
-      } else if (symmetricKeys.length !== seriesItems.length) {
+      } else if (cipherTexts.length < 1 || cipherTexts.length > seriesItems.length) {
         throw new InternalServerErrorException(
-          `Expected length of symmetric keys '${cipherTexts.length}' to match length of series instrument content '${symmetricKeys.length}'`
+          `Expected number of submitted series items '${cipherTexts.length}' to be between 1 and the series instrument content length '${seriesItems.length}'`
         );
       }
     } else if (remoteAssignment.encryptedData.includes('$') || remoteAssignment.symmetricKey.includes('$')) {

--- a/apps/gateway/src/Root.tsx
+++ b/apps/gateway/src/Root.tsx
@@ -51,7 +51,7 @@ export const Root = ({ id, initialSeriesIndex, target, token }: RootProps) => {
     if (target.kind === 'SERIES' && result.kind === 'SERIES') {
       updateData = {
         ...result,
-        status: result.instrumentId === target.items.at(-1)?.id ? 'COMPLETE' : undefined
+        status: result.complete ? 'COMPLETE' : undefined
       };
     } else if (target.kind !== 'SERIES') {
       updateData = {

--- a/packages/instrument-guidelines/AGENTS.md
+++ b/packages/instrument-guidelines/AGENTS.md
@@ -179,14 +179,36 @@ The `content` may be either a bare ordered array of identities, or an object tha
 with optional series-level `params`:
 
 ```ts
-type SeriesContent =
+// TData defaults to `any`; annotate the `data` parameter (or pass TData) to type it.
+type SeriesParams<TItemName extends string = string, TData = any> = {
+  skipProgress?: boolean;
+  // Called after each item is submitted with that item's data and its
+  // `{ itemIndex, itemName }`. Return `true` to end the series early: the
+  // remaining items are not administered and the series is marked complete.
+  // The terminating item's own record is still saved.
+  terminate?: (this: void, data: TData, context: { itemIndex: number; itemName: TItemName }) => boolean;
+};
+
+type SeriesContent<TItemName extends string = string, TData = any> =
   | ScalarInstrumentInternal[]
-  | { items: ScalarInstrumentInternal[]; params?: { skipProgress?: boolean } };
+  | { items: ScalarInstrumentInternal[]; params?: SeriesParams<TItemName, TData> };
 
 interface SeriesInstrument<TLanguage extends InstrumentLanguage> extends BaseInstrument<TLanguage> {
   content: SeriesContent;
   internal?: never;
   kind: 'SERIES';
+}
+```
+
+Use `terminate` for conditional early exit — e.g. a consent form as the first item that,
+when declined, prevents the remaining items from being shown. When the series is authored with
+`defineSeriesInstrument`, `itemName` is narrowed to the literal union of the series' item names.
+`data` defaults to `any`, so annotate it inline with the terminating item's data shape:
+
+```ts
+params: {
+  // itemName: 'CONSENT_FORM' | 'QUESTIONNAIRE'
+  terminate: (data: { consent?: boolean }, { itemName }) => itemName === 'CONSENT_FORM' && data.consent === false;
 }
 ```
 

--- a/packages/instrument-guidelines/AGENTS.md
+++ b/packages/instrument-guidelines/AGENTS.md
@@ -180,7 +180,14 @@ with optional series-level `params`:
 
 ```ts
 // TData defaults to `any`; annotate the `data` parameter (or pass TData) to type it.
+// A localized message keyed by language, e.g. `{ en: '…', fr: '…' }`.
+type CompletionMessage = { [L in Language]?: string };
+
 type SeriesParams<TItemName extends string = string, TData = any> = {
+  // Returns a custom localized message for the completion screen, or `null`/`undefined` for the
+  // default. `terminated` is `true` when the series ended early via `terminate`, so the message
+  // can differ per outcome.
+  completionMessage?: (this: void, context: { itemName?: TItemName; terminated: boolean }) => CompletionMessage | null;
   skipProgress?: boolean;
   // Called after each item is submitted with that item's data and its
   // `{ itemIndex, itemName }`. Return `true` to end the series early: the
@@ -209,6 +216,17 @@ when declined, prevents the remaining items from being shown. When the series is
 params: {
   // itemName: 'CONSENT_FORM' | 'QUESTIONNAIRE'
   terminate: (data: { consent?: boolean }, { itemName }) => itemName === 'CONSENT_FORM' && data.consent === false;
+}
+```
+
+Use `completionMessage` to customize the localized text on the final "Thank You" screen — for
+example, to explain that the series ended because consent was declined. Return a `{ en, fr }`
+object (a bare string is treated as a translation key, not literal text), or `null` for the default:
+
+```ts
+params: {
+  completionMessage: ({ terminated }) =>
+    terminated ? { en: 'Because you did not consent, the questionnaire was not administered.', fr: '…' } : null;
 }
 ```
 

--- a/packages/instrument-library/src/forms/DNP_GENERAL_CONSENT_FORM/index.ts
+++ b/packages/instrument-library/src/forms/DNP_GENERAL_CONSENT_FORM/index.ts
@@ -50,6 +50,6 @@ export default defineInstrument({
   },
   measures: null,
   validationSchema: z.object({
-    consent: z.literal(true, { message: 'You must agree to the terms to continue' })
+    consent: z.boolean()
   })
 });

--- a/packages/instrument-library/src/forms/DNP_GENERAL_CONSENT_FORM/index.ts
+++ b/packages/instrument-library/src/forms/DNP_GENERAL_CONSENT_FORM/index.ts
@@ -26,10 +26,20 @@ export default defineInstrument({
         consent: {
           kind: 'boolean',
           label: {
-            en: 'I have read, understand, and agree to the above terms',
-            fr: "J'ai lu, compris et accepté les conditions ci-dessus."
+            en: 'Do you accept the above terms?',
+            fr: 'Acceptez-vous les conditions ci-dessus ?'
           },
-          variant: 'checkbox'
+          options: {
+            en: {
+              false: 'I decline the terms',
+              true: 'I have read, understand, and accept the above terms'
+            },
+            fr: {
+              false: 'Je refuse les conditions',
+              true: "J'ai lu, compris et accepté les conditions ci-dessus"
+            }
+          },
+          variant: 'radio'
         }
       }
     }

--- a/packages/instrument-library/src/series/DNP_HAPPINESS_QUESTIONNAIRE_WITH_CONSENT/index.ts
+++ b/packages/instrument-library/src/series/DNP_HAPPINESS_QUESTIONNAIRE_WITH_CONSENT/index.ts
@@ -47,6 +47,16 @@ export default defineSeriesInstrument({
       // happiness questionnaire is never administered.
       terminate: (data: { consent?: boolean }, { itemName }) => {
         return itemName === 'DNP_GENERAL_CONSENT_FORM' && data.consent === false;
+      },
+      // Explain on the completion screen why the series ended when consent was declined.
+      completionMessage: ({ terminated }) => {
+        if (terminated) {
+          return {
+            en: 'Because you did not consent, the happiness questionnaire was not administered. Thank you for your time.',
+            fr: "Comme vous n'avez pas donné votre consentement, le questionnaire sur le bonheur n'a pas été administré. Merci de votre temps."
+          };
+        }
+        return null;
       }
     }
   }

--- a/packages/instrument-library/src/series/DNP_HAPPINESS_QUESTIONNAIRE_WITH_CONSENT/index.ts
+++ b/packages/instrument-library/src/series/DNP_HAPPINESS_QUESTIONNAIRE_WITH_CONSENT/index.ts
@@ -1,7 +1,6 @@
-import type { SeriesInstrument } from '/runtime/v1/@opendatacapture/runtime-core';
+import { defineSeriesInstrument } from '/runtime/v1/@opendatacapture/runtime-core';
 
-const instrument: SeriesInstrument = {
-  __runtimeVersion: 1,
+export default defineSeriesInstrument({
   kind: 'SERIES',
   language: ['en', 'fr'],
   tags: {
@@ -30,9 +29,6 @@ const instrument: SeriesInstrument = {
     }
   },
   content: {
-    params: {
-      skipProgress: true
-    },
     items: [
       {
         name: 'DNP_GENERAL_CONSENT_FORM',
@@ -42,8 +38,16 @@ const instrument: SeriesInstrument = {
         name: 'DNP_HAPPINESS_QUESTIONNAIRE',
         edition: 1
       }
-    ]
+    ],
+    params: {
+      skipProgress: true,
+      // `itemName` is narrowed to 'DNP_GENERAL_CONSENT_FORM' | 'DNP_HAPPINESS_QUESTIONNAIRE';
+      // `data` defaults to `any`, so it can be annotated inline with the item's data shape.
+      // If the participant declines the general consent form, end the series early so the
+      // happiness questionnaire is never administered.
+      terminate: (data: { consent?: boolean }, { itemName }) => {
+        return itemName === 'DNP_GENERAL_CONSENT_FORM' && data.consent === false;
+      }
+    }
   }
-};
-
-export default instrument;
+});

--- a/packages/react-core/src/components/InstrumentRenderer/SeriesInstrumentRenderer.tsx
+++ b/packages/react-core/src/components/InstrumentRenderer/SeriesInstrumentRenderer.tsx
@@ -62,6 +62,7 @@ export const SeriesInstrumentRenderer = ({
   const scalarState = useInterpretedInstrument(scalarBundle ?? '');
 
   const [isInstrumentInProgress, setIsInstrumentInProgress] = useState(false);
+  const [completion, setCompletion] = useState<null | { itemName?: string; terminated: boolean }>(null);
 
   const params = rootState.status === 'DONE' ? getSeriesInstrumentParams(rootState.instrument.content) : {};
   const skipProgress = params.skipProgress ?? false;
@@ -82,6 +83,9 @@ export const SeriesInstrumentRenderer = ({
       kind: 'SERIES'
     });
 
+    if (isLastItem || shouldTerminate) {
+      setCompletion({ itemName, terminated: shouldTerminate });
+    }
     if (shouldTerminate) {
       setIndex(2);
       return;
@@ -91,6 +95,9 @@ export const SeriesInstrumentRenderer = ({
       setIsInstrumentInProgress(false);
     }
   };
+
+  const completionMessage =
+    params.completionMessage?.({ itemName: completion?.itemName, terminated: completion?.terminated ?? false }) ?? null;
 
   useEffect(() => {
     if (currentItemIndex === target.items.length) {
@@ -194,10 +201,12 @@ export const SeriesInstrumentRenderer = ({
                   })}
                 </Heading>
                 <p className="text-muted-foreground text-sm">
-                  {t({
-                    en: 'You have successfully completed all steps of this instrument.',
-                    fr: 'Vous avez terminé avec succès toutes les étapes de cet instrument.'
-                  })}
+                  {t(
+                    completionMessage ?? {
+                      en: 'You have successfully completed all steps of this instrument.',
+                      fr: 'Vous avez terminé avec succès toutes les étapes de cet instrument.'
+                    }
+                  )}
                 </p>
               </div>
             ))

--- a/packages/react-core/src/components/InstrumentRenderer/SeriesInstrumentRenderer.tsx
+++ b/packages/react-core/src/components/InstrumentRenderer/SeriesInstrumentRenderer.tsx
@@ -63,18 +63,29 @@ export const SeriesInstrumentRenderer = ({
 
   const [isInstrumentInProgress, setIsInstrumentInProgress] = useState(false);
 
-  const skipProgress =
-    rootState.status === 'DONE'
-      ? (getSeriesInstrumentParams(rootState.instrument.content).skipProgress ?? false)
-      : false;
+  const params = rootState.status === 'DONE' ? getSeriesInstrumentParams(rootState.instrument.content) : {};
+  const skipProgress = params.skipProgress ?? false;
 
   const handleSubmit = async ({ data }: FormContentSubmitResult | InteractiveContentSubmitResult) => {
+    const parsedData = JSON.parse(JSON.stringify(data, replacer)) as Json;
+    const isLastItem = currentItemIndex === target.items.length - 1;
+    // `scalarState` is DONE here (its content is what was just submitted); its
+    // `internal.name` gives the item name for the predicate context.
+    const itemName = scalarState.status === 'DONE' ? (scalarState.instrument.internal?.name ?? '') : '';
+    const shouldTerminate = params.terminate?.(parsedData, { itemIndex: currentItemIndex, itemName }) ?? false;
+
     await onSubmit?.({
-      data: JSON.parse(JSON.stringify(data, replacer)) as Json,
+      complete: isLastItem || shouldTerminate,
+      data: parsedData,
       index,
       instrumentId: scalarId!,
       kind: 'SERIES'
     });
+
+    if (shouldTerminate) {
+      setIndex(2);
+      return;
+    }
     setCurrentItemIndex(currentItemIndex + 1);
     if (!skipProgress) {
       setIsInstrumentInProgress(false);

--- a/packages/react-core/src/components/InstrumentRenderer/types.ts
+++ b/packages/react-core/src/components/InstrumentRenderer/types.ts
@@ -27,6 +27,7 @@ export namespace InstrumentSubmitHandler {
   type InteractiveContext = ContextMixin<InteractiveContentSubmitResult>;
 
   type SeriesContext = ContextMixin<{
+    complete: boolean;
     index: number;
     kind: Extract<InstrumentKind, 'SERIES'>;
   }>;

--- a/packages/runtime-core/src/define.ts
+++ b/packages/runtime-core/src/define.ts
@@ -2,7 +2,12 @@
 
 import type { ApprovedLicense } from '@opendatacapture/licenses';
 
-import type { InstrumentKind, InstrumentLanguage, InstrumentValidationSchema } from './types/instrument.base.js';
+import type {
+  InstrumentKind,
+  InstrumentLanguage,
+  InstrumentValidationSchema,
+  ScalarInstrumentInternal
+} from './types/instrument.base.js';
 import type { FileInstrument } from './types/instrument.file.js';
 import type { FormInstrument } from './types/instrument.form.js';
 import type { InteractiveInstrument } from './types/instrument.interactive.js';
@@ -66,10 +71,15 @@ export function defineInstrument<
 }
 
 /** @public */
-export function defineSeriesInstrument<TLanguage extends InstrumentLanguage>(
-  def: Omit<SeriesInstrument<TLanguage>, '__runtimeVersion'>
-): SeriesInstrument<TLanguage> {
+export function defineSeriesInstrument<
+  const TItems extends readonly ScalarInstrumentInternal[],
+  TLanguage extends InstrumentLanguage
+>(
+  def: Omit<SeriesInstrument<TLanguage, TItems[number]['name']>, '__runtimeVersion' | 'content'> & {
+    content: TItems | { items: TItems; params?: SeriesInstrument.Params<TItems[number]['name']> };
+  }
+): SeriesInstrument<TLanguage, TItems[number]['name']> {
   return Object.assign(def, {
     __runtimeVersion: 1 as const
-  });
+  }) as unknown as SeriesInstrument<TLanguage, TItems[number]['name']>;
 }

--- a/packages/runtime-core/src/types/instrument.series.ts
+++ b/packages/runtime-core/src/types/instrument.series.ts
@@ -12,7 +12,25 @@ declare namespace SeriesInstrument {
     itemName: TItemName;
   };
 
+  export type CompletionContext<TItemName extends string = string> = {
+    /** The item after which the series ended (the terminating item, or the final item). */
+    itemName?: TItemName;
+    /** Whether the series ended early because `terminate` returned `true`. */
+    terminated: boolean;
+  };
+
+  /** A localized message; keyed by language (e.g. `{ en, fr }`). */
+  export type CompletionMessage = {
+    [L in Language]?: string;
+  };
+
   export type Params<TItemName extends string = string, TData = any> = {
+    /**
+     * Returns a custom localized `CompletionMessage` to show on the series completion screen, or
+     * `null`/`undefined` to use the default. `context.terminated` indicates whether the series
+     * ended early via `terminate`, allowing a distinct message per outcome.
+     */
+    completionMessage?: (this: void, context: CompletionContext<TItemName>) => CompletionMessage | null | undefined;
     skipProgress?: boolean;
     /**
      * Called after each item is submitted with that item's data and its `{ itemIndex, itemName }`.

--- a/packages/runtime-core/src/types/instrument.series.ts
+++ b/packages/runtime-core/src/types/instrument.series.ts
@@ -7,18 +7,36 @@ import type { BaseInstrument, InstrumentLanguage, ScalarInstrumentInternal } fro
 
 /** @public */
 declare namespace SeriesInstrument {
-  export type Params = {
-    skipProgress?: boolean;
+  export type TerminateContext<TItemName extends string = string> = {
+    itemIndex: number;
+    itemName: TItemName;
   };
 
-  export type Content = ScalarInstrumentInternal[] | { items: ScalarInstrumentInternal[]; params?: Params };
+  export type Params<TItemName extends string = string, TData = any> = {
+    skipProgress?: boolean;
+    /**
+     * Called after each item is submitted with that item's data and its `{ itemIndex, itemName }`.
+     * Return `true` to end the series early. When authored via `defineSeriesInstrument`, `itemName`
+     * is narrowed to the literal union of the series' item names. `data` defaults to `any`; annotate
+     * the parameter (or pass `TData`) to type it as the terminating item's data shape.
+     */
+    terminate?: (this: void, data: TData, context: TerminateContext<TItemName>) => boolean;
+  };
+
+  export type Content<TItemName extends string = string, TData = any> =
+    | ScalarInstrumentInternal[]
+    | { items: ScalarInstrumentInternal[]; params?: Params<TItemName, TData> };
 }
 
 /** @public */
-declare type SeriesInstrument<TLanguage extends InstrumentLanguage = InstrumentLanguage> = Merge<
+declare type SeriesInstrument<
+  TLanguage extends InstrumentLanguage = InstrumentLanguage,
+  TItemName extends string = string,
+  TData = any
+> = Merge<
   BaseInstrument<TLanguage>,
   {
-    content: SeriesInstrument.Content;
+    content: SeriesInstrument.Content<TItemName, TData>;
     internal?: never;
     kind: 'SERIES';
   }

--- a/packages/schemas/src/instrument/__tests__/instrument.series.test.ts
+++ b/packages/schemas/src/instrument/__tests__/instrument.series.test.ts
@@ -1,0 +1,32 @@
+import { seriesInstrument } from '@opendatacapture/instrument-stubs/series';
+import { describe, expect, it } from 'vitest';
+
+import { $SeriesInstrument } from '../instrument.series.js';
+
+describe('$SeriesInstrument', () => {
+  it('should successfully parse a valid series instrument', () => {
+    expect($SeriesInstrument.safeParse(seriesInstrument.instance).success).toBe(true);
+  });
+
+  it('should accept a function as the terminate param', () => {
+    const instance = {
+      ...seriesInstrument.instance,
+      content: {
+        items: [{ edition: 1, name: 'HAPPINESS_QUESTIONNAIRE' }],
+        params: { terminate: () => true }
+      }
+    };
+    expect($SeriesInstrument.safeParse(instance).success).toBe(true);
+  });
+
+  it('should reject a non-function terminate param', () => {
+    const instance = {
+      ...seriesInstrument.instance,
+      content: {
+        items: [{ edition: 1, name: 'HAPPINESS_QUESTIONNAIRE' }],
+        params: { terminate: 'nope' }
+      }
+    };
+    expect($SeriesInstrument.safeParse(instance).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/instrument/__tests__/instrument.series.test.ts
+++ b/packages/schemas/src/instrument/__tests__/instrument.series.test.ts
@@ -19,6 +19,28 @@ describe('$SeriesInstrument', () => {
     expect($SeriesInstrument.safeParse(instance).success).toBe(true);
   });
 
+  it('should accept a function as the completionMessage param', () => {
+    const instance = {
+      ...seriesInstrument.instance,
+      content: {
+        items: [{ edition: 1, name: 'HAPPINESS_QUESTIONNAIRE' }],
+        params: { completionMessage: () => ({ en: 'Done' }) }
+      }
+    };
+    expect($SeriesInstrument.safeParse(instance).success).toBe(true);
+  });
+
+  it('should reject a non-function completionMessage param', () => {
+    const instance = {
+      ...seriesInstrument.instance,
+      content: {
+        items: [{ edition: 1, name: 'HAPPINESS_QUESTIONNAIRE' }],
+        params: { completionMessage: { en: 'Done' } }
+      }
+    };
+    expect($SeriesInstrument.safeParse(instance).success).toBe(false);
+  });
+
   it('should reject a non-function terminate param', () => {
     const instance = {
       ...seriesInstrument.instance,

--- a/packages/schemas/src/instrument/instrument.series.ts
+++ b/packages/schemas/src/instrument/instrument.series.ts
@@ -1,10 +1,11 @@
 import type { InstrumentLanguage, SeriesInstrument } from '@opendatacapture/runtime-core';
 import { z } from 'zod/v4';
 
-import { $$BaseInstrument, $ScalarInstrumentInternal } from './instrument.base.js';
+import { $$BaseInstrument, $AnyDynamicFunction, $ScalarInstrumentInternal } from './instrument.base.js';
 
 const $SeriesInstrumentParams = z.object({
-  skipProgress: z.boolean().optional()
+  skipProgress: z.boolean().optional(),
+  terminate: $AnyDynamicFunction.optional()
 }) satisfies z.ZodType<SeriesInstrument.Params>;
 
 const $SeriesInstrumentContent = z.union([

--- a/packages/schemas/src/instrument/instrument.series.ts
+++ b/packages/schemas/src/instrument/instrument.series.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4';
 import { $$BaseInstrument, $AnyDynamicFunction, $ScalarInstrumentInternal } from './instrument.base.js';
 
 const $SeriesInstrumentParams = z.object({
+  completionMessage: $AnyDynamicFunction.optional(),
   skipProgress: z.boolean().optional(),
   terminate: $AnyDynamicFunction.optional()
 }) satisfies z.ZodType<SeriesInstrument.Params>;


### PR DESCRIPTION
## Summary

Adds conditional early-termination support to **SERIES** instruments, along with the supporting renderer, gateway, and API changes needed to make it work end-to-end (in-person and remote assignments).

### Series feature
- **`terminate` predicate** (`params.terminate`): called after each item is submitted; returning `true` ends the series early so the remaining items are never administered. The terminating item's own record is still saved. Example use: a consent form as the first item that, when declined, skips the rest.
- **`completionMessage`** (`params.completionMessage`): returns a custom localized (`{ en, fr }`) message for the completion screen, or `null` for the default. Receives `{ terminated, itemName }` so the message can differ on early exit (e.g. "the questionnaire was not administered because you did not consent").
- **Typed authoring via generics**: `defineSeriesInstrument` now infers the item-name literal union, so `terminate`/`completionMessage` receive a strongly-typed `itemName`. Item `data` is a generic defaulting to `any`, so it can be annotated inline without a cast.

### Renderer / gateway
- `SeriesInstrumentRenderer` evaluates `terminate`, jumps to the completion screen on early exit, renders the custom `completionMessage`, and emits a new `complete` flag on the submit payload.
- Gateway (`Root.tsx`) marks a remote assignment `COMPLETE` via the `complete` flag instead of comparing against the last item's id, so early termination completes the assignment correctly.

### API synchronizer (`gateway.synchronizer.ts`)
- **Fix**: a completed series may now contain fewer records than items (an early-terminated prefix); previously the sync threw on a strict length mismatch. Validation now accepts a non-empty prefix and checks cipher-text/symmetric-key counts against each other.
- **Better error logging**: per-step failure logs (decrypt / parse / create) that identify the failing instrument and include the relevant payload, replacing an unreadable dump of the whole assignment (which also leaked the private key and large base64 blobs).

### Consent form
- `DNP_GENERAL_CONSENT_FORM`: changed the consent field from a checkbox to an accept/decline **radio**, and relaxed its schema from `z.literal(true)` to `z.boolean()` so a decline is submittable (which drives the new early-exit demo in `DNP_HAPPINESS_QUESTIONNAIRE_WITH_CONSENT`).

### Docs / tests
- Documented `terminate` and `completionMessage` in `packages/instrument-guidelines/AGENTS.md`.
- Added schema tests for the new `params` (`instrument.series.test.ts`).
- Added `CLAUDE.md`.

## Verification
- `pnpm lint` and `pnpm test` pass (36 test files, 244 passed / 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)