### PR TITLE
fix(api): keep an uploaded file instrument record pending

### DIFF
--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -240,13 +240,29 @@ describe('InstrumentRecordsService', () => {
       expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: undefined }));
     });
 
-    // `pending` is intentionally not written on create; the find-side OR filter treats missing and
-    // false `pending` alike (see the 'find' describe block), so records stay query-visible without it.
     it('should create records via createMany with the processed record data', async () => {
       await instrumentRecordsService.upload({ ...baseUploadData });
 
       expect(instrumentRecordModel.createMany).toHaveBeenCalledWith({
         data: [expect.objectContaining({ instrumentId: 'instrument-1', subjectId: 'subject-1' })]
+      });
+    });
+
+    it('should settle a form instrument record, since an upload carries its data in full', async () => {
+      await instrumentRecordsService.upload({ ...baseUploadData });
+
+      expect(instrumentRecordModel.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ pending: false })]
+      });
+    });
+
+    it('should leave a file instrument record pending, so its files can still be attached', async () => {
+      instrumentsService.findById.mockResolvedValue({ ...mockInstrument, kind: 'FILE' } as any);
+
+      await instrumentRecordsService.upload({ ...baseUploadData });
+
+      expect(instrumentRecordModel.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ pending: true })]
       });
     });
   });

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -445,7 +445,7 @@ export class InstrumentRecordsService {
             date,
             groupId,
             instrumentId,
-            pending: false,
+            pending: instrument.kind === 'FILE',
             sessionId: session.id,
             subjectId
           };


### PR DESCRIPTION
This is the test failure I've been flagging as pre-existing in #1418, #1419, #1420 and #1421. It turns out to be a real defect, not a stale test.

## What happened

`InstrumentRecordsService.upload` builds its records without a `pending` field at all, so every bulk-uploaded record is persisted with the field **absent** rather than `false`.

PR #1404 ("fix pending tag issue which cause old data not to be visible") fixed the resulting invisibility by teaching `find` to match records where the field is missing:

```ts
// records created before the file instrument feature do not have the pending field at all,
// and prisma NOT filters on mongodb exclude documents where the field is missing entirely
{ OR: [{ pending: { isSet: false } }, { pending: null }, { pending: false }] }
```

and in the same commit added a test asserting that `upload` sets `pending` — but never made that change to `upload`. **The test has been red on `main` since that PR merged** (`8998d811d`).

So the test was correct and expressed the intent; the production half of the fix was simply missing.

## Why it still matters

The comment on the compatibility clause says it exists for *"records created before the file instrument feature"*. But because `upload` still omits the field, that clause is not a legacy shim — it is load-bearing for **newly created data**, and any query that filters on `pending` the natural way silently misses every uploaded record.

Confirmed against a live instance, before the fix:

```
record exists:                            true
has pending field:                        false
matched by a plain {pending:false} query: 0
matched by the compat OR clause:          1
```

## Why this mirrors `create` instead of hardcoding `false`

My first cut was `pending: false`, which is literally what the test asserts. Then I checked whether `upload` can receive a **file** instrument — it does not reject them the way it rejects series instruments — and it can:

```
upload of a FILE instrument: HTTP 201
persisted: 1
```

Hardcoding `false` would therefore mark a record with no attached files as complete, and `FilesService.getAssociations` would then reject any attempt to attach them with `Upload already completed`. So this uses the same expression `create` already uses one function above:

```ts
pending: instrument.kind === 'FILE',
```

which satisfies the test (its fixture is a `FORM`) and keeps the two creation paths consistent.

## Verified live, after the fix

```
form upload      pending = false     visible in the datahub
file upload      pending = true      correctly excluded until its files arrive
main behaviour   pending = ABSENT    still visible via the compatibility clause
```

No regression for existing data: records created before this change are still matched by the `isSet: false` clause, which stays exactly as it is.

## Tests

The existing test now passes. Added one covering the file-instrument branch, so the `create`/`upload` consistency is pinned rather than incidental.

**`vitest run` across the whole workspace is now fully green — 37/37 files, 254 passed, 1 skipped, 0 failed.** It has had this one failure throughout.

- `tsc --noEmit` on `apps/api` — clean
- `eslint src` — clean
- `prettier --check` — clean

## Note

While verifying this I re-confirmed the separate issue filed as #1414: `upload`'s return value is `findMany({ groupId, instrumentId })`, so uploading one record returned all 8 records for that instrument. Not touched here.

---

## Rebased onto `main` — the scope is now much narrower than this title suggests

Rebased onto `26ec89168`; conflict resolved, CI green.

You were right that this needed deciding rather than replaying, but the history is not quite
"`main` took the opposite approach". Reconstructing it:

- When `722f0a0b0` reframed the create-side test, `upload` genuinely did not write `pending` — I
  confirmed at `722f0a0b0^` that only `create` did. So that reasoning was correct at the time.
- Separately and on a different branch, `573f307c9` ("resolve series regressions after main merge")
  added `pending: false` to `upload`. It reached `main` **after** the test was reframed, so nothing
  re-asserted it.

Net effect on today's `main`: `upload` writes `pending: false` unconditionally, and no test covers it.
So the "write the field at all" half of this PR has already arrived by another route. **What remains
is only the FILE case**, which is still a real defect:

| | `create` | `upload` on `main` | this branch |
|---|---|---|---|
| FORM | `false` | `false` | `false` |
| FILE | `true` | `false` ❌ | `true` |

`FilesService` clears `pending` once the upload lands, and refuses to attach a file to a record that
is not pending — so a bulk-uploaded file record is born settled and its files can never be attached.
`upload` does not reject file instruments the way it rejects series instruments; verified live, a
file instrument upload returns 201.

The diff is now one expression plus its tests, and the title and commit message were rewritten to say
so. The comment `722f0a0b0` left on the create-side test is corrected, since on this branch it
asserts the opposite of what the code does, and the FORM case gets its assertion back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZEJLwa7jwD8sKzcE4PfSc
