### PR TITLE
feat(react-core): validate scalar submissions against the instrument schema

### DIFF
--- a/packages/react-core/src/components/InstrumentRenderer/ScalarInstrumentRenderer.tsx
+++ b/packages/react-core/src/components/InstrumentRenderer/ScalarInstrumentRenderer.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from 'react';
 
 import { replacer } from '@douglasneuroinformatics/libjs';
 import { Spinner } from '@douglasneuroinformatics/libui/components';
-import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { InterpretOptions } from '@opendatacapture/instrument-interpreter';
-import type { AnyScalarInstrument } from '@opendatacapture/runtime-core';
+import type { AnyScalarInstrument, AnyUnilingualScalarInstrument, Json } from '@opendatacapture/runtime-core';
 import type { ScalarInstrumentBundleContainer } from '@opendatacapture/schemas/instrument';
 import { match } from 'ts-pattern';
 
@@ -17,6 +17,7 @@ import { InstrumentSummary } from '../InstrumentSummary';
 import { InteractiveContent } from '../InteractiveContent';
 import { ContentPlaceholder } from './ContentPlaceholder';
 import { InstrumentRendererContainer } from './InstrumentRendererContainer';
+import { validateSubmission } from './validateSubmission';
 
 import type { SubjectDisplayInfo } from '../../types';
 import type { NavigationBlockerComponent } from '../NavigationBlockerDialog';
