### PR TITLE
fix(api): explicitly inject S3Client into StorageService

### DIFF
--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ConfigService } from '@douglasneuroinformatics/libnest';
-import { Injectable, Optional, ServiceUnavailableException } from '@nestjs/common';
+import { Inject, Injectable, Optional, ServiceUnavailableException } from '@nestjs/common';
 import type { OnModuleInit } from '@nestjs/common';
 import type { $FileLocation, $PresignedUrlInfo } from '@opendatacapture/schemas/storage';
 
@@ -28,7 +28,7 @@ export class StorageService implements OnModuleInit {
 
   constructor(
     private readonly configService: ConfigService,
-    @Optional() private readonly s3: null | S3Client
+    @Optional() @Inject(S3Client) private readonly s3: null | S3Client
   ) {
     this.enabled = !!this.configService.get('STORAGE_ENABLED');
     this.bucket = this.configService.get('STORAGE_BUCKET');


### PR DESCRIPTION
## Summary

`StorageService` never actually receives its `S3Client`, so **the API crash-loops on startup whenever `STORAGE_ENABLED=true`**. This makes any storage-enabled deployment (self-hosted rustfs/MinIO, file instruments, etc.) unusable. The fix is a one-line DI annotation.

## Symptom

With `STORAGE_ENABLED=true`, the `api` container restarts continuously. Logs show:

```
ServiceUnavailableException: File storage is not configured
    at StorageService.requireStorage (/app/src/storage/storage.service.ts:97:19)
    at StorageService.onModuleInit (/app/src/storage/storage.service.ts:78:37)
  response: { message: 'File storage is not configured', error: 'Service Unavailable', statusCode: 503 }
```

The environment is fully configured — `STORAGE_ENABLED`, `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`, `STORAGE_BUCKET`, and `STORAGE_ENDPOINT` are all present in the container — yet `requireStorage()` reports storage as unconfigured.

## Root cause

`requireStorage()` throws when `!this.enabled || !this.s3 || !this.bucket`. Since `onModuleInit()` only reaches `requireStorage()` after passing its own `if (!this.enabled ...) return` guard, `enabled` is truthy and `bucket` is set — so **`this.s3` is `null`**.

`this.s3` is the injected `S3Client`. The constructor parameter is:

```ts
constructor(
  private readonly configService: ConfigService,
  @Optional() private readonly s3: null | S3Client
) { ... }
```

The parameter type is the union **`null | S3Client`**. TypeScript emits the reflected `design:paramtypes` metadata for a `null | X` union as **`Object`**, not `X`. Confirmed in the compiled bundle:

```js
StorageService = _ts_decorate([
  Injectable(),
  _ts_param(1, Optional()),
  _ts_metadata("design:paramtypes", [
    ConfigService,
    Object            // <-- s3 param: erased to Object, not S3Client
  ])
]);
```

Nest therefore has no usable token to resolve the parameter by type. Because the parameter is `@Optional()`, Nest does not error — it **silently injects `null`**. The `S3Client` provider registered in `StorageModule` is never wired into `StorageService`, so `this.s3` is *always* `null`, independent of configuration. The factory that builds the real client (gated on `STORAGE_ENABLED`) runs fine; its result is just never delivered.

## Fix

Add an explicit `@Inject(S3Client)` so Nest resolves the parameter by token rather than by the union-erased design type:

```ts
@Optional() @Inject(S3Client) private readonly s3: null | S3Client
```

The nullable type is retained on purpose: the provider legitimately returns `null` when `STORAGE_ENABLED` is false, and `@Optional()` remains correct for that case.

## Verification

Built the production `api` image from this branch and ran the full docker-compose stack with `STORAGE_ENABLED=true` against a rustfs backend:

- **Before:** `api` in `Restarting` state, looping on `ServiceUnavailableException: File storage is not configured`.
- **After:** `api` stays `Up`; no storage error; `GET /api/v1/setup` returns `{"release":{"type":"production","version":"2.1.2"}, ...}` and the bucket is created/verified on init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)