### PR TITLE
fix(api): resolve the instrument subject filter without a relation join

### DIFF
--- a/.agents/docs/architecture/auth-and-permissions.md
+++ b/.agents/docs/architecture/auth-and-permissions.md
@@ -70,6 +70,16 @@ available in this codebase. Check the `where` clause of every query you add or t
 that the controller actually forwards `@CurrentUser('ability')` — `EntityOperationOptions.ability`
 is optional, so a controller that simply never passes it compiles and runs.
 
+**A defined ability holding no rule for the queried subject does not produce a deny-all filter —
+CASL's `accessibleBy` throws `ForbiddenError`.** That error is not an `HttpException`, so the
+global exception filter renders it as a 500. It is reachable whenever the route guard names a
+different subject than the service queries: a STANDARD user passes a `read Instrument` guard but
+holds no rule on `InstrumentRecord`, so a record query made on their behalf throws. The throw is
+deliberate — `accessibleQuery` is kept as-is rather than returning a deny-all filter — so where
+such a caller is legitimate, guard the query with `ability.can(action, subject)` and return the
+empty result instead; `findInstrumentIdsBySubject` in `src/instruments/instruments.service.ts` is
+the reference example.
+
 One call site uses `{ ...accessibleQuery(...), id: subjectId }` instead of `AND: [...]`
 (`src/subjects/subjects.service.ts`). Spreading merges keys and will silently lose a condition if
 the generated query and the literal share one. Prefer `AND`.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -83,6 +83,14 @@ restriction**, which reads clinical data across every group. Nothing catches thi
 eslint, not a passing test suite. It is the single highest-severity mistake available in this
 codebase, so verify the `where` clause of any query you add or edit.
 
+The defined case has the opposite failure mode: **an ability holding no rule at all for the queried
+subject makes `accessibleQuery` throw CASL's `ForbiddenError`**, which is not an `HttpException`
+and so surfaces as a 500. This is reachable whenever a route's guard names one subject but the
+service queries another — a STANDARD user passes `read Instrument` yet holds no `read` rule on
+`InstrumentRecord`. That behaviour is deliberate and stays; where such a caller is legitimate,
+short-circuit before the query with `ability.can(action, subject)` and return the empty result —
+see `findInstrumentIdsBySubject` in `src/instruments/instruments.service.ts`.
+
 Granting a new `action`/`subject` pair means editing `src/auth/ability.factory.ts` and adding tests
 for **both** the allow and the deny case — see `src/auth/__tests__/ability.factory.test.ts`.
 

--- a/apps/api/src/instruments/__tests__/instruments.service.spec.ts
+++ b/apps/api/src/instruments/__tests__/instruments.service.spec.ts
@@ -9,6 +9,7 @@ import type { SeriesInstrument } from '@opendatacapture/runtime-core';
 import type { WithID } from '@opendatacapture/schemas/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AbilityFactory } from '@/auth/ability.factory';
 import { accessibleQuery, createAppAbility } from '@/auth/ability.utils';
 
 import { InstrumentsService } from '../instruments.service';
@@ -690,6 +691,25 @@ describe('InstrumentsService', () => {
 
       const [call] = instrumentRecordModel.findMany.mock.lastCall as [{ where: { AND: unknown[] } }];
       expect(call.where.AND[0]).toStrictEqual(accessibleQuery(ability, 'read', 'InstrumentRecord'));
+    });
+
+    // Built through the factory rather than by hand: a hand-built ability tends to include a
+    // `read InstrumentRecord` rule, and it is the absence of one that breaks. A STANDARD user holds
+    // `create` but not `read`, and this route is gated on `read Instrument`, which they do hold.
+    it('should resolve for a caller who may read no records, rather than failing the request', async () => {
+      const abilityFactory = new AbilityFactory(MockFactory.createMock(LoggingService) as unknown as LoggingService);
+      const ability = abilityFactory.createForPayload({
+        basePermissionLevel: 'STANDARD',
+        groups: [{ id: 'group-1' }],
+        id: 'user-1'
+      } as any);
+
+      await expect(instrumentsService.find({ subjectId: 'subject-1' }, { ability })).resolves.toStrictEqual([]);
+
+      expect(instrumentRecordModel.findMany).not.toHaveBeenCalled();
+      expect(instrumentModel.findMany.mock.lastCall?.[0]).toMatchObject({
+        where: { AND: expect.arrayContaining([{ id: { in: [] } }]) }
+      });
     });
 
     it('should return nothing when the subject has no records', async () => {

--- a/apps/api/src/instruments/__tests__/instruments.service.spec.ts
+++ b/apps/api/src/instruments/__tests__/instruments.service.spec.ts
@@ -9,6 +9,8 @@ import type { SeriesInstrument } from '@opendatacapture/runtime-core';
 import type { WithID } from '@opendatacapture/schemas/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { accessibleQuery, createAppAbility } from '@/auth/ability.utils';
+
 import { InstrumentsService } from '../instruments.service';
 
 import type { InstrumentVirtualizationContext } from '../instruments.service';
@@ -642,6 +644,62 @@ describe('InstrumentsService', () => {
         { id: 'owned', seriesGroupId: 'group-1' },
         { id: 'shared', seriesGroupId: null }
       ]);
+    });
+  });
+
+  describe('find', () => {
+    beforeEach(() => {
+      instrumentModel.findMany.mockResolvedValue([]);
+      instrumentRecordModel.findMany.mockResolvedValue([]);
+      vi.spyOn(instrumentsService as any, 'instantiate').mockResolvedValue([]);
+    });
+
+    it('should not query records when no subject is given, so the unfiltered listing costs one query', async () => {
+      await instrumentsService.find();
+      expect(instrumentRecordModel.findMany).not.toHaveBeenCalled();
+    });
+
+    // A `records: { some: ... }` relation filter compiles to a $lookup that materialises every
+    // record belonging to an instrument, which mongodb aborts past 100 MiB. The subject's own
+    // records are queried instead, so the work is bounded by the subject rather than the instrument.
+    it('should resolve the subject filter against records rather than joining from instruments', async () => {
+      instrumentRecordModel.findMany.mockResolvedValueOnce([{ instrumentId: 'id-1' }, { instrumentId: 'id-2' }] as any);
+
+      await instrumentsService.find({ subjectId: 'subject-1' });
+
+      expect(instrumentRecordModel.findMany).toHaveBeenCalledWith({
+        distinct: ['instrumentId'],
+        select: { instrumentId: true },
+        where: { AND: [{}, { subjectId: 'subject-1' }] }
+      });
+      expect(instrumentModel.findMany.mock.lastCall?.[0]).toMatchObject({
+        where: { AND: expect.arrayContaining([{ id: { in: ['id-1', 'id-2'] } }]) }
+      });
+      expect(JSON.stringify(instrumentModel.findMany.mock.lastCall?.[0])).not.toContain('records');
+    });
+
+    it('should constrain the record lookup to what the caller may read, so the filter cannot be resolved from other groups records', async () => {
+      // Conditions are what make this meaningful: an unconditional read rule yields `{}`, which is
+      // indistinguishable from the ability never having been applied.
+      const ability = createAppAbility([
+        { action: 'read', conditions: { groupId: { in: ['group-1'] } }, subject: 'InstrumentRecord' },
+        { action: 'read', subject: 'Instrument' }
+      ]);
+
+      await instrumentsService.find({ subjectId: 'subject-1' }, { ability });
+
+      const [call] = instrumentRecordModel.findMany.mock.lastCall as [{ where: { AND: unknown[] } }];
+      expect(call.where.AND[0]).toStrictEqual(accessibleQuery(ability, 'read', 'InstrumentRecord'));
+    });
+
+    it('should return nothing when the subject has no records', async () => {
+      instrumentRecordModel.findMany.mockResolvedValueOnce([]);
+
+      await instrumentsService.find({ subjectId: 'subject-with-no-records' });
+
+      expect(instrumentModel.findMany.mock.lastCall?.[0]).toMatchObject({
+        where: { AND: expect.arrayContaining([{ id: { in: [] } }]) }
+      });
     });
   });
 });

--- a/apps/api/src/instruments/instruments.service.ts
+++ b/apps/api/src/instruments/instruments.service.ts
@@ -36,6 +36,7 @@ import type {
 import { pick } from 'lodash-es';
 
 import { accessibleQuery } from '@/auth/ability.utils';
+import type { AppAbility } from '@/auth/auth.types';
 import type { EntityOperationOptions } from '@/core/types';
 
 import { CreateInstrumentDto } from './dto/create-instrument.dto';
@@ -261,18 +262,20 @@ export class InstrumentsService {
     { ability }: EntityOperationOptions = {},
     groupIds?: string[]
   ): Promise<WithID<SomeInstrument<TKind>>[]> {
+    // Resolved against InstrumentRecord rather than expressed as a `records: { some: ... }` relation
+    // filter. On mongodb prisma compiles that filter into a $lookup which materialises *every* record
+    // belonging to an instrument into one array before applying the predicate, and mongodb caps a
+    // single document's $lookup output at 100 MiB. A busy instrument therefore fails the whole query
+    // outright once it passes that threshold. Querying the child collection is bounded by the
+    // subject's own records instead of the instrument's.
+    const subjectInstrumentIds = query.subjectId
+      ? await this.findInstrumentIdsBySubject(query.subjectId, ability)
+      : null;
+
     const instruments = await this.instrumentModel.findMany({
       where: {
         AND: [
-          {
-            records: query.subjectId
-              ? {
-                  some: {
-                    subjectId: query.subjectId
-                  }
-                }
-              : undefined
-          },
+          subjectInstrumentIds ? { id: { in: subjectInstrumentIds } } : {},
           query.seriesGroupId
             ? {
                 OR: [
@@ -518,6 +521,22 @@ export class InstrumentsService {
       InstrumentLanguage,
       string[]
     >;
+  }
+
+  /**
+   * The ids of the instruments the subject has at least one record for.
+   *
+   * Scoped to the records the caller may read, so the filter cannot be resolved from records outside
+   * their groups — the ids feed straight into the instrument query, so an unscoped lookup would
+   * disclose which instruments a subject has been administered elsewhere.
+   */
+  private async findInstrumentIdsBySubject(subjectId: string, ability?: AppAbility): Promise<string[]> {
+    const records = await this.instrumentRecordModel.findMany({
+      distinct: ['instrumentId'],
+      select: { instrumentId: true },
+      where: { AND: [accessibleQuery(ability, 'read', 'InstrumentRecord'), { subjectId }] }
+    });
+    return records.map((record) => record.instrumentId);
   }
 
   /**

--- a/apps/api/src/instruments/instruments.service.ts
+++ b/apps/api/src/instruments/instruments.service.ts
@@ -531,6 +531,13 @@ export class InstrumentsService {
    * disclose which instruments a subject has been administered elsewhere.
    */
   private async findInstrumentIdsBySubject(subjectId: string, ability?: AppAbility): Promise<string[]> {
+    // `accessibleQuery` throws rather than returning a restrictive filter when the ability holds no
+    // rule for the subject at all, and a STANDARD user holds `create` but not `read` on
+    // InstrumentRecord. This route is gated on `read Instrument`, which they do hold, so they reach
+    // here; no readable records means no instruments qualify.
+    if (ability && !ability.can('read', 'InstrumentRecord')) {
+      return [];
+    }
     const records = await this.instrumentRecordModel.findMany({
       distinct: ['instrumentId'],
       select: { instrumentId: true },

--- a/testing/src/specs/authorization.spec.ts
+++ b/testing/src/specs/authorization.spec.ts
@@ -39,5 +39,43 @@ test.describe('authorization', () => {
       await page.goto('/session/remote-assignment');
       await expect(page).toHaveURL('/session/start-session');
     });
+
+    // `GET /v1/instruments/info` is gated on `read Instrument`, which a standard user holds, but
+    // resolving `subjectId` reads instrument records, which they do not. Scoping that lookup to the
+    // caller must answer with an empty list rather than failing the request.
+    //
+    // The defect this endpoint was changed for -- a mongodb $lookup exceeding its 100 MiB per-document
+    // ceiling once one instrument holds ~182,000 records -- cannot be reproduced at this tier. That
+    // gap is deliberate; the evidence for it is in the PR, measured against a live instance.
+    test('should answer the subject-filtered instrument list for a caller who may read no records', async ({
+      apiRequestContext,
+      roleAccount
+    }) => {
+      const { accessToken } = await roleAccount('STANDARD');
+
+      const response = await apiRequestContext.get('/api/v1/instruments/info?subjectId=any-subject', {
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+
+      expect(response.status()).toBe(200);
+      expect(await response.json()).toStrictEqual([]);
+    });
+  });
+
+  // The populated case -- a group manager reaching /datahub/$subjectId/table and picking an
+  // instrument from the list -- is covered end to end by `instrument-completion.spec.ts`, which
+  // administers one first so the list has something in it.
+  test('should serve the subject-filtered instrument list to a group manager', async ({
+    apiRequestContext,
+    roleAccount
+  }) => {
+    const { accessToken } = await roleAccount('GROUP_MANAGER');
+
+    const response = await apiRequestContext.get('/api/v1/instruments/info?subjectId=any-subject', {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toStrictEqual([]);
   });
 });

--- a/testing/src/specs/authorization.spec.ts
+++ b/testing/src/specs/authorization.spec.ts
@@ -64,8 +64,9 @@ test.describe('authorization', () => {
 
   // The populated case -- a group manager reaching /datahub/$subjectId/table and picking an
   // instrument from the list -- is covered end to end by `instrument-completion.spec.ts`, which
-  // administers one first so the list has something in it.
-  test('should serve the subject-filtered instrument list to a group manager', async ({
+  // administers one first so the list has something in it. This case only pins the contract for a
+  // subject with no visible records: an empty list, not an error.
+  test('should answer the subject-filtered instrument list for a group manager rather than erroring', async ({
     apiRequestContext,
     roleAccount
   }) => {


### PR DESCRIPTION
Fixes #1416.

`GET /v1/instruments/info?subjectId=` returns **HTTP 500** — and the datahub subject view stops rendering entirely — once a single instrument accumulates roughly 182,000 records.

## Cause

`InstrumentsService.find` expressed "instruments this subject has records for" as a prisma relation filter:

```ts
records: query.subjectId ? { some: { subjectId: query.subjectId } } : undefined
```

On MongoDB, prisma compiles that into a `$lookup` which materialises **every record belonging to an instrument** into a single array before applying the predicate. MongoDB caps one document's `$lookup` output at 100 MiB and aborts the whole aggregation past it (error 4568):

```
Executor error during aggregate command on namespace: <db>.InstrumentModel
:: caused by :: Total size of documents in InstrumentRecordModel matching
pipeline's $lookup stage exceeds 104857600 bytes
```

The limit cannot be raised, and `allowDiskUse` does not apply to it.

Two things make this worse than the raw number suggests:

- **The threshold is per-instrument, not per-collection**, so the *busiest* instrument hits it first. A core intake questionnaire administered at every visit reaches 182,000 records at 5,000 subjects × 36 visits — an ordinary size here.
- **There is no partial degradation.** `useInstrumentVisualization` calls this endpoint on mount, and it backs both `/datahub/$subjectId/table` and `/datahub/$subjectId/graph`, so both pages fail and the user has no workaround.

## The fix

Query the child collection instead of joining from the parent. The work is then bounded by the *subject's* records (tens) rather than the *instrument's* (hundreds of thousands), and there is no size ceiling:

```ts
const subjectInstrumentIds = query.subjectId ? await this.findInstrumentIdsBySubject(query.subjectId) : null;

const instruments = await this.instrumentModel.findMany({
  where: {
    AND: [subjectInstrumentIds ? { id: { in: subjectInstrumentIds } } : {}, accessibleQuery(ability, 'read', 'Instrument')]
  }
});
```

## Verified against a live instance

Real API, real MongoDB replica set, database provisioned through the app's own `POST /v1/setup`, then one instrument pushed past the ceiling.

**Above the ceiling — busiest instrument at 105.7 MiB, identical database for both:**

| | result |
|---|---|
| `main` | **HTTP 500** (three times), `exceeds 104857600 bytes` |
| this branch | **HTTP 200** in 77 ms, 811 bytes |

**Below the ceiling — same 55.3 MiB instrument, where `main` still answers:**

| | latency |
|---|---|
| `main` | 1.83s / 1.69s / 1.66s |
| this branch | 0.10s / 0.042s / 0.041s |

So this is not only an outage fix: even well under the limit the endpoint was taking **~1.7 seconds to return 811 bytes**, and it now takes ~40 ms.

## Tests

Three added to `instruments.service.spec.ts`:

- the subject filter is resolved against `InstrumentRecord` and the instrument query contains no `records` relation filter (this is the regression guard — it asserts the *absence* of the construct that fails);
- no record query is issued when no subject is given;
- a subject with no records yields `{ id: { in: [] } }` rather than an unfiltered query.

The existing `findInfo` tests are unchanged and still pass.

## Checks

- `tsc --noEmit` on `apps/api` — clean
- `eslint src` — clean
- `prettier --check` — clean
- `vitest run` (whole workspace) — 255 passed, 1 skipped, 1 failed

The one failure is `instrument-records.service.spec.ts > upload > should create records with pending set`. This branch is cut from `main`, so it still carries that pre-existing failure — **#1422 fixes it**, and the suite is fully green there.

## Notes

- `@@index([instrumentId])` on `InstrumentRecord` (proposed in #1406) is a useful mitigation for the old query but **not a fix** — it does not remove the 100 MiB ceiling. This change removes the ceiling from the picture entirely; the index still helps the new query.
- Because the failure only appears above a data-volume threshold, no small-fixture test would have caught it. A seeded at-scale test in the e2e suite would be worth adding separately.
- I swept for other relation filters on high-cardinality relations. `FilesService.find` uses `files: { every: ... }`, which is bounded by files-per-record and is safe today; it is the only other instance.

---

## Rebased onto `main`, review items addressed

Rebased onto `26ec89168`. The stale CI is gone and the branch is mergeable; `lint-and-test` is green.

**Conflict resolution.** `main` gained a `seriesGroupId` clause in the same `where` this PR rewrites.
Both are kept — the `records: { some: ... }` relation filter is the only thing removed, replaced by
the resolved id list. The spec conflicts were pure additions from `main` (series fixtures), kept as-is.

**Copilot: the record lookup was unscoped.** Fixed. `findInstrumentIdsBySubject` now takes the
caller's ability and applies `accessibleQuery(ability, 'read', 'InstrumentRecord')`. This mattered:
the ids feed straight into the instrument query, so an unscoped lookup would disclose which
instruments a subject had been administered outside the caller's groups — something the relation
filter it replaces did not do. Pinned by a test asserting the exact `accessibleQuery` clause, using a
*conditioned* ability so it cannot pass vacuously.

**Copilot: misleading test name.** Renamed to say what it actually asserts — that no *record* query
runs when no subject is given.

---

## Round 2: rebased onto `5bfe4b2dc`, review items addressed

**1. The new 500 — confirmed and fixed.** You were right, and I reproduced it exactly: with an
ability holding no `read InstrumentRecord` rule, `accessibleQuery` throws
`ForbiddenError: It's not allowed to run "read" on "InstrumentRecord"` rather than returning `{}`.
Only an `undefined` ability returns `{}`. `findInstrumentIdsBySubject` now returns an empty id list
for such a caller, before `accessibleQuery` is reached. The scoping itself stays, as you asked.

**2. A test that would have caught it.** Added, built through
`AbilityFactory.createForPayload({ basePermissionLevel: 'STANDARD', ... })` rather than by hand —
your point about the existing test is exactly right, a hand-built ability tends to carry the very
rule whose absence breaks this. Verified by mutation: removing the guard fails it with that
`ForbiddenError`.

**3. End-to-end.** Added to `authorization.spec.ts`: a STANDARD case asserting the endpoint answers
200 rather than 500, and a group-manager case alongside it. The STANDARD one returns 500 without the
guard — verified. The at-scale reproduction is noted in the spec as a deliberate gap rather than left
silent, as you suggested; the populated UI path is already covered by `instrument-completion.spec.ts`,
so I pointed at that rather than duplicating it.

Noted on `@@index([subjectId])` — agreed it is the natural companion, and I have left it out of this
PR as you asked. The group-visibility consequence stays as decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZEJLwa7jwD8sKzcE4PfSc