@@ -53,11 +54,27 @@ export const ScalarInstrumentRenderer = ({
   target
 }: ScalarInstrumentRendererProps) => {
   const [data, setData] = useState<unknown>();
-  const interpreted = useInterpretedInstrument(target.bundle, options);
+  const interpreted = useInterpretedInstrument<AnyUnilingualScalarInstrument>(target.bundle, options);
   const [index, setIndex] = useState<0 | 1 | 2>(0);
   const { t } = useTranslation();
+  const addNotification = useNotificationsStore((store) => store.addNotification);
 
   const handleSubmit = async ({ data, ...result }: AnyContentResult) => {
+    if (interpreted.status === 'DONE') {
+      const serializedData = JSON.parse(JSON.stringify(data, replacer)) as Json;
+      const validationResult = validateSubmission(interpreted.instrument, serializedData);
+      if (!validationResult.success) {
+        console.error(validationResult.issues);
+        addNotification({
+          message: t({
+            en: 'The information submitted is invalid and cannot be saved. Please contact the platform administrator.',
+            fr: "Les informations soumises sont invalides et ne peuvent pas être enregistrées. Veuillez contacter l'administrateur de la plateforme."
+          }),
+          type: 'error'
+        });
+        return;
+      }
+    }
     await onSubmit?.({
       ...result,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/react-core/src/components/InstrumentRenderer/SeriesInstrumentRenderer.tsx
+++ b/packages/react-core/src/components/InstrumentRenderer/SeriesInstrumentRenderer.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from 'react';
 
 import { replacer } from '@douglasneuroinformatics/libjs';
 import { Button, Heading, Spinner } from '@douglasneuroinformatics/libui/components';
-import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import { getSeriesInstrumentParams } from '@opendatacapture/instrument-utils';
-import type { Json, UnilingualSeriesInstrument } from '@opendatacapture/runtime-core';
+import type { AnyUnilingualScalarInstrument, Json, UnilingualSeriesInstrument } from '@opendatacapture/runtime-core';
 import type { SeriesInstrumentBundleContainer } from '@opendatacapture/schemas/instrument';
 import { CircleCheckIcon } from 'lucide-react';
 import { match } from 'ts-pattern';
@@ -16,6 +16,7 @@ import { InstrumentOverview } from '../InstrumentOverview';
 import { InteractiveContent } from '../InteractiveContent';
 import { ContentPlaceholder } from './ContentPlaceholder';
 import { InstrumentRendererContainer } from './InstrumentRendererContainer';
+import { validateSubmission } from './validateSubmission';
 
 import type { SubjectDisplayInfo } from '../../types';
 import type { FormContentSubmitResult } from '../FormContent';
@@ -54,12 +55,13 @@ export const SeriesInstrumentRenderer = ({
     return initialSeriesIndex;
   });
   const { t } = useTranslation();
+  const addNotification = useNotificationsStore((store) => store.addNotification);
 
   const scalarBundle = target.items[currentItemIndex]?.bundle;
   const scalarId = target.items[currentItemIndex]?.id;
 
   const rootState = useInterpretedInstrument<UnilingualSeriesInstrument>(target.bundle);
-  const scalarState = useInterpretedInstrument(scalarBundle ?? '');
+  const scalarState = useInterpretedInstrument<AnyUnilingualScalarInstrument>(scalarBundle ?? '');
 
   const [isInstrumentInProgress, setIsInstrumentInProgress] = useState(false);
   const [completion, setCompletion] = useState<null | { itemName?: string; terminated: boolean }>(null);
@@ -69,6 +71,20 @@ export const SeriesInstrumentRenderer = ({
 
   const handleSubmit = async ({ data }: FormContentSubmitResult | InteractiveContentSubmitResult) => {
     const parsedData = JSON.parse(JSON.stringify(data, replacer)) as Json;
+    if (scalarState.status === 'DONE') {
+      const validationResult = validateSubmission(scalarState.instrument, parsedData);
+      if (!validationResult.success) {
+        console.error(validationResult.issues);
+        addNotification({
+          message: t({
+            en: 'The information submitted is invalid and cannot be saved. Please contact the platform administrator.',
+            fr: "Les informations soumises sont invalides et ne peuvent pas être enregistrées. Veuillez contacter l'administrateur de la plateforme."
+          }),
+          type: 'error'
+        });
+        return;
+      }
+    }
     const isLastItem = currentItemIndex === target.items.length - 1;
     // `scalarState` is DONE here (its content is what was just submitted); its
     // `internal.name` gives the item name for the predicate context.

--- a/packages/react-core/src/components/InstrumentRenderer/validateSubmission.ts
+++ b/packages/react-core/src/components/InstrumentRenderer/validateSubmission.ts
@@ -1,0 +1,23 @@
+import { reviver } from '@douglasneuroinformatics/libjs';
+import type { AnyUnilingualScalarInstrument, Json } from '@opendatacapture/runtime-core';
+
+export type SubmissionValidationResult = { issues: unknown; success: false } | { success: true };
+
+/**
+ * Validate serialized submission data against a scalar instrument's validation schema, mirroring the
+ * check the API performs before ingesting a record (see `InstrumentRecordsService`). The data is
+ * round-tripped through the `reviver` so serialized types (e.g. `Set`, `Date`) are reconstructed
+ * into the shape the schema expects — exactly as the API does prior to validating. The gateway
+ * cannot evaluate the bundle to run this check itself (it is internet-facing, unlike the API), so
+ * this is the last opportunity to reject nonconforming data before it is encrypted and submitted.
+ */
+export function validateSubmission(
+  instrument: AnyUnilingualScalarInstrument,
+  serializedData: Json
+): SubmissionValidationResult {
+  const result = instrument.validationSchema.safeParse(JSON.parse(JSON.stringify(serializedData), reviver));
+  if (result.success) {
+    return { success: true };
+  }
+  return { issues: result.error.issues, success: false };
+}


### PR DESCRIPTION
## Context

When a remote assignment is completed on the gateway, the submitted data is encrypted and stored, then later ingested by the API — which validates it against the instrument's `validationSchema` (`InstrumentRecordsService`). If the data doesn't conform, ingestion fails, and because the gateway is internet-facing (unlike the firewalled API) it cannot evaluate the bundle to catch this itself.

Auditing the client submit paths, only **forms** were actually validated against `validationSchema` before submission — the libui `Form` runs `validationSchema.safeParseAsync` and blocks on failure. **Interactive** instruments submit their task's `done(...)` output after only a `$Json` shape check, so nonconforming interactive data reaches the gateway and then fails indefinitely at API sync. (File instruments use `validationSchema: z.any()`, so there is nothing to enforce.)

## Change

Validate every scalar submission against the instrument's `validationSchema` at the renderer chokepoint — `ScalarInstrumentRenderer` and `SeriesInstrumentRenderer` `handleSubmit` — before the data is encrypted and sent. On failure the submission is blocked, the zod issues are logged, and the user gets an error notification (EN/FR).

- The check lives in the browser, where the bundle has **already** been interpreted to render the instrument, so no bundle evaluation is added and the gateway never has to run untrusted instrument code.
- Data is round-tripped through the libjs `reviver` (`validateSubmission.ts`) so serialized types (`Set`, `Date`) are reconstructed into the exact shape the API validates — a valid `Set` field is not falsely rejected.
- The guard runs uniformly for all scalar kinds: redundant-but-harmless for forms (and it validates the post-serialization shape the API actually sees), a no-op for `z.any()` files, and the real coverage for interactive.
- The two renderers are independent submit paths (a series renders `FormContent`/`InteractiveContent` directly, not via `ScalarInstrumentRenderer`), so each needs its own guard.

## Note on scope / limitations

This is a **client-side** check. It cannot stop a malicious client that bypasses the JS from PATCHing arbitrary data — server-side enforcement was deliberately ruled out because it would require the internet-facing gateway to evaluate untrusted bundles. What it reliably prevents is the real-world case: a well-behaved participant whose interactive task produced data that doesn't match the schema, which previously succeeded silently and then failed forever at sync. The API remains the source of truth and still validates on ingestion.

## Testing

- `pnpm lint` (all packages) and `pnpm test` (251 passed, 1 skipped) pass.
- Verified `validateSubmission` against a **real bundled** library instrument (`DNP_HAPPINESS_QUESTIONNAIRE`): conforming data accepted; wrong-type, out-of-range, and missing-required-field all rejected; a valid `Set` field round-trips through the reviver and is accepted while an invalid enum member inside it is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)