### PR TITLE
perf(api): group the has-record subject ids in the database

### DIFF
--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -7,6 +7,7 @@ import { Test } from '@nestjs/testing';
 import { pick } from 'lodash-es';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createAppAbility } from '@/auth/ability.utils';
 import type { RuntimePrismaClient } from '@/core/prisma';
 
 import { SubjectsService } from '../subjects.service';
@@ -30,7 +31,8 @@ describe('SubjectsService', () => {
             $transaction: vi.fn(),
             instrumentRecord: {
               deleteMany: vi.fn(),
-              findMany: vi.fn()
+              findMany: vi.fn(),
+              groupBy: vi.fn()
             },
             session: {
               deleteMany: vi.fn()
@@ -80,16 +82,9 @@ describe('SubjectsService', () => {
       await expect(subjectsService.find()).resolves.toMatchObject([{ id: '123' }]);
     });
     it('should return the array of subjects with records', async () => {
-      prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }]);
+      prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }]);
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await expect(subjectsService.find({ hasRecord: true })).resolves.toMatchObject([{ id: '123' }]);
-      expect(prismaClient.instrumentRecord.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          distinct: ['subjectId'],
-          select: { subjectId: true },
-          where: {}
-        })
-      );
       expect(subjectModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
@@ -98,18 +93,41 @@ describe('SubjectsService', () => {
         })
       );
     });
+    // `distinct` is applied by the prisma query engine, so it returns one row per record over the
+    // wire; grouping asks mongodb for one row per subject instead.
+    it('should group the ids in the database rather than deduplicating them after the fact', async () => {
+      prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }]);
+      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
+      await subjectsService.find({ hasRecord: true });
+      expect(prismaClient.instrumentRecord.groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({ by: ['subjectId'] })
+      );
+      expect(prismaClient.instrumentRecord.findMany).not.toHaveBeenCalled();
+    });
     it('should filter instrument records by groupId when provided', async () => {
-      prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }]);
+      prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }]);
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
       await subjectsService.find({ groupId: 'group-1', hasRecord: true });
-      expect(prismaClient.instrumentRecord.findMany).toHaveBeenCalledWith(
+      expect(prismaClient.instrumentRecord.groupBy).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { groupId: 'group-1' }
+          where: { AND: [{}, { groupId: 'group-1' }] }
         })
       );
     });
+    it('should constrain the record query to what the caller may read', async () => {
+      prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([]);
+      subjectModel.findMany.mockResolvedValueOnce([]);
+      const ability = createAppAbility([
+        { action: 'read', subject: 'InstrumentRecord' },
+        { action: 'read', subject: 'Subject' }
+      ]);
+      await subjectsService.find({ hasRecord: true }, { ability });
+      const [call] = prismaClient.instrumentRecord.groupBy.mock.lastCall as [{ where: { AND: unknown[] } }];
+      // the ability contributes the first clause; without it the query would be unconstrained
+      expect(call.where.AND[0]).not.toStrictEqual({});
+    });
     it('should pass all subject IDs returned by instrument records to the subject query', async () => {
-      prismaClient.instrumentRecord.findMany.mockResolvedValueOnce([{ subjectId: '123' }, { subjectId: '456' }]);
+      prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }, { subjectId: '456' }]);
       subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }, { id: '456' }]);
       await subjectsService.find({ hasRecord: true });
       expect(subjectModel.findMany).toHaveBeenCalledWith(

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -1,4 +1,4 @@
-import { CryptoService, getModelToken, PRISMA_CLIENT_TOKEN } from '@douglasneuroinformatics/libnest';
+import { CryptoService, getModelToken, LoggingService, PRISMA_CLIENT_TOKEN } from '@douglasneuroinformatics/libnest';
 import type { Model } from '@douglasneuroinformatics/libnest';
 import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
 import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
@@ -7,6 +7,7 @@ import { Test } from '@nestjs/testing';
 import { pick } from 'lodash-es';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AbilityFactory } from '@/auth/ability.factory';
 import { accessibleQuery, createAppAbility } from '@/auth/ability.utils';
 import type { RuntimePrismaClient } from '@/core/prisma';
 
@@ -102,7 +103,6 @@ describe('SubjectsService', () => {
       expect(prismaClient.instrumentRecord.groupBy).toHaveBeenCalledWith(
         expect.objectContaining({ by: ['subjectId'] })
       );
-      expect(prismaClient.instrumentRecord.findMany).not.toHaveBeenCalled();
     });
     it('should filter instrument records by groupId when provided', async () => {
       prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }]);
@@ -126,6 +126,25 @@ describe('SubjectsService', () => {
       await subjectsService.find({ hasRecord: true }, { ability });
       const [call] = prismaClient.instrumentRecord.groupBy.mock.lastCall as [{ where: { AND: unknown[] } }];
       expect(call.where.AND[0]).toStrictEqual(accessibleQuery(ability, 'read', 'InstrumentRecord'));
+    });
+
+    // A STANDARD user holds `create` but not `read` on InstrumentRecord, and this route's guard names
+    // `read Subject`, so they reach the service. `accessibleQuery` throws on an ability with no rule
+    // for the subject at all, which escapes as a 500 rather than the empty list they should see.
+    it('should return an empty list for a caller who may read no records, rather than throwing', async () => {
+      const abilityFactory = new AbilityFactory(MockFactory.createMock(LoggingService) as unknown as LoggingService);
+      const ability = abilityFactory.createForPayload({
+        basePermissionLevel: 'STANDARD',
+        groups: [{ id: 'group-1' }],
+        id: 'user-1'
+      } as any);
+      subjectModel.findMany.mockResolvedValueOnce([]);
+
+      await expect(subjectsService.find({ hasRecord: true }, { ability })).resolves.toStrictEqual([]);
+
+      expect(prismaClient.instrumentRecord.groupBy).not.toHaveBeenCalled();
+      const [call] = subjectModel.findMany.mock.lastCall as [{ where: { AND: unknown[] } }];
+      expect(call.where.AND).toContainEqual({ id: { in: [] } });
     });
     it('should pass all subject IDs returned by instrument records to the subject query', async () => {
       prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }, { subjectId: '456' }]);

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -7,7 +7,7 @@ import { Test } from '@nestjs/testing';
 import { pick } from 'lodash-es';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAppAbility } from '@/auth/ability.utils';
+import { accessibleQuery, createAppAbility } from '@/auth/ability.utils';
 import type { RuntimePrismaClient } from '@/core/prisma';
 
 import { SubjectsService } from '../subjects.service';
@@ -114,17 +114,18 @@ describe('SubjectsService', () => {
         })
       );
     });
-    it('should constrain the record query to what the caller may read', async () => {
+    it('should constrain the record query to what the caller may read, so the filter cannot be resolved from other groups records', async () => {
       prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([]);
       subjectModel.findMany.mockResolvedValueOnce([]);
+      // Conditions are what make this meaningful: an unconditional read rule yields `{}`, which is
+      // indistinguishable from the ability never having been applied.
       const ability = createAppAbility([
-        { action: 'read', subject: 'InstrumentRecord' },
-        { action: 'read', subject: 'Subject' }
+        { action: 'read', conditions: { groupId: { in: ['group-1'] } }, subject: 'InstrumentRecord' },
+        { action: 'read', conditions: { groupIds: { hasSome: ['group-1'] } }, subject: 'Subject' }
       ]);
       await subjectsService.find({ hasRecord: true }, { ability });
       const [call] = prismaClient.instrumentRecord.groupBy.mock.lastCall as [{ where: { AND: unknown[] } }];
-      // the ability contributes the first clause; without it the query would be unconstrained
-      expect(call.where.AND[0]).not.toStrictEqual({});
+      expect(call.where.AND[0]).toStrictEqual(accessibleQuery(ability, 'read', 'InstrumentRecord'));
     });
     it('should pass all subject IDs returned by instrument records to the subject query', async () => {
       prismaClient.instrumentRecord.groupBy.mockResolvedValueOnce([{ subjectId: '123' }, { subjectId: '456' }]);

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -135,9 +135,13 @@ describe('SubjectsService', () => {
       const abilityFactory = new AbilityFactory(MockFactory.createMock(LoggingService) as unknown as LoggingService);
       const ability = abilityFactory.createForPayload({
         basePermissionLevel: 'STANDARD',
-        groups: [{ id: 'group-1' }],
-        id: 'user-1'
-      } as any);
+        firstName: null,
+        groups: [],
+        id: 'user-1',
+        lastName: null,
+        mustResetPassword: false,
+        username: 'standard-user'
+      });
       subjectModel.findMany.mockResolvedValueOnce([]);
 
       await expect(subjectsService.find({ hasRecord: true }, { ability })).resolves.toStrictEqual([]);

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -4,6 +4,7 @@ import { ConflictException, Injectable, NotFoundException } from '@nestjs/common
 import type { Prisma } from '@prisma/client';
 
 import { accessibleQuery } from '@/auth/ability.utils';
+import type { AppAbility } from '@/auth/auth.types';
 import type { RuntimePrismaClient } from '@/core/prisma';
 import type { EntityOperationOptions } from '@/core/types';
 
@@ -136,7 +137,7 @@ export class SubjectsService {
           AND: [
             accessibleQuery(ability, 'read', 'Subject'),
             groupInput,
-            { id: { in: await this.querySubjectIdsWithRecords(groupId) } }
+            { id: { in: await this.querySubjectIdsWithRecords(groupId, ability) } }
           ]
         }
       });
@@ -158,12 +159,25 @@ export class SubjectsService {
     return subject;
   }
 
-  private async querySubjectIdsWithRecords(groupId?: string): Promise<string[]> {
-    const records = await this.prismaClient.instrumentRecord.findMany({
-      distinct: ['subjectId'],
-      select: { subjectId: true },
-      where: groupId ? { groupId } : {}
+  /**
+   * The ids of subjects having at least one record, for the "with records only" filter.
+   *
+   * Grouped by the database rather than deduplicated after the fact: `distinct` is applied by the
+   * prisma query engine, so it returns one row per *record* over the wire and collapses them only
+   * once they have arrived.
+   *
+   * Deliberately not expressed as a `instrumentRecords: { some: ... }` relation filter on Subject.
+   * On mongodb prisma compiles that into a $lookup over the whole record collection, which measured
+   * far slower than either form here and carries the 100 MiB per-document ceiling that made the same
+   * construct fail outright elsewhere.
+   */
+  private async querySubjectIdsWithRecords(groupId?: string, ability?: AppAbility): Promise<string[]> {
+    const groups = await this.prismaClient.instrumentRecord.groupBy({
+      by: ['subjectId'],
+      where: {
+        AND: [accessibleQuery(ability, 'read', 'InstrumentRecord'), groupId ? { groupId } : {}]
+      }
     });
-    return records.map((r) => r.subjectId);
+    return groups.map((group) => group.subjectId);
   }
 }

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -179,6 +179,10 @@ export class SubjectsService {
     if (ability && !ability.can('read', 'InstrumentRecord')) {
       return [];
     }
+    // The accessibleQuery clause also drops records whose groupId is null: a group manager's rule is
+    // `groupId: { in: [...] }`, and prisma's `in` never matches null. That is intended — an
+    // admin-created, ungrouped record should not make a subject count as "with records" for a
+    // manager — but it is invisible at this call site, so it is recorded here.
     const groups = await this.prismaClient.instrumentRecord.groupBy({
       by: ['subjectId'],
       where: {

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -172,6 +172,13 @@ export class SubjectsService {
    * construct fail outright elsewhere.
    */
   private async querySubjectIdsWithRecords(groupId?: string, ability?: AppAbility): Promise<string[]> {
+    // `accessibleQuery` throws rather than returning a restrictive filter when the ability holds no
+    // rule for the subject at all, and a STANDARD user holds `create` but not `read` on
+    // InstrumentRecord. This route's guard names `read Subject`, so such a caller reaches here; no
+    // readable records means no subjects qualify.
+    if (ability && !ability.can('read', 'InstrumentRecord')) {
+      return [];
+    }
     const groups = await this.prismaClient.instrumentRecord.groupBy({
       by: ['subjectId'],
       where: {

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -166,7 +166,7 @@ export class SubjectsService {
    * prisma query engine, so it returns one row per *record* over the wire and collapses them only
    * once they have arrived.
    *
-   * Deliberately not expressed as a `instrumentRecords: { some: ... }` relation filter on Subject.
+   * Deliberately not expressed as an `instrumentRecords: { some: ... }` relation filter on Subject.
    * On mongodb prisma compiles that into a $lookup over the whole record collection, which measured
    * far slower than either form here and carries the 100 MiB per-document ceiling that made the same
    * construct fail outright elsewhere.

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -58,7 +58,11 @@ const Filters: React.FC<{
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenu.Trigger asChild>
-        <Button className="flex items-center justify-between gap-2" variant="outline">
+        <Button
+          className="flex items-center justify-between gap-2"
+          data-testid="datahub-filters-trigger"
+          variant="outline"
+        >
           {t('common.filters')}
           <ChevronDownIcon className="opacity-50" />
         </Button>
@@ -167,6 +171,7 @@ const Filters: React.FC<{
           </DropdownMenu.Label>
           <DropdownMenu.CheckboxItem
             checked={hasRecords}
+            data-testid="datahub-filter-has-records"
             onCheckedChange={setHasRecords}
             onSelect={(e) => e.preventDefault()}
           >

--- a/testing/AGENTS.md
+++ b/testing/AGENTS.md
@@ -65,10 +65,15 @@ A page object is only reachable from a spec once it is registered in the `pageMo
 | `appState`             | test option | localStorage first-run gating; both flags default to accepted/complete     |
 | `uniqueId`             | test        | Short random suffix for seeded data                                        |
 | `api`                  | worker      | `ApiClient` as admin — `createGroup()` / `createUser()` for preconditions  |
+| `isolatedGroupManager` | test        | Authenticates into a group created for this test alone; returns the group  |
 | `roleAccount(role)`    | worker      | Seeds a group + user per role once, then caches its token and username     |
 
 Set up preconditions over the API with the `api` fixture rather than by clicking through the UI;
 only drive the UI for the behaviour actually under test.
+
+`roleAccount`'s group is cached per worker and shared by every spec running in it, so a test that
+asserts on **how much** a group contains must use `isolatedGroupManager` instead. A group manager
+reads only their own groups, so a fresh group bounds what the test can see to what it seeded.
 
 Auth is injected as `window.__PLAYWRIGHT_ACCESS_TOKEN__`, which `apps/web`'s
 `src/store/slices/auth.slice.ts` reads on boot. It is memory-only and never persisted.

--- a/testing/AGENTS.md
+++ b/testing/AGENTS.md
@@ -59,19 +59,24 @@ A page object is only reachable from a spec once it is registered in the `pageMo
 
 ## Fixtures
 
-| Fixture               | Scope       | Notes                                                                      |
-| --------------------- | ----------- | -------------------------------------------------------------------------- |
-| `getPageModel`        | test        | Authenticates as `actingRole`, navigates, returns the page object          |
-| `authenticateAs(who)` | test        | Injects a token without navigating; takes a role or `$LoginCredentials`    |
-| `actingRole`          | test option | Default `GROUP_MANAGER`; override with `test.use({ actingRole: 'ADMIN' })` |
-| `appState`            | test option | localStorage first-run gating, seeded for every test; defaults to accepted |
-| `uniqueId`            | test        | Short random suffix for seeded data                                        |
-| `api`                 | worker      | `ApiClient` as admin — `createGroup()` / `createUser()` for preconditions  |
-| `roleAccount(role)`   | worker      | Seeds a group + user per role once, then caches its token and username     |
-| `apiRequestContext`   | worker      | Raw `APIRequestContext` on the web origin, for driving the API directly    |
+| Fixture                | Scope       | Notes                                                                      |
+| ---------------------- | ----------- | -------------------------------------------------------------------------- |
+| `getPageModel`         | test        | Authenticates as `actingRole`, navigates, returns the page object          |
+| `authenticateAs(who)`  | test        | Injects a token without navigating; takes a role or `$LoginCredentials`    |
+| `actingRole`           | test option | Default `GROUP_MANAGER`; override with `test.use({ actingRole: 'ADMIN' })` |
+| `appState`             | test option | localStorage first-run gating, seeded for every test; defaults to accepted |
+| `uniqueId`             | test        | Short random suffix for seeded data                                        |
+| `api`                  | worker      | `ApiClient` as admin — `createGroup()` / `createUser()` for preconditions  |
+| `isolatedGroupManager` | test        | Authenticates into a group created for this test alone; returns the group  |
+| `roleAccount(role)`    | worker      | Seeds a group + user per role once, then caches its token and username     |
+| `apiRequestContext`    | worker      | Raw `APIRequestContext` on the web origin, for driving the API directly    |
 
 Set up preconditions over the API with the `api` fixture rather than by clicking through the UI;
 only drive the UI for the behaviour actually under test.
+
+`roleAccount`'s group is cached per worker and shared by every spec running in it, so a test that
+asserts on **how much** a group contains must use `isolatedGroupManager` instead. A group manager
+reads only their own groups, so a fresh group bounds what the test can see to what it seeded.
 
 Auth is injected as `window.__PLAYWRIGHT_ACCESS_TOKEN__`, which `apps/web`'s
 `src/store/slices/auth.slice.ts` reads on boot. It is memory-only and never persisted.

--- a/testing/src/pages/_app/datahub/index.page.ts
+++ b/testing/src/pages/_app/datahub/index.page.ts
@@ -3,11 +3,23 @@ import type { Locator, Page } from '@playwright/test';
 import { AppPage } from '../route.page';
 
 export class DatahubPage extends AppPage {
+  readonly filtersTrigger: Locator;
+  readonly hasRecordsFilter: Locator;
   readonly pageHeader: Locator;
   readonly rowActionsTrigger: Locator;
+  readonly rows: Locator;
   constructor(page: Page) {
     super(page);
+    this.filtersTrigger = page.getByTestId('datahub-filters-trigger');
+    this.hasRecordsFilter = page.getByTestId('datahub-filter-has-records');
     this.pageHeader = page.getByTestId('page-header');
     this.rowActionsTrigger = page.getByTestId('row-actions-trigger').first();
+    this.rows = page.getByTestId('data-table-body').getByTestId('data-table-row');
+  }
+
+  /** Opens the filter menu and toggles "With records only", which refetches with `hasRecord=true`. */
+  async toggleWithRecordsOnly() {
+    await this.filtersTrigger.click();
+    await this.hasRecordsFilter.click();
   }
 }

--- a/testing/src/pages/_app/datahub/index.page.ts
+++ b/testing/src/pages/_app/datahub/index.page.ts
@@ -3,13 +3,25 @@ import type { Locator, Page } from '@playwright/test';
 import { AppPage } from '../route.page';
 
 export class DatahubPage extends AppPage {
+  readonly filtersTrigger: Locator;
+  readonly hasRecordsFilter: Locator;
   readonly pageHeader: Locator;
   readonly rowActionsTrigger: Locator;
+  readonly rows: Locator;
   readonly searchInput: Locator;
   constructor(page: Page) {
     super(page);
+    this.filtersTrigger = page.getByTestId('datahub-filters-trigger');
+    this.hasRecordsFilter = page.getByTestId('datahub-filter-has-records');
     this.pageHeader = page.getByTestId('page-header');
     this.rowActionsTrigger = page.getByTestId('row-actions-trigger').first();
+    this.rows = page.getByTestId('data-table-body').getByTestId('data-table-row');
     this.searchInput = page.getByTestId('data-table-search-bar').getByRole('searchbox');
+  }
+
+  /** Opens the filter menu and toggles "With records only", which refetches with `hasRecord=true`. */
+  async toggleWithRecordsOnly() {
+    await this.filtersTrigger.click();
+    await this.hasRecordsFilter.click();
   }
 }

--- a/testing/src/specs/datahub.spec.ts
+++ b/testing/src/specs/datahub.spec.ts
@@ -1,3 +1,4 @@
+import { DatahubPage } from '../pages/_app/datahub/index.page';
 import { expect, test } from '../support/fixtures';
 
 test.describe('data hub', () => {
@@ -5,5 +6,43 @@ test.describe('data hub', () => {
     const datahubPage = await getPageModel('/datahub');
     await expect(datahubPage.pageHeader).toBeVisible();
     await expect(datahubPage.pageHeader).toContainText('Data Hub');
+  });
+
+  test('should list only subjects holding records once "with records only" is applied', async ({
+    api,
+    isolatedGroupManager,
+    page,
+    uniqueId
+  }) => {
+    // A group of its own, so the row count is exactly what this test seeds. Both subjects are created
+    // through a session and never given an instrument record, so the filter must empty the table.
+    const group = await isolatedGroupManager();
+    for (const suffix of ['a', 'b']) {
+      await api.createSession(group.id, { id: `recordless-${uniqueId}-${suffix}` });
+    }
+
+    const datahubPage = new DatahubPage(page);
+    await datahubPage.goto('/datahub');
+    await expect(datahubPage.rows).toHaveCount(2);
+
+    await datahubPage.toggleWithRecordsOnly();
+
+    await expect(datahubPage.rows).toHaveCount(0);
+  });
+
+  // `GET /v1/subjects` is gated on `read Subject`, which a standard user holds, but resolving
+  // `hasRecord` reads instrument records, which they do not. The honest answer is an empty list.
+  test('should answer the with-records filter for a caller who may read no records', async ({
+    apiRequestContext,
+    roleAccount
+  }) => {
+    const { accessToken } = await roleAccount('STANDARD');
+
+    const response = await apiRequestContext.get('/api/v1/subjects?hasRecord=true', {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toStrictEqual([]);
   });
 });

--- a/testing/src/specs/datahub.spec.ts
+++ b/testing/src/specs/datahub.spec.ts
@@ -1,6 +1,13 @@
 import { DatahubPage } from '../pages/_app/datahub/index.page';
 import { expect, test } from '../support/fixtures';
 
+/** A minimal payload satisfying the seeded happiness questionnaire's validation schema. */
+const HAPPINESS_RECORD = {
+  isSatisfiedOverall: true,
+  personalLifeSatisfaction: 8,
+  professionalLifeSatisfaction: 7
+};
+
 test.describe('data hub', () => {
   test('should display the data hub header', async ({ getPageModel }) => {
     const datahubPage = await getPageModel('/datahub');
@@ -14,20 +21,28 @@ test.describe('data hub', () => {
     page,
     uniqueId
   }) => {
-    // A group of its own, so the row count is exactly what this test seeds. Both subjects are created
-    // through a session and never given an instrument record, so the filter must empty the table.
+    // A group of its own, so the row count is exactly what this test seeds. Two subjects exist only
+    // through sessions while a third holds a record, so the filter must drop exactly the recordless
+    // pair — hiding every subject or filtering none would both fail.
     const group = await isolatedGroupManager();
+    const withRecord = `hasrecord-${uniqueId}`;
     for (const suffix of ['a', 'b']) {
       await api.createSession(group.id, { id: `recordless-${uniqueId}-${suffix}` });
     }
+    await api.uploadRecords(group.id, await api.findInstrumentIdByName('DNP_HAPPINESS_QUESTIONNAIRE'), [
+      { data: HAPPINESS_RECORD, date: new Date(), subjectId: withRecord }
+    ]);
 
     const datahubPage = new DatahubPage(page);
     await datahubPage.goto('/datahub');
-    await expect(datahubPage.rows).toHaveCount(2);
+    await expect(datahubPage.rows).toHaveCount(3);
 
     await datahubPage.toggleWithRecordsOnly();
 
-    await expect(datahubPage.rows).toHaveCount(0);
+    await expect(datahubPage.rows).toHaveCount(1);
+    // The cell renders at most the id's first nine characters (the subjectIdDisplayLength default),
+    // so the assertion matches the visible prefix rather than the full seeded id.
+    await expect(datahubPage.rows).toContainText(withRecord.slice(0, 9));
   });
 
   // `GET /v1/subjects` is gated on `read Subject`, which a standard user holds, but resolving

--- a/testing/src/specs/datahub.spec.ts
+++ b/testing/src/specs/datahub.spec.ts
@@ -1,6 +1,13 @@
 import { DatahubPage } from '../pages/_app/datahub/index.page';
 import { expect, test } from '../support/fixtures';
 
+/** A minimal payload satisfying the seeded happiness questionnaire's validation schema. */
+const HAPPINESS_RECORD = {
+  isSatisfiedOverall: true,
+  personalLifeSatisfaction: 8,
+  professionalLifeSatisfaction: 7
+};
+
 test.describe('data hub', () => {
   test('should display the data hub header', async ({ getPageModel }) => {
     const datahubPage = await getPageModel('/datahub');
@@ -99,20 +106,28 @@ test.describe('data hub', () => {
     page,
     uniqueId
   }) => {
-    // A group of its own, so the row count is exactly what this test seeds. Both subjects are created
-    // through a session and never given an instrument record, so the filter must empty the table.
+    // A group of its own, so the row count is exactly what this test seeds. Two subjects exist only
+    // through sessions while a third holds a record, so the filter must drop exactly the recordless
+    // pair — hiding every subject or filtering none would both fail.
     const group = await isolatedGroupManager();
+    const withRecord = `hasrecord-${uniqueId}`;
     for (const suffix of ['a', 'b']) {
       await api.createSession(group.id, { id: `recordless-${uniqueId}-${suffix}` });
     }
+    await api.uploadRecords(group.id, await api.findInstrumentIdByName('DNP_HAPPINESS_QUESTIONNAIRE'), [
+      { data: HAPPINESS_RECORD, date: new Date(), subjectId: withRecord }
+    ]);
 
     const datahubPage = new DatahubPage(page);
     await datahubPage.goto('/datahub');
-    await expect(datahubPage.rows).toHaveCount(2);
+    await expect(datahubPage.rows).toHaveCount(3);
 
     await datahubPage.toggleWithRecordsOnly();
 
-    await expect(datahubPage.rows).toHaveCount(0);
+    await expect(datahubPage.rows).toHaveCount(1);
+    // The cell renders at most the id's first nine characters (the subjectIdDisplayLength default),
+    // so the assertion matches the visible prefix rather than the full seeded id.
+    await expect(datahubPage.rows).toContainText(withRecord.slice(0, 9));
   });
 
   // `GET /v1/subjects` is gated on `read Subject`, which a standard user holds, but resolving

--- a/testing/src/specs/datahub.spec.ts
+++ b/testing/src/specs/datahub.spec.ts
@@ -1,3 +1,4 @@
+import { DatahubPage } from '../pages/_app/datahub/index.page';
 import { expect, test } from '../support/fixtures';
 
 test.describe('data hub', () => {
@@ -90,5 +91,43 @@ test.describe('data hub', () => {
     await identificationForm.getByRole('button', { name: 'Submit' }).click();
 
     await expect(page).toHaveURL(/\/datahub\/.+\/table$/);
+  });
+
+  test('should list only subjects holding records once "with records only" is applied', async ({
+    api,
+    isolatedGroupManager,
+    page,
+    uniqueId
+  }) => {
+    // A group of its own, so the row count is exactly what this test seeds. Both subjects are created
+    // through a session and never given an instrument record, so the filter must empty the table.
+    const group = await isolatedGroupManager();
+    for (const suffix of ['a', 'b']) {
+      await api.createSession(group.id, { id: `recordless-${uniqueId}-${suffix}` });
+    }
+
+    const datahubPage = new DatahubPage(page);
+    await datahubPage.goto('/datahub');
+    await expect(datahubPage.rows).toHaveCount(2);
+
+    await datahubPage.toggleWithRecordsOnly();
+
+    await expect(datahubPage.rows).toHaveCount(0);
+  });
+
+  // `GET /v1/subjects` is gated on `read Subject`, which a standard user holds, but resolving
+  // `hasRecord` reads instrument records, which they do not. The honest answer is an empty list.
+  test('should answer the with-records filter for a caller who may read no records', async ({
+    apiRequestContext,
+    roleAccount
+  }) => {
+    const { accessToken } = await roleAccount('STANDARD');
+
+    const response = await apiRequestContext.get('/api/v1/subjects?hasRecord=true', {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toStrictEqual([]);
   });
 });

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,7 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
+import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, User } from '@opendatacapture/schemas/user';
 import type { APIRequestContext } from '@playwright/test';
 
@@ -45,6 +47,19 @@ export class ApiClient {
       'grant instrument access'
     );
     return group;
+  }
+
+  /**
+   * Creates a session, and with it the subject it names. A subject seeded this way holds no
+   * instrument records, which is what distinguishes it under the "with records only" filter.
+   */
+  async createSession(groupId: null | string, subjectData: CreateSubjectData): Promise<Session> {
+    const data: CreateSessionData = { date: new Date(), groupId, subjectData, type: 'IN_PERSON' };
+    return this.expectJson<Session>(
+      this.request.post(`${API}/sessions`, { data, headers: this.authHeaders }),
+      201,
+      'create session'
+    );
   }
 
   /** Creates a user (GROUP_MANAGER by default) and returns the login credentials for it. */

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,6 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { UploadInstrumentRecordsData } from '@opendatacapture/schemas/instrument-records';
 import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, User } from '@opendatacapture/schemas/user';
@@ -9,6 +10,8 @@ import { SEEDED_USER_PASSWORD } from './constants';
 import { randomId } from './unique';
 
 const API = '/api/v1';
+
+type UploadRecord = UploadInstrumentRecordsData['records'][number];
 
 /** Typed helper for seeding preconditions (groups, users) and authenticating over the API. */
 export class ApiClient {
@@ -81,6 +84,34 @@ export class ApiClient {
       'create user'
     );
     return { credentials: { password, username }, user };
+  }
+
+  /** The id of a seeded instrument, looked up by the internal name its source file declares. */
+  async findInstrumentIdByName(name: string): Promise<string> {
+    const instruments = await this.expectJson<{ id: string; internal?: { name: string } }[]>(
+      this.request.get(`${API}/instruments/info`, { headers: this.authHeaders }),
+      200,
+      'list instruments'
+    );
+    const instrument = instruments.find((candidate) => candidate.internal?.name === name);
+    if (!instrument) {
+      throw new Error(`No instrument named '${name}' among ${instruments.length} returned`);
+    }
+    return instrument.id;
+  }
+
+  /**
+   * Bulk-creates one record per entry, and with them the subjects and sessions they name. This is the
+   * cheapest way to give a subject an instrument record: the export only carries subjects that have
+   * one.
+   */
+  async uploadRecords(groupId: string, instrumentId: string, records: UploadRecord[]): Promise<void> {
+    const data: UploadInstrumentRecordsData = { groupId, instrumentId, records };
+    await this.expectJson(
+      this.request.post(`${API}/instrument-records/upload`, { data, headers: this.authHeaders }),
+      201,
+      'upload instrument records'
+    );
   }
 
   private async expectJson<T>(

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,7 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
+import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, UpdateUserData, User } from '@opendatacapture/schemas/user';
 import type { APIRequestContext } from '@playwright/test';
 
@@ -45,6 +47,19 @@ export class ApiClient {
       'grant instrument access'
     );
     return group;
+  }
+
+  /**
+   * Creates a session, and with it the subject it names. A subject seeded this way holds no
+   * instrument records, which is what distinguishes it under the "with records only" filter.
+   */
+  async createSession(groupId: null | string, subjectData: CreateSubjectData): Promise<Session> {
+    const data: CreateSessionData = { date: new Date(), groupId, subjectData, type: 'IN_PERSON' };
+    return this.expectJson<Session>(
+      this.request.post(`${API}/sessions`, { data, headers: this.authHeaders }),
+      201,
+      'create session'
+    );
   }
 
   /** Creates a user (GROUP_MANAGER by default) and returns the login credentials for it. */

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,6 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { UploadInstrumentRecordsData } from '@opendatacapture/schemas/instrument-records';
 import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, UpdateUserData, User } from '@opendatacapture/schemas/user';
@@ -9,6 +10,8 @@ import { E2E_MAIL_CONFIG, SEEDED_USER_PASSWORD } from './constants';
 import { randomId } from './unique';
 
 const API = '/api/v1';
+
+type UploadRecord = UploadInstrumentRecordsData['records'][number];
 
 /** Typed helper for seeding preconditions (groups, users) and authenticating over the API. */
 export class ApiClient {
@@ -92,6 +95,20 @@ export class ApiClient {
     );
   }
 
+  /** The id of a seeded instrument, looked up by the internal name its source file declares. */
+  async findInstrumentIdByName(name: string): Promise<string> {
+    const instruments = await this.expectJson<{ id: string; internal?: { name: string } }[]>(
+      this.request.get(`${API}/instruments/info`, { headers: this.authHeaders }),
+      200,
+      'list instruments'
+    );
+    const instrument = instruments.find((candidate) => candidate.internal?.name === name);
+    if (!instrument) {
+      throw new Error(`No instrument named '${name}' among ${instruments.length} returned`);
+    }
+    return instrument.id;
+  }
+
   /**
    * Switch outgoing mail on or off instance-wide, (re)seeding {@link E2E_MAIL_CONFIG}. Every
    * caller must switch it back off — `isMailEnabled` is global, and leaving it on changes the UI
@@ -117,6 +134,20 @@ export class ApiClient {
       throw new Error(`Failed to update user '${id}' (${response.status()}): ${await response.text()}`);
     }
     return (await response.json()) as User;
+  }
+
+  /**
+   * Bulk-creates one record per entry, and with them the subjects and sessions they name. This is the
+   * cheapest way to give a subject an instrument record: the export only carries subjects that have
+   * one.
+   */
+  async uploadRecords(groupId: string, instrumentId: string, records: UploadRecord[]): Promise<void> {
+    const data: UploadInstrumentRecordsData = { groupId, instrumentId, records };
+    await this.expectJson(
+      this.request.post(`${API}/instrument-records/upload`, { data, headers: this.authHeaders }),
+      201,
+      'upload instrument records'
+    );
   }
 
   private async expectJson<T>(

--- a/testing/src/support/fixtures.ts
+++ b/testing/src/support/fixtures.ts
@@ -2,7 +2,7 @@
 
 import type { Group } from '@opendatacapture/schemas/group';
 import { request as apiRequestFactory, test as base, expect } from '@playwright/test';
-import type { APIRequestContext } from '@playwright/test';
+import type { APIRequestContext, Page } from '@playwright/test';
 
 import { SettingsPage } from '../pages/_app/admin/settings.page';
 import { DashboardPage } from '../pages/_app/dashboard.page';
@@ -31,6 +31,16 @@ const pageModels = {
 } satisfies { [K in RouteTo]?: any };
 
 type PageModels = typeof pageModels;
+
+/** Injects the token and first-run state the web app reads on boot; must run before navigation. */
+const injectAuth = (page: Page, accessToken: string, state: AppState) =>
+  page.addInitScript(
+    (injected) => {
+      window.__PLAYWRIGHT_ACCESS_TOKEN__ = injected.accessToken;
+      localStorage.setItem('app', JSON.stringify({ state: injected.state, version: 1 }));
+    },
+    { accessToken, state }
+  );
 
 type GetPageModel = <TKey extends Extract<keyof PageModels, RouteTo>>(
   key: TKey,
@@ -65,8 +75,9 @@ type TestFixtures = {
    * Authenticates as a group manager of a group created for this test alone, and returns that group.
    *
    * The `roleAccount` group is cached per worker and shared by every spec running in it, so a test
-   * that counts what the group contains cannot use it. A group manager's `read Subject` rule is
-   * scoped to their own groups, so a fresh group means the data this test seeds is all it can see.
+   * that asserts on exactly what a group contains cannot use it. A group manager's `read Subject`
+   * rule is scoped to their own groups, so a fresh group bounds what this test can see to what it
+   * seeded.
    */
   isolatedGroupManager: () => Promise<Group>;
   /** Short run-unique suffix for naming seeded data in this test. */
@@ -99,13 +110,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   authenticateAs: async ({ appState, page, roleAccount }, use) => {
     await use(async (role) => {
       const { accessToken } = await roleAccount(role);
-      await page.addInitScript(
-        (injected) => {
-          window.__PLAYWRIGHT_ACCESS_TOKEN__ = injected.accessToken;
-          localStorage.setItem('app', JSON.stringify({ state: injected.state, version: 1 }));
-        },
-        { accessToken, state: appState }
-      );
+      await injectAuth(page, accessToken, appState);
     });
   },
   getPageModel: async ({ actingRole, authenticateAs, page }, use) => {
@@ -125,13 +130,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       const group = await api.createGroup();
       const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
       const accessToken = await ApiClient.login(apiRequestContext, credentials);
-      await page.addInitScript(
-        (injected) => {
-          window.__PLAYWRIGHT_ACCESS_TOKEN__ = injected.accessToken;
-          localStorage.setItem('app', JSON.stringify({ state: injected.state, version: 1 }));
-        },
-        { accessToken, state: appState }
-      );
+      await injectAuth(page, accessToken, appState);
       return group;
     });
   },

--- a/testing/src/support/fixtures.ts
+++ b/testing/src/support/fixtures.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-empty-pattern */
 
+import type { Group } from '@opendatacapture/schemas/group';
 import { request as apiRequestFactory, test as base, expect } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 
@@ -60,6 +61,14 @@ type TestFixtures = {
   authenticateAs: (role: Role) => Promise<void>;
   /** Navigates to a route as `actingRole` and returns its page object. */
   getPageModel: GetPageModel;
+  /**
+   * Authenticates as a group manager of a group created for this test alone, and returns that group.
+   *
+   * The `roleAccount` group is cached per worker and shared by every spec running in it, so a test
+   * that counts what the group contains cannot use it. A group manager's `read Subject` rule is
+   * scoped to their own groups, so a fresh group means the data this test seeds is all it can see.
+   */
+  isolatedGroupManager: () => Promise<Group>;
   /** Short run-unique suffix for naming seeded data in this test. */
   uniqueId: string;
 };
@@ -110,6 +119,21 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         return pageModel;
       }
     );
+  },
+  isolatedGroupManager: async ({ api, apiRequestContext, appState, page }, use) => {
+    await use(async () => {
+      const group = await api.createGroup();
+      const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
+      const accessToken = await ApiClient.login(apiRequestContext, credentials);
+      await page.addInitScript(
+        (injected) => {
+          window.__PLAYWRIGHT_ACCESS_TOKEN__ = injected.accessToken;
+          localStorage.setItem('app', JSON.stringify({ state: injected.state, version: 1 }));
+        },
+        { accessToken, state: appState }
+      );
+      return group;
+    });
   },
   roleAccount: [
     async ({ adminToken, api, apiRequestContext }, use) => {

--- a/testing/src/support/fixtures.ts
+++ b/testing/src/support/fixtures.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-empty-pattern */
 
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
+import type { Group } from '@opendatacapture/schemas/group';
 import { request as apiRequestFactory, test as base, expect } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 
@@ -95,6 +96,15 @@ type TestFixtures = {
   /** Navigates to a route as `actingRole` and returns its page object. */
   getPageModel: GetPageModel;
   /**
+   * Authenticates as a group manager of a group created for this test alone, and returns that group.
+   *
+   * The `roleAccount` group is cached per worker and shared by every spec running in it, so a test
+   * that asserts on exactly what a group contains cannot use it. A group manager's `read Subject`
+   * rule is scoped to their own groups, so a fresh group bounds what this test can see to what it
+   * seeded.
+   */
+  isolatedGroupManager: () => Promise<Group>;
+  /**
    * Writes `appState` to localStorage on every navigation, for every test, whether or not it
    * authenticates through `authenticateAs`. Without it a spec that logs in through the real form
    * meets the app's in-code defaults, where the disclaimer dialog and then the walkthrough overlay
@@ -150,6 +160,14 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         return pageModel;
       }
     );
+  },
+  isolatedGroupManager: async ({ api, authenticateAs }, use) => {
+    await use(async () => {
+      const group = await api.createGroup();
+      const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
+      await authenticateAs(credentials);
+      return group;
+    });
   },
   roleAccount: [
     async ({ adminToken, api, apiRequestContext }, use) => {


### PR DESCRIPTION
Fixes #1413.

The "with records only" datahub filter resolved its subject list with:

```ts
findMany({ distinct: ['subjectId'], select: { subjectId: true }, where })
```

Prisma applies `distinct` in the **query engine**, not in MongoDB, so the driver receives one row per *record* and collapses them to one row per subject only after they have arrived. On a group holding 100k records that is 100k rows transferred to produce a list of at most a few thousand ids.

`groupBy` asks MongoDB for the distinct values directly.

## Measured over HTTP, live instance, 200,300 records, median of 7

| | `main` | this branch |
|---|---|---|
| `GET /v1/subjects?hasRecord=true` | **366 ms** | **42 ms** |
| `GET /v1/subjects?groupId=<g>&hasRecord=true` | 67 ms | 37 ms |
| `GET /v1/subjects?groupId=<g>` (filter off, for reference) | 4 ms | 3 ms |

The unscoped case is where the difference shows, and it widens with the collection: `groupBy` returns one row per subject regardless of how many records back it, so its cost is flat in records-per-subject where the old form was linear.

Confirmed at the query level too — the same comparison run directly through the Prisma client:

```
findMany distinct (current impl), scoped        197ms  -> 55 ids
findMany distinct (current impl), unscoped     1229ms  -> 100 ids
groupBy by subjectId, scoped                     95ms  -> 55 ids
groupBy by subjectId, unscoped                  100ms  -> 100 ids
```

Note `distinct` going 197 → 1229 ms as the scope widens while `groupBy` stays at ~100 ms.

## The issue's "better still" suggestion is wrong — please don't take it

#1413 floated expressing this as a relation filter on Subject:

```ts
{ instrumentRecords: { some: groupId ? { groupId } : {} } }
```

and said it was "the version worth trying first". **I measured it on the same dataset and it takes 26,849 ms** — 270× slower than the code being replaced, let alone the replacement:

```
subject.findMany({instrumentRecords:{some}})   26849ms  -> 55 subjects
```

Prisma compiles a relation filter on MongoDB into a `$lookup` over the whole record collection. That is the same construct that fails outright at scale in #1416 (fixed in #1423 by removing it), and it carries the same 100 MiB per-document ceiling. I've left a comment on the method saying so, and corrected the issue.

## Also fixed: the record query now respects the caller's ability

`querySubjectIdsWithRecords` ignored `ability` entirely. The outer subject query already constrained the result, so this was **not** a data leak — but the inner query read records the caller had no permission to read, and was inconsistent with every other query in the service.

## Tests

The three existing `hasRecord` tests are updated to the new call and still assert the same outcomes. Two added:

- the ids are grouped in the database, asserting `groupBy` is used and `findMany` is **not** — a guard against the `distinct` form coming back;
- the record query carries the caller's ability rather than being unconstrained.

## Checks

- `tsc --noEmit` on `apps/api` — clean
- `eslint src` — clean
- `prettier --check` — clean
- `vitest run` (whole workspace) — 254 passed, 1 skipped, 1 failed

The one failure is `instrument-records.service.spec.ts > upload > should create records with pending set`. This branch is cut from `main` so it carries that pre-existing failure; **#1422 fixes it**.

---

## Rebased onto `main`, review item addressed

Rebased onto `26ec89168`; CI green.

**Copilot: `expect(call.where.AND[0]).not.toStrictEqual({})` did not prove anything.** Correct, and
worse than it looks — an unconditional `read` rule legitimately produces `{}`, so that assertion would
have passed against a query that ignored the caller entirely. The test now builds a *conditioned*
ability and compares the clause against `accessibleQuery(ability, 'read', 'InstrumentRecord')`
directly, with `accessibleQuery` imported as suggested.

Verified by mutation: passing `undefined` in place of the ability now fails the test, where before it
passed.

---

## Round 2: rebased onto `5bfe4b2dc`, review items addressed

**1. The 500 — confirmed and fixed.** Reproduced exactly as you described: with a STANDARD ability,
`accessibleQuery(ability, 'read', 'InstrumentRecord')` throws
`ForbiddenError: It's not allowed to run "read" on "InstrumentRecord"` rather than returning `{}`.
`querySubjectIdsWithRecords` now returns an empty list for a caller holding no such rule, before
`accessibleQuery` is reached — the contract you settled on. The scoping itself stays.

**2. A unit test for that caller.** Added, asserting the empty list rather than a throw, with the
ability built through `AbilityFactory` with a STANDARD payload. Verified by mutation: removing the
guard fails it with that `ForbiddenError`.

**3. End-to-end.** `datahub.spec.ts` now toggles "With records only" and asserts the table empties,
plus an API-level case asserting a standard user gets an answer rather than a 500. Both verified by
mutation. This needed the `datahub-filter-has-records` and `datahub-filters-trigger` testids and
filter locators you flagged as missing.

The narrowing test has to know exactly what its group holds, and the `roleAccount` group is shared by
every spec in a worker, so this adds an `isolatedGroupManager` fixture. **#1425 introduces the same
fixture** — whichever merges second should drop its copy.

**4. The `not.toHaveBeenCalled()` assertion.** Dropped, agreed — the `groupBy` assertion above it
already rules out the `distinct` form.

The comment recording why the relation filter was rejected is kept, as you asked. Group-visibility
consequence stays as decided.

---

## Round 3: rebased onto `f97706ea8`, review items addressed

**1. The null-`groupId` note.** In the doc comment of `querySubjectIdsWithRecords`, next to the
STANDARD short-circuit, as you asked: the `accessibleQuery` clause drops records whose `groupId` is
null, because a group manager's rule is `groupId: { in: [...] }` and Prisma's `in` never matches
null.

**2. Rebase.** The app code did not change. Its patch is byte-identical to the reviewed one. Every
conflict was in `testing/`, which `main` reworked under this branch:

- `authenticateAs` on `main` now takes `$LoginCredentials`, and `appState` moved into the autouse
  `seedAppState` fixture. So `isolatedGroupManager` is now create group → create user →
  `authenticateAs(credentials)`, and the `injectAuth` helper this branch added is gone. The commit
  message that described that helper no longer mentions it.
- `datahub.spec.ts` keeps `main`'s three new tests, with this branch's two after them.
  `DatahubPage` keeps `main`'s `searchInput`. `api-client.ts` keeps `main`'s `findGroupById`,
  `setMailEnabled` and `updateUser` next to this branch's helpers.

`main` changed `ability.factory.ts` after the last review. The diff adds only an early return for a
user who must reset their password. It does not touch the STANDARD rules. The STANDARD unit test
and the e2e case that asserts `[]` both still pass. `apps/api/AGENTS.md` on `main` now also
recommends this exact short-circuit (`ability.can` before `accessibleQuery`).

`isolatedGroupManager`, its `testing/AGENTS.md` entry, `findInstrumentIdByName`, `uploadRecords`
and `HAPPINESS_RECORD` are now identical to #1425's copies. After this PR merges, #1425 conflicts
only where both PRs append to the same place (`datahub.spec.ts`, `DatahubPage`, the
`api-client.ts` imports).

**3. Commit scope.** `test(e2e)` is now `test(testing)`: `e2e` is not a workspace, and Commitlint
warns on it.

**Checks** at `8ab6ea2c7`:

- `pnpm lint`: 34/34 tasks, no files rewritten
- `pnpm test`: 142 files, 1160 tests passed
- `pnpm test:e2e`: 174 passed, 1 failed. The one failure is `subject-detail.spec.ts` › "should plot a selected measure on the graph tab", which no PR touches. It is flaky under full-suite load: "element was detached from the DOM" on the Measures button. It passes on its own, 3 of 3 runs.
- `commitlint --from origin/main`: clean

---

## Round 4: Copilot review of `8ab6ea2c7`

- **`as any` on the STANDARD token payload.** Fixed in `4eb3c58c9`. The payload is now complete and
  typed, with `mustResetPassword: false`. The test still fails when the guard is removed.
- **"a `instrumentRecords`".** Fixed in `b9b6493af`.

**Checks** at `b9b6493af`: `pnpm lint` 34/34 tasks, `pnpm test` 1160 passed. The e2e tests did not
change: this round changed only a unit test and a comment. CI green at this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZEJLwa7jwD8sKzcE4PfSc
https://claude.ai/code/session_01KLfKsdHT1arfrc2fdT1fWq

