### PR TITLE
refactor(api): drop the instrument edition fallback during gateway sync

### DIFF
--- a/apps/api/src/gateway/__tests__/gateway.synchronizer.spec.ts
+++ b/apps/api/src/gateway/__tests__/gateway.synchronizer.spec.ts
@@ -24,7 +24,6 @@ vi.mock('@douglasneuroinformatics/libcrypto', () => ({
 }));
 
 const CURRENT_EDITION_ID = 'instrument-edition-1';
-const LATEST_EDITION_ID = 'instrument-edition-2';
 
 describe('GatewaySynchronizer', () => {
   let gatewaySynchronizer: GatewaySynchronizer;
@@ -82,7 +81,6 @@ describe('GatewaySynchronizer', () => {
       internal: { edition: 1, name: 'HAPPINESS_QUESTIONNAIRE' },
       kind: 'FORM'
     });
-    instrumentsService.findLatestScalarEditionId.mockResolvedValue(CURRENT_EDITION_ID);
     sessionsService.create.mockResolvedValue({ id: 'session-1' });
     vi.mocked(HybridCrypto).decrypt.mockResolvedValue(JSON.stringify({ score: 1 }));
   });
@@ -98,28 +96,10 @@ describe('GatewaySynchronizer', () => {
       expect(instrumentRecordsService.create).toHaveBeenCalledWith(
         expect.objectContaining({ instrumentId: CURRENT_EDITION_ID })
       );
-      expect(instrumentsService.findLatestScalarEditionId).not.toHaveBeenCalled();
       expect(gatewayService.deleteRemoteAssignment).toHaveBeenCalledWith('assignment-1');
     });
 
-    it('should retry against the latest edition when the data fails validation', async () => {
-      gatewayService.fetchRemoteAssignments.mockResolvedValue([createRemoteAssignment('assignment-1')]);
-      instrumentsService.findLatestScalarEditionId.mockResolvedValue(LATEST_EDITION_ID);
-      instrumentRecordsService.create
-        .mockRejectedValueOnce(new UnprocessableEntityException('Data received for record does not pass validation'))
-        .mockResolvedValueOnce({ id: 'record-1' });
-
-      await gatewaySynchronizer.sync();
-
-      expect(instrumentRecordsService.create).toHaveBeenCalledTimes(2);
-      expect(instrumentRecordsService.create).toHaveBeenLastCalledWith(
-        expect.objectContaining({ instrumentId: LATEST_EDITION_ID })
-      );
-      expect(instrumentRecordsService.deleteById).not.toHaveBeenCalled();
-      expect(gatewayService.deleteRemoteAssignment).toHaveBeenCalledWith('assignment-1');
-    });
-
-    it('should not retry when the data fails validation and there is no newer edition', async () => {
+    it('should not delete the remote assignment when the data fails validation', async () => {
       gatewayService.fetchRemoteAssignments.mockResolvedValue([createRemoteAssignment('assignment-1')]);
       instrumentRecordsService.create.mockRejectedValue(new UnprocessableEntityException('Failed validation'));
 

--- a/apps/api/src/gateway/gateway.synchronizer.ts
+++ b/apps/api/src/gateway/gateway.synchronizer.ts
@@ -1,6 +1,6 @@
 import { HybridCrypto } from '@douglasneuroinformatics/libcrypto';
 import { ConfigService, LoggingService } from '@douglasneuroinformatics/libnest';
-import { Injectable, InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import type { OnApplicationBootstrap } from '@nestjs/common';
 import { getSeriesInstrumentItems } from '@opendatacapture/instrument-utils';
 import type { ScalarInstrumentInternal } from '@opendatacapture/runtime-core';
@@ -139,10 +139,9 @@ export class GatewaySynchronizer implements OnApplicationBootstrap {
       for (let i = 0; i < cipherTexts.length; i++) {
         const cipherText = cipherTexts[i]!;
         const symmetricKey = symmetricKeys[i]!;
-        const internal = instrument.kind === 'SERIES' ? seriesItems![i]! : instrument.internal;
         const instrumentId =
           instrument.kind === 'SERIES'
-            ? this.instrumentsService.generateScalarInstrumentId({ internal })
+            ? this.instrumentsService.generateScalarInstrumentId({ internal: seriesItems![i]! })
             : instrument.id;
         let decryptedData: string;
         try {
@@ -164,38 +163,16 @@ export class GatewaySynchronizer implements OnApplicationBootstrap {
           throw err;
         }
 
-        const createRecord = (instrumentId: string) => {
-          return this.instrumentRecordsService.create({
+        try {
+          const record = await this.instrumentRecordsService.create({
             assignmentId: assignment.id,
             data,
-            date: remoteAssignment.completedAt!,
+            date: remoteAssignment.completedAt,
             groupId: assignment.groupId ?? undefined,
             instrumentId,
             sessionId: session.id,
             subjectId: assignment.subjectId
           });
-        };
-
-        try {
-          let record: Awaited<ReturnType<typeof createRecord>>;
-          try {
-            record = await createRecord(instrumentId);
-          } catch (err) {
-            // The data may have been submitted against an instrument whose validation schema was
-            // since corrected in a subsequent edition, in which case it can only be ingested by
-            // validating it against that edition instead.
-            if (!(err instanceof UnprocessableEntityException)) {
-              throw err;
-            }
-            const latestId = await this.instrumentsService.findLatestScalarEditionId({ internal });
-            if (latestId === instrumentId) {
-              throw err;
-            }
-            this.loggingService.warn(
-              `Data for instrument '${internal.name}' (edition ${internal.edition}) failed validation against its own schema; retrying against the latest edition with id '${latestId}'`
-            );
-            record = await createRecord(latestId);
-          }
           this.loggingService.log(`Created record with ID: ${record.id}`);
           createdRecordIds.push(record.id);
         } catch (err) {

--- a/apps/api/src/instruments/__tests__/instruments.service.spec.ts
+++ b/apps/api/src/instruments/__tests__/instruments.service.spec.ts
@@ -9,7 +9,6 @@ import { InstrumentsService } from '../instruments.service';
 
 describe('InstrumentsService', () => {
   let instrumentsService: InstrumentsService;
-  let cryptoService: MockedInstance<CryptoService>;
   let instrumentModel: MockedInstance<Model<'Instrument'>>;
 
   beforeEach(async () => {
@@ -24,36 +23,11 @@ describe('InstrumentsService', () => {
       ]
     }).compile();
     instrumentsService = moduleRef.get(InstrumentsService);
-    cryptoService = moduleRef.get(CryptoService);
     instrumentModel = moduleRef.get(getModelToken('Instrument'));
   });
 
   it('should be defined', () => {
     expect(instrumentsService).toBeDefined();
     expect(instrumentModel).toBeDefined();
-  });
-
-  describe('findLatestScalarEditionId', () => {
-    const internal = { edition: 1, name: 'HAPPINESS_QUESTIONNAIRE' };
-
-    beforeEach(() => {
-      cryptoService.hash.mockImplementation((value: string) => `hash(${value})`);
-    });
-
-    it('should return the id of the provided edition, if no later edition exists', async () => {
-      instrumentModel.exists.mockResolvedValue(false);
-      await expect(instrumentsService.findLatestScalarEditionId({ internal })).resolves.toBe(
-        'hash(HAPPINESS_QUESTIONNAIRE-1)'
-      );
-    });
-
-    it('should return the id of the latest edition, if multiple later editions exist', async () => {
-      instrumentModel.exists.mockImplementation(({ id }: { id: string }) => {
-        return Promise.resolve(id === 'hash(HAPPINESS_QUESTIONNAIRE-2)' || id === 'hash(HAPPINESS_QUESTIONNAIRE-3)');
-      });
-      await expect(instrumentsService.findLatestScalarEditionId({ internal })).resolves.toBe(
-        'hash(HAPPINESS_QUESTIONNAIRE-3)'
-      );
-    });
   });
 });

--- a/apps/api/src/instruments/instruments.service.ts
+++ b/apps/api/src/instruments/instruments.service.ts
@@ -213,23 +213,6 @@ export class InstrumentsService {
     return Array.from(results.values());
   }
 
-  /**
-   * Resolve the id of the most recent edition of a scalar instrument. Since the id is derived from
-   * the name and edition, successive editions can be probed without instantiating any bundle.
-   */
-  async findLatestScalarEditionId({ internal: { edition, name } }: Pick<AnyScalarInstrument, 'internal'>) {
-    let latestId = this.generateScalarInstrumentId({ internal: { edition, name } });
-    let nextEdition = edition + 1;
-    while (true) {
-      const nextId = this.generateScalarInstrumentId({ internal: { edition: nextEdition, name } });
-      if (!(await this.instrumentModel.exists({ id: nextId }))) {
-        return latestId;
-      }
-      latestId = nextId;
-      nextEdition++;
-    }
-  }
-
   generateInstrumentId(instrument: AnyInstrument) {
     if (isScalarInstrument(instrument)) {
       return this.generateScalarInstrumentId(instrument);


### PR DESCRIPTION
Silently revalidating submitted data against a newer edition attributed records to a form the subject never saw. Keep only the resilience fixes, so a record that fails validation no longer aborts the sync of every other assignment.