### PR TITLE
perf(api): batch session creation and scope the upload response (alternative to #1424)

### DIFF
--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -184,19 +184,60 @@ describe('InstrumentRecordsService', () => {
     beforeEach(() => {
       instrumentsService.findById.mockResolvedValue(mockInstrument as any);
       subjectsService.createMany.mockResolvedValue([] as any);
-      sessionsService.create.mockResolvedValue(mockSession as any);
+      sessionsService.createMany.mockResolvedValue([mockSession] as any);
       sessionsService.deleteByIds.mockResolvedValue(undefined as any);
       instrumentRecordModel.createMany.mockResolvedValue([] as any);
       instrumentRecordModel.findMany.mockResolvedValue([] as any);
     });
 
-    it('should call sessionsService.create with the provided username', async () => {
+    it('should create the sessions in one batched call carrying the provided username', async () => {
       usersService.findByUsername.mockResolvedValueOnce({ groups: [{ id: 'group-1' }], username: 'validuser' } as any);
 
       await instrumentRecordsService.upload({ ...baseUploadData, groupId: 'group-1', username: 'validuser' });
 
       expect(usersService.findByUsername).toHaveBeenCalledWith('validuser', undefined);
-      expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: 'validuser' }));
+      expect(sessionsService.create).not.toHaveBeenCalled();
+      expect(sessionsService.createMany).toHaveBeenCalledTimes(1);
+      expect(sessionsService.createMany).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: 'group-1', type: 'RETROSPECTIVE', username: 'validuser' })
+      );
+    });
+
+    it('should batch every record into a single session creation call', async () => {
+      const records = Array.from({ length: 25 }, (_, i) => ({
+        data: { answer: i },
+        date: new Date(),
+        subjectId: `subject-${i}`
+      }));
+      sessionsService.createMany.mockResolvedValueOnce(
+        records.map((_, i) => ({ ...mockSession, id: `session-${i}` })) as any
+      );
+
+      await instrumentRecordsService.upload({ ...baseUploadData, records });
+
+      expect(sessionsService.createMany).toHaveBeenCalledTimes(1);
+      const [call] = sessionsService.createMany.mock.lastCall as [{ entries: unknown[] }];
+      expect(call.entries).toHaveLength(25);
+    });
+
+    it('should pair each record with the session created for it, by position', async () => {
+      const records = [
+        { data: { answer: 1 }, date: new Date(), subjectId: 'subject-a' },
+        { data: { answer: 2 }, date: new Date(), subjectId: 'subject-b' }
+      ];
+      sessionsService.createMany.mockResolvedValueOnce([
+        { ...mockSession, id: 'session-a' },
+        { ...mockSession, id: 'session-b' }
+      ] as any);
+
+      await instrumentRecordsService.upload({ ...baseUploadData, records });
+
+      expect(instrumentRecordModel.createMany.mock.lastCall?.[0]).toMatchObject({
+        data: [
+          { sessionId: 'session-a', subjectId: 'subject-a' },
+          { sessionId: 'session-b', subjectId: 'subject-b' }
+        ]
+      });
     });
 
     it('should throw a ForbiddenException when a non-admin user uploads without a group', async () => {
@@ -209,7 +250,7 @@ describe('InstrumentRecordsService', () => {
         instrumentRecordsService.upload({ ...baseUploadData, username: 'validuser' })
       ).rejects.toBeInstanceOf(ForbiddenException);
 
-      expect(sessionsService.create).not.toHaveBeenCalled();
+      expect(sessionsService.createMany).not.toHaveBeenCalled();
     });
 
     it('should throw a ForbiddenException when a user uploads to a group they are not a member of', async () => {
@@ -222,7 +263,7 @@ describe('InstrumentRecordsService', () => {
         instrumentRecordsService.upload({ ...baseUploadData, groupId: 'group-1', username: 'validuser' })
       ).rejects.toBeInstanceOf(ForbiddenException);
 
-      expect(sessionsService.create).not.toHaveBeenCalled();
+      expect(sessionsService.createMany).not.toHaveBeenCalled();
     });
 
     it('should reject and not create any sessions when an unknown username is provided', async () => {
@@ -234,18 +275,89 @@ describe('InstrumentRecordsService', () => {
         NotFoundException
       );
 
-      expect(sessionsService.create).not.toHaveBeenCalled();
+      expect(sessionsService.createMany).not.toHaveBeenCalled();
     });
 
-    it('should call sessionsService.create with username undefined when no username is provided', async () => {
+    it('should create the sessions with username undefined when no username is provided', async () => {
       await instrumentRecordsService.upload({ ...baseUploadData });
 
       expect(usersService.findByUsername).not.toHaveBeenCalled();
-      expect(sessionsService.create).toHaveBeenCalledWith(expect.objectContaining({ username: undefined }));
+      expect(sessionsService.createMany).toHaveBeenCalledWith(expect.objectContaining({ username: undefined }));
     });
 
-    // `pending` is intentionally not written on create; the find-side OR filter treats missing and
-    // false `pending` alike (see the 'find' describe block), so records stay query-visible without it.
+    it('should return only the records this upload created, not every record in the group', async () => {
+      await instrumentRecordsService.upload({ ...baseUploadData, groupId: 'group-1' });
+
+      expect(instrumentRecordModel.findMany).toHaveBeenCalledWith({
+        where: { sessionId: { in: ['session-1'] } }
+      });
+    });
+
+    it('should reject an invalid record before creating any sessions', async () => {
+      instrumentsService.findById.mockResolvedValue({
+        ...mockInstrument,
+        validationSchema: { safeParse: () => ({ error: { issues: [] }, success: false }) }
+      } as any);
+
+      await expect(instrumentRecordsService.upload({ ...baseUploadData })).rejects.toBeInstanceOf(
+        UnprocessableEntityException
+      );
+
+      expect(sessionsService.createMany).not.toHaveBeenCalled();
+      expect(instrumentRecordModel.createMany).not.toHaveBeenCalled();
+    });
+
+    it('should report which record failed and why, so a rejected batch can be corrected', async () => {
+      const issues = [{ message: 'Required', path: ['answer'] }];
+      instrumentsService.findById.mockResolvedValue({
+        ...mockInstrument,
+        validationSchema: {
+          safeParse: (data: any) => (data.answer === 2 ? { error: { issues }, success: false } : { data, success: true })
+        }
+      } as any);
+
+      await expect(
+        instrumentRecordsService.upload({
+          ...baseUploadData,
+          records: [
+            { data: { answer: 1 }, date: new Date(), subjectId: 'subject-1' },
+            { data: { answer: 2 }, date: new Date(), subjectId: 'subject-2' }
+          ]
+        })
+      ).rejects.toMatchObject({
+        response: { issues, message: expect.stringContaining('at index 1') }
+      });
+    });
+
+    it('should roll back the sessions when the record insert fails, so none is left without records', async () => {
+      instrumentRecordModel.createMany.mockRejectedValueOnce(new Error('insert failed'));
+
+      await expect(instrumentRecordsService.upload({ ...baseUploadData })).rejects.toThrow('insert failed');
+
+      expect(sessionsService.deleteByIds).toHaveBeenCalledWith(['session-1']);
+    });
+
+    it('should keep the sessions when only the read-back fails, since the records already reference them', async () => {
+      instrumentRecordModel.findMany.mockRejectedValueOnce(new Error('read-back failed'));
+
+      await expect(instrumentRecordsService.upload({ ...baseUploadData })).rejects.toThrow('read-back failed');
+
+      expect(sessionsService.deleteByIds).not.toHaveBeenCalled();
+    });
+
+    // The bulk payload cannot carry a file and this path never attaches one, so such a record could
+    // only ever be incomplete. Refusing it is the same call `create` makes for series instruments.
+    it('should reject a file instrument rather than write a record its files can never reach', async () => {
+      instrumentsService.findById.mockResolvedValue({ ...mockInstrument, kind: 'FILE' } as any);
+
+      await expect(instrumentRecordsService.upload({ ...baseUploadData })).rejects.toBeInstanceOf(
+        UnprocessableEntityException
+      );
+
+      expect(sessionsService.createMany).not.toHaveBeenCalled();
+      expect(instrumentRecordModel.createMany).not.toHaveBeenCalled();
+    });
+
     it('should create records via createMany with the processed record data', async () => {
       await instrumentRecordsService.upload({ ...baseUploadData });
 

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -24,7 +24,7 @@ import type {
   UploadInstrumentRecordsData
 } from '@opendatacapture/schemas/instrument-records';
 import { Prisma } from '@prisma/client';
-import type { InstrumentRecord as PrismaInstrumentRecord, Session } from '@prisma/client';
+import type { InstrumentRecord as PrismaInstrumentRecord } from '@prisma/client';
 import { isNumber, mergeWith, pickBy } from 'lodash-es';
 
 import { accessibleQuery } from '@/auth/ability.utils';
@@ -34,7 +34,6 @@ import { GroupsService } from '@/groups/groups.service';
 import { InstrumentsService } from '@/instruments/instruments.service';
 import { SessionsService } from '@/sessions/sessions.service';
 import { StorageService } from '@/storage/storage.service';
-import { CreateSubjectDto } from '@/subjects/dto/create-subject.dto';
 import { SubjectsService } from '@/subjects/subjects.service';
 import { UsersService } from '@/users/users.service';
 
@@ -398,6 +397,14 @@ export class InstrumentRecordsService {
         `Cannot create instrument record for series instrument '${instrument.id}'`
       );
     }
+    // A bulk-uploaded file record could never be completed: the payload schema has nowhere to carry a
+    // file, this path never attaches one, and the response ids the client would need to attach one
+    // afterwards are discarded. Refuse it rather than write a record that can only ever be pending.
+    if (instrument.kind === 'FILE') {
+      throw new UnprocessableEntityException(
+        `Cannot create instrument record for file instrument '${instrument.id}': files cannot be attached to a bulk upload`
+      );
+    }
 
     if (username) {
       const user = await this.usersService.findByUsername(username, options);
@@ -409,70 +416,60 @@ export class InstrumentRecordsService {
       }
     }
 
-    const createdSessionsArray: Session[] = [];
+    // Every record is validated before anything is written, so a malformed record in the middle of a
+    // batch rejects the request without first creating sessions that then have to be rolled back.
+    const validatedRecords = records.map((record, index) => {
+      const parseResult = instrument.validationSchema.safeParse(this.parseJson(record.data));
+      if (!parseResult.success) {
+        throw new UnprocessableEntityException({
+          error: 'Unprocessable Entity',
+          issues: parseResult.error.issues,
+          message: `Data received for record at index ${index} does not pass validation schema of instrument '${instrument.id}'`,
+          statusCode: 422
+        });
+      }
+      return { data: parseResult.data, date: record.date, subjectId: record.subjectId };
+    });
 
+    // One batched call rather than one session creation per record, which cost several queries each.
+    // Returned in input order, so each record can be paired with its session by index.
+    const sessions = await this.sessionsService.createMany({
+      entries: validatedRecords.map((record) => ({
+        date: record.date,
+        subjectData: { id: record.subjectId }
+      })),
+      groupId: groupId ?? null,
+      type: 'RETROSPECTIVE',
+      username: username ?? undefined
+    });
+
+    // Only the insert is rolled back on failure. Deleting the sessions after it has succeeded would
+    // strand the records that now reference them, so the read-back below sits outside the catch.
     try {
-      const subjectIdList = records.map(({ subjectId }) => {
-        const subjectToAdd: CreateSubjectDto = { id: subjectId };
-
-        return subjectToAdd;
-      });
-
-      await this.subjectsService.createMany(subjectIdList);
-
-      const preProcessedRecords = await Promise.all(
-        records.map(async (record) => {
-          const { data: rawData, date, subjectId } = record;
-
-          // Validate data
-          const parseResult = instrument.validationSchema.safeParse(this.parseJson(rawData));
-          if (!parseResult.success) {
-            console.error(parseResult.error.issues);
-            throw new UnprocessableEntityException(
-              `Data received for record does not pass validation schema of instrument '${instrument.id}'`
-            );
-          }
-
-          const session = await this.sessionsService.create({
-            date: date,
-            groupId: groupId ?? null,
-            subjectData: { id: subjectId },
-            type: 'RETROSPECTIVE',
-            username: username ?? undefined
-          });
-
-          createdSessionsArray.push(session);
-
-          const computedMeasures = instrument.measures
-            ? this.instrumentMeasuresService.computeMeasures(instrument.measures, parseResult.data)
-            : null;
-
-          return {
-            computedMeasures,
-            data: this.serializeData(parseResult.data),
-            date,
-            groupId,
-            instrumentId,
-            pending: false,
-            sessionId: session.id,
-            subjectId
-          };
-        })
-      );
       await this.instrumentRecordModel.createMany({
-        data: preProcessedRecords
-      });
-
-      return this.instrumentRecordModel.findMany({
-        where: {
+        data: validatedRecords.map((record, index) => ({
+          computedMeasures: instrument.measures
+            ? this.instrumentMeasuresService.computeMeasures(instrument.measures, record.data)
+            : null,
+          data: this.serializeData(record.data),
+          date: record.date,
           groupId,
-          instrumentId
-        }
+          instrumentId,
+          pending: false,
+          sessionId: sessions[index]!.id,
+          subjectId: record.subjectId
+        }))
       });
     } catch (err) {
-      await this.sessionsService.deleteByIds(createdSessionsArray.map((session) => session.id));
+      await this.sessionsService.deleteByIds(sessions.map((session) => session.id));
       throw err;
     }
+
+    return this.instrumentRecordModel.findMany({
+      where: {
+        sessionId: { in: sessions.map((session) => session.id) }
+      }
+    });
   }
 
   private getInstrumentById(instrumentId: string) {

--- a/apps/api/src/sessions/__tests__/sessions.service.spec.ts
+++ b/apps/api/src/sessions/__tests__/sessions.service.spec.ts
@@ -1,0 +1,173 @@
+import { getModelToken, LoggingService, PRISMA_CLIENT_TOKEN } from '@douglasneuroinformatics/libnest';
+import type { Model } from '@douglasneuroinformatics/libnest';
+import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
+import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
+import { Test } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RuntimePrismaClient } from '@/core/prisma';
+import { GroupsService } from '@/groups/groups.service';
+import { SubjectsService } from '@/subjects/subjects.service';
+
+import { SessionsService } from '../sessions.service';
+
+describe('SessionsService', () => {
+  let sessionsService: SessionsService;
+  let sessionModel: MockedInstance<Model<'Session'>>;
+  let groupsService: MockedInstance<GroupsService>;
+  let subjectsService: MockedInstance<SubjectsService>;
+  let prismaClient: MockedInstance<RuntimePrismaClient> & { [key: string]: any };
+
+  const entry = (id: string) => ({ date: new Date(), subjectData: { id } });
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        SessionsService,
+        MockFactory.createForModelToken(getModelToken('Session')),
+        MockFactory.createForService(GroupsService),
+        MockFactory.createForService(LoggingService),
+        MockFactory.createForService(SubjectsService),
+        {
+          provide: PRISMA_CLIENT_TOKEN,
+          useValue: {
+            subject: { findMany: vi.fn(), updateMany: vi.fn() },
+            user: { findFirst: vi.fn() }
+          }
+        }
+      ]
+    }).compile();
+
+    sessionsService = moduleRef.get(SessionsService);
+    sessionModel = moduleRef.get(getModelToken('Session'));
+    groupsService = moduleRef.get(GroupsService);
+    subjectsService = moduleRef.get(SubjectsService);
+    prismaClient = moduleRef.get(PRISMA_CLIENT_TOKEN);
+
+    subjectsService.createMany.mockResolvedValue([] as any);
+    subjectsService.addGroupForSubjects.mockResolvedValue({ count: 0 } as any);
+    prismaClient.subject.findMany.mockResolvedValue([{ groupIds: [], id: 'subject-1' }]);
+    prismaClient.user.findFirst.mockResolvedValue(null);
+    sessionModel.createMany.mockResolvedValue({ count: 1 } as any);
+    sessionModel.findMany.mockImplementation(({ where }: any) =>
+      Promise.resolve(where.id.in.map((id: string) => ({ id })))
+    );
+  });
+
+  describe('createMany', () => {
+    it('should not touch the database when there are no entries', async () => {
+      await expect(sessionsService.createMany({ entries: [], groupId: null, type: 'RETROSPECTIVE' })).resolves.toEqual(
+        []
+      );
+      expect(sessionModel.createMany).not.toHaveBeenCalled();
+    });
+
+    // A session whose groupId is unset is invisible to a group manager, whose Session rule is
+    // { groupId: { in: [...] } }, and uncounted by every group-scoped query.
+    it('should set the groupId on a session for a subject that is already a member of the group', async () => {
+      prismaClient.subject.findMany.mockResolvedValueOnce([{ groupIds: ['group-1'], id: 'subject-1' }]);
+      groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
+
+      await sessionsService.createMany({
+        entries: [entry('subject-1')],
+        groupId: 'group-1',
+        type: 'RETROSPECTIVE'
+      });
+
+      expect(sessionModel.createMany.mock.lastCall?.[0]).toMatchObject({ data: [{ groupId: 'group-1' }] });
+    });
+
+    it('should associate the batch with the group in a single write', async () => {
+      prismaClient.subject.findMany.mockResolvedValueOnce([
+        { groupIds: ['group-1'], id: 'subject-1' },
+        { groupIds: [], id: 'subject-2' }
+      ]);
+      groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
+
+      await sessionsService.createMany({
+        entries: [entry('subject-1'), entry('subject-2')],
+        groupId: 'group-1',
+        type: 'RETROSPECTIVE'
+      });
+
+      // Every subject is handed over; which of them actually need the write is decided by the query
+      // `SubjectsService` builds, not by a membership list read here.
+      expect(subjectsService.addGroupForSubjects).toHaveBeenCalledExactlyOnceWith(
+        ['subject-1', 'subject-2'],
+        'group-1'
+      );
+    });
+
+    it('should not associate anything when no group was supplied', async () => {
+      await sessionsService.createMany({ entries: [entry('subject-1')], groupId: null, type: 'RETROSPECTIVE' });
+
+      expect(groupsService.findById).not.toHaveBeenCalled();
+      expect(subjectsService.addGroupForSubjects).not.toHaveBeenCalled();
+    });
+
+    it('should return the sessions in the order the entries were given, so callers can pair by index', async () => {
+      prismaClient.subject.findMany.mockResolvedValueOnce([
+        { groupIds: [], id: 'subject-a' },
+        { groupIds: [], id: 'subject-b' }
+      ]);
+      // The read-back is a findMany, which is free to return documents in any order.
+      sessionModel.findMany.mockImplementationOnce(({ where }: any) =>
+        Promise.resolve([...where.id.in].reverse().map((id: string) => ({ id })))
+      );
+
+      const sessions = await sessionsService.createMany({
+        entries: [entry('subject-a'), entry('subject-b')],
+        groupId: null,
+        type: 'RETROSPECTIVE'
+      });
+
+      const [call] = sessionModel.createMany.mock.lastCall as [{ data: { id: string; subjectId: string }[] }];
+      expect(sessions.map((session) => session.id)).toStrictEqual(call.data.map((session) => session.id));
+      expect(call.data.map((session) => session.subjectId)).toStrictEqual(['subject-a', 'subject-b']);
+    });
+
+    it('should create every session in one call rather than one call per entry', async () => {
+      const entries = Array.from({ length: 20 }, (_, i) => entry(`subject-${i}`));
+      prismaClient.subject.findMany.mockResolvedValueOnce(entries.map((_, i) => ({ groupIds: [], id: `subject-${i}` })));
+
+      await sessionsService.createMany({ entries, groupId: null, type: 'RETROSPECTIVE' });
+
+      expect(sessionModel.createMany).toHaveBeenCalledOnce();
+      expect(sessionModel.createMany.mock.lastCall?.[0].data).toHaveLength(20);
+    });
+
+    it('should resolve the user once for the whole batch and stamp it on every session', async () => {
+      const entries = [entry('subject-a'), entry('subject-b')];
+      prismaClient.subject.findMany.mockResolvedValueOnce([
+        { groupIds: [], id: 'subject-a' },
+        { groupIds: [], id: 'subject-b' }
+      ]);
+      prismaClient.user.findFirst.mockResolvedValueOnce({ id: 'user-1', username: 'someone' });
+
+      await sessionsService.createMany({ entries, groupId: null, type: 'RETROSPECTIVE', username: 'someone' });
+
+      expect(prismaClient.user.findFirst).toHaveBeenCalledOnce();
+      expect(sessionModel.createMany.mock.lastCall?.[0]).toMatchObject({
+        data: [{ userId: 'user-1' }, { userId: 'user-1' }]
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('should return the single session created for the entry', async () => {
+      groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
+
+      const session = await sessionsService.create({
+        date: new Date(),
+        groupId: 'group-1',
+        subjectData: { id: 'subject-1' },
+        type: 'IN_PERSON'
+      });
+
+      expect(sessionModel.createMany.mock.lastCall?.[0]).toMatchObject({
+        data: [{ groupId: 'group-1', subjectId: 'subject-1', type: 'IN_PERSON' }]
+      });
+      expect(session.id).toBe(sessionModel.createMany.mock.lastCall?.[0].data[0].id);
+    });
+  });
+});

--- a/apps/api/src/sessions/__tests__/sessions.service.spec.ts
+++ b/apps/api/src/sessions/__tests__/sessions.service.spec.ts
@@ -31,7 +31,6 @@ describe('SessionsService', () => {
         {
           provide: PRISMA_CLIENT_TOKEN,
           useValue: {
-            subject: { findMany: vi.fn(), updateMany: vi.fn() },
             user: { findFirst: vi.fn() }
           }
         }
@@ -46,7 +45,7 @@ describe('SessionsService', () => {
 
     subjectsService.createMany.mockResolvedValue([] as any);
     subjectsService.addGroupForSubjects.mockResolvedValue({ count: 0 } as any);
-    prismaClient.subject.findMany.mockResolvedValue([{ groupIds: [], id: 'subject-1' }]);
+    subjectsService.findByIds.mockResolvedValue([{ groupIds: [], id: 'subject-1' }] as any);
     prismaClient.user.findFirst.mockResolvedValue(null);
     sessionModel.createMany.mockResolvedValue({ count: 1 } as any);
     sessionModel.findMany.mockImplementation(({ where }: any) =>
@@ -65,7 +64,7 @@ describe('SessionsService', () => {
     // A session whose groupId is unset is invisible to a group manager, whose Session rule is
     // { groupId: { in: [...] } }, and uncounted by every group-scoped query.
     it('should set the groupId on a session for a subject that is already a member of the group', async () => {
-      prismaClient.subject.findMany.mockResolvedValueOnce([{ groupIds: ['group-1'], id: 'subject-1' }]);
+      subjectsService.findByIds.mockResolvedValueOnce([{ groupIds: ['group-1'], id: 'subject-1' }] as any);
       groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
 
       await sessionsService.createMany({
@@ -78,10 +77,10 @@ describe('SessionsService', () => {
     });
 
     it('should associate the batch with the group in a single write', async () => {
-      prismaClient.subject.findMany.mockResolvedValueOnce([
+      subjectsService.findByIds.mockResolvedValueOnce([
         { groupIds: ['group-1'], id: 'subject-1' },
         { groupIds: [], id: 'subject-2' }
-      ]);
+      ] as any);
       groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
 
       await sessionsService.createMany({
@@ -106,10 +105,10 @@ describe('SessionsService', () => {
     });
 
     it('should return the sessions in the order the entries were given, so callers can pair by index', async () => {
-      prismaClient.subject.findMany.mockResolvedValueOnce([
+      subjectsService.findByIds.mockResolvedValueOnce([
         { groupIds: [], id: 'subject-a' },
         { groupIds: [], id: 'subject-b' }
-      ]);
+      ] as any);
       // The read-back is a findMany, which is free to return documents in any order.
       sessionModel.findMany.mockImplementationOnce(({ where }: any) =>
         Promise.resolve([...where.id.in].reverse().map((id: string) => ({ id })))
@@ -128,7 +127,9 @@ describe('SessionsService', () => {
 
     it('should create every session in one call rather than one call per entry', async () => {
       const entries = Array.from({ length: 20 }, (_, i) => entry(`subject-${i}`));
-      prismaClient.subject.findMany.mockResolvedValueOnce(entries.map((_, i) => ({ groupIds: [], id: `subject-${i}` })));
+      subjectsService.findByIds.mockResolvedValueOnce(
+        entries.map((_, i) => ({ groupIds: [], id: `subject-${i}` })) as any
+      );
 
       await sessionsService.createMany({ entries, groupId: null, type: 'RETROSPECTIVE' });
 
@@ -138,10 +139,10 @@ describe('SessionsService', () => {
 
     it('should resolve the user once for the whole batch and stamp it on every session', async () => {
       const entries = [entry('subject-a'), entry('subject-b')];
-      prismaClient.subject.findMany.mockResolvedValueOnce([
+      subjectsService.findByIds.mockResolvedValueOnce([
         { groupIds: [], id: 'subject-a' },
         { groupIds: [], id: 'subject-b' }
-      ]);
+      ] as any);
       prismaClient.user.findFirst.mockResolvedValueOnce({ id: 'user-1', username: 'someone' });
 
       await sessionsService.createMany({ entries, groupId: null, type: 'RETROSPECTIVE', username: 'someone' });

--- a/apps/api/src/sessions/__tests__/sessions.service.spec.ts
+++ b/apps/api/src/sessions/__tests__/sessions.service.spec.ts
@@ -2,6 +2,7 @@ import { getModelToken, LoggingService, PRISMA_CLIENT_TOKEN } from '@douglasneur
 import type { Model } from '@douglasneuroinformatics/libnest';
 import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
 import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
+import { InternalServerErrorException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -45,7 +46,6 @@ describe('SessionsService', () => {
 
     subjectsService.createMany.mockResolvedValue([] as any);
     subjectsService.addGroupForSubjects.mockResolvedValue({ count: 0 } as any);
-    subjectsService.findByIds.mockResolvedValue([{ groupIds: [], id: 'subject-1' }] as any);
     prismaClient.user.findFirst.mockResolvedValue(null);
     sessionModel.createMany.mockResolvedValue({ count: 1 } as any);
     sessionModel.findMany.mockImplementation(({ where }: any) =>
@@ -64,7 +64,6 @@ describe('SessionsService', () => {
     // A session whose groupId is unset is invisible to a group manager, whose Session rule is
     // { groupId: { in: [...] } }, and uncounted by every group-scoped query.
     it('should set the groupId on a session for a subject that is already a member of the group', async () => {
-      subjectsService.findByIds.mockResolvedValueOnce([{ groupIds: ['group-1'], id: 'subject-1' }] as any);
       groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
 
       await sessionsService.createMany({
@@ -77,10 +76,6 @@ describe('SessionsService', () => {
     });
 
     it('should associate the batch with the group in a single write', async () => {
-      subjectsService.findByIds.mockResolvedValueOnce([
-        { groupIds: ['group-1'], id: 'subject-1' },
-        { groupIds: [], id: 'subject-2' }
-      ] as any);
       groupsService.findById.mockResolvedValueOnce({ id: 'group-1' } as any);
 
       await sessionsService.createMany({
@@ -105,10 +100,6 @@ describe('SessionsService', () => {
     });
 
     it('should return the sessions in the order the entries were given, so callers can pair by index', async () => {
-      subjectsService.findByIds.mockResolvedValueOnce([
-        { groupIds: [], id: 'subject-a' },
-        { groupIds: [], id: 'subject-b' }
-      ] as any);
       // The read-back is a findMany, which is free to return documents in any order.
       sessionModel.findMany.mockImplementationOnce(({ where }: any) =>
         Promise.resolve([...where.id.in].reverse().map((id: string) => ({ id })))
@@ -127,9 +118,6 @@ describe('SessionsService', () => {
 
     it('should create every session in one call rather than one call per entry', async () => {
       const entries = Array.from({ length: 20 }, (_, i) => entry(`subject-${i}`));
-      subjectsService.findByIds.mockResolvedValueOnce(
-        entries.map((_, i) => ({ groupIds: [], id: `subject-${i}` })) as any
-      );
 
       await sessionsService.createMany({ entries, groupId: null, type: 'RETROSPECTIVE' });
 
@@ -139,10 +127,6 @@ describe('SessionsService', () => {
 
     it('should resolve the user once for the whole batch and stamp it on every session', async () => {
       const entries = [entry('subject-a'), entry('subject-b')];
-      subjectsService.findByIds.mockResolvedValueOnce([
-        { groupIds: [], id: 'subject-a' },
-        { groupIds: [], id: 'subject-b' }
-      ] as any);
       prismaClient.user.findFirst.mockResolvedValueOnce({ id: 'user-1', username: 'someone' });
 
       await sessionsService.createMany({ entries, groupId: null, type: 'RETROSPECTIVE', username: 'someone' });
@@ -151,6 +135,22 @@ describe('SessionsService', () => {
       expect(sessionModel.createMany.mock.lastCall?.[0]).toMatchObject({
         data: [{ userId: 'user-1' }, { userId: 'user-1' }]
       });
+    });
+
+    // Without this, a session missing from the read-back would be handed to the caller as
+    // `undefined` typed `Session`, and `POST /sessions` would answer 201 with an empty body.
+    it('should throw rather than return a gap when the read-back misses a created session', async () => {
+      sessionModel.findMany.mockImplementationOnce(({ where }: any) =>
+        Promise.resolve(where.id.in.slice(1).map((id: string) => ({ id })))
+      );
+
+      await expect(
+        sessionsService.createMany({
+          entries: [entry('subject-a'), entry('subject-b')],
+          groupId: null,
+          type: 'RETROSPECTIVE'
+        })
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
     });
   });
 

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -1,16 +1,22 @@
 import { InjectModel, InjectPrismaClient, LoggingService } from '@douglasneuroinformatics/libnest';
 import type { Model } from '@douglasneuroinformatics/libnest';
-import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import type { Group } from '@opendatacapture/schemas/group';
 import type { CreateSessionData } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { Prisma, Session, Subject, User } from '@prisma/client';
+import { ObjectId } from 'mongodb';
 
 import { accessibleQuery } from '@/auth/ability.utils';
 import type { RuntimePrismaClient } from '@/core/prisma';
 import type { EntityOperationOptions } from '@/core/types';
 import { GroupsService } from '@/groups/groups.service';
 import { SubjectsService } from '@/subjects/subjects.service';
+
+/** The batched form of `CreateSessionData`: what varies per session, and what the batch shares. */
+type CreateManySessionsData = Pick<CreateSessionData, 'groupId' | 'type' | 'username'> & {
+  entries: Pick<CreateSessionData, 'date' | 'subjectData'>[];
+};
 
 @Injectable()
 export class SessionsService {
@@ -29,54 +35,62 @@ export class SessionsService {
   }
 
   async create({ date, groupId, subjectData, type, username }: CreateSessionData): Promise<Session> {
-    this.loggingService.debug({ message: 'Attempting to create session' });
-    const subject = await this.resolveSubject(subjectData);
+    const [session] = await this.createMany({
+      entries: [{ date, subjectData }],
+      groupId,
+      type,
+      username
+    });
+    return session!;
+  }
 
-    let user: null | Omit<User, 'hashedPassword'> = null;
+  /**
+   * Create one session per entry, in a fixed number of queries rather than a fixed number per entry.
+   *
+   * Returned in the same order as `entries`, so a caller can pair each session with the input that
+   * produced it without a second lookup.
+   */
+  async createMany({ entries, groupId, type, username }: CreateManySessionsData): Promise<Session[]> {
+    if (entries.length === 0) {
+      return [];
+    }
+    this.loggingService.debug({ message: `Attempting to create ${entries.length} session(s)` });
 
-    if (username) {
-      user = await this.prismaClient.user.findFirst({
-        where: {
-          username: username
-        }
-      });
+    const subjects = await this.resolveSubjects(entries.map((entry) => entry.subjectData));
+
+    const user: null | Omit<User, 'hashedPassword'> = username
+      ? await this.prismaClient.user.findFirst({ where: { username } })
+      : null;
+
+    const group: Group | null = groupId ? await this.groupsService.findById(groupId) : null;
+    if (group) {
+      await this.subjectsService.addGroupForSubjects(
+        subjects.map((subject) => subject.id),
+        group.id
+      );
     }
 
-    // If the subject is not yet associated with the group, check it exists then append it
-    let group: Group | null = null;
-    if (groupId && !subject.groupIds.includes(groupId)) {
-      group = await this.groupsService.findById(groupId);
-      if (group) {
-        await this.subjectsService.addGroupForSubject(subject.id, group.id);
-      }
-    }
+    // Generated up front so the sessions can be read back in the order they were requested;
+    // createMany does not return the documents it inserted.
+    const ids = entries.map(() => new ObjectId().toHexString());
 
-    const { id } = await this.sessionModel.create({
-      data: {
-        date,
-        group: group
-          ? {
-              connect: { id: group.id }
-            }
-          : undefined,
-        subject: {
-          connect: { id: subject.id }
-        },
+    await this.sessionModel.createMany({
+      data: entries.map((entry, index) => ({
+        date: entry.date,
+        groupId: group?.id ?? null,
+        id: ids[index]!,
+        subjectId: entry.subjectData.id,
         type,
-        user: user
-          ? {
-              connect: { id: user.id }
-            }
-          : undefined
-      }
+        userId: user?.id ?? null
+      }))
     });
 
-    return (await this.sessionModel.findUnique({
-      include: {
-        subject: true
-      },
-      where: { id }
-    }))!;
+    const created = await this.sessionModel.findMany({
+      include: { subject: true },
+      where: { id: { in: ids } }
+    });
+    const byId = new Map(created.map((session) => [session.id, session]));
+    return ids.map((id) => byId.get(id)!);
   }
 
   async deleteById(id: string, { ability }: EntityOperationOptions = {}) {
@@ -126,18 +140,10 @@ export class SessionsService {
     return session;
   }
 
-  /** Get the subject if they exist, otherwise create them */
-  private async resolveSubject(subjectData: CreateSubjectData) {
-    this.loggingService.debug({ message: 'Attempting to resolve subject', subjectData });
-    let subject: Subject;
-    try {
-      subject = await this.subjectsService.findById(subjectData.id);
-    } catch (err) {
-      if (!(err instanceof NotFoundException)) {
-        throw new InternalServerErrorException('Unexpected Error', { cause: err });
-      }
-      subject = await this.subjectsService.create(subjectData);
-    }
-    return subject;
+  /** Get each subject if they exist, otherwise create them, in two queries regardless of count. */
+  private async resolveSubjects(subjectData: CreateSubjectData[]): Promise<Subject[]> {
+    const ids = Array.from(new Set(subjectData.map((subject) => subject.id)));
+    await this.subjectsService.createMany(subjectData);
+    return this.prismaClient.subject.findMany({ where: { id: { in: ids } } });
   }
 }

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -1,10 +1,9 @@
 import { InjectModel, InjectPrismaClient, LoggingService } from '@douglasneuroinformatics/libnest';
 import type { Model } from '@douglasneuroinformatics/libnest';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import type { Group } from '@opendatacapture/schemas/group';
 import type { CreateSessionData } from '@opendatacapture/schemas/session';
-import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
-import type { Prisma, Session, Subject, User } from '@prisma/client';
+import type { Prisma, Session, User } from '@prisma/client';
 import { ObjectId } from 'mongodb';
 
 import { accessibleQuery } from '@/auth/ability.utils';
@@ -56,7 +55,7 @@ export class SessionsService {
     }
     this.loggingService.debug({ message: `Attempting to create ${entries.length} session(s)` });
 
-    const subjects = await this.resolveSubjects(entries.map((entry) => entry.subjectData));
+    await this.subjectsService.createMany(entries.map((entry) => entry.subjectData));
 
     const user: null | Omit<User, 'hashedPassword'> = username
       ? await this.prismaClient.user.findFirst({ where: { username } })
@@ -65,7 +64,7 @@ export class SessionsService {
     const group: Group | null = groupId ? await this.groupsService.findById(groupId) : null;
     if (group) {
       await this.subjectsService.addGroupForSubjects(
-        subjects.map((subject) => subject.id),
+        Array.from(new Set(entries.map((entry) => entry.subjectData.id))),
         group.id
       );
     }
@@ -90,7 +89,13 @@ export class SessionsService {
       where: { id: { in: ids } }
     });
     const byId = new Map(created.map((session) => [session.id, session]));
-    return ids.map((id) => byId.get(id)!);
+    return ids.map((id) => {
+      const session = byId.get(id);
+      if (!session) {
+        throw new InternalServerErrorException(`Failed to read back created session with id: ${id}`);
+      }
+      return session;
+    });
   }
 
   async deleteById(id: string, { ability }: EntityOperationOptions = {}) {
@@ -138,12 +143,5 @@ export class SessionsService {
       throw new NotFoundException(`Failed to find session with ID: ${id}`);
     }
     return session;
-  }
-
-  /** Get each subject if they exist, otherwise create them, in two queries regardless of count. */
-  private async resolveSubjects(subjectData: CreateSubjectData[]): Promise<Subject[]> {
-    const ids = Array.from(new Set(subjectData.map((subject) => subject.id)));
-    await this.subjectsService.createMany(subjectData);
-    return this.subjectsService.findByIds(ids);
   }
 }

--- a/apps/api/src/sessions/sessions.service.ts
+++ b/apps/api/src/sessions/sessions.service.ts
@@ -144,6 +144,6 @@ export class SessionsService {
   private async resolveSubjects(subjectData: CreateSubjectData[]): Promise<Subject[]> {
     const ids = Array.from(new Set(subjectData.map((subject) => subject.id)));
     await this.subjectsService.createMany(subjectData);
-    return this.prismaClient.subject.findMany({ where: { id: { in: ids } } });
+    return this.subjectsService.findByIds(ids);
   }
 }

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -185,4 +185,14 @@ describe('SubjectsService', () => {
       await expect(subjectsService.findById('123')).resolves.toMatchObject({ id: '123' });
     });
   });
+
+  describe('findByIds', () => {
+    it('should query the whole id set in one call, omitting missing ids rather than throwing', async () => {
+      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
+      await expect(subjectsService.findByIds(['123', 'does-not-exist'])).resolves.toMatchObject([{ id: '123' }]);
+      expect(subjectModel.findMany).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ where: expect.objectContaining({ id: { in: ['123', 'does-not-exist'] } }) })
+      );
+    });
+  });
 });

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -185,14 +185,4 @@ describe('SubjectsService', () => {
       await expect(subjectsService.findById('123')).resolves.toMatchObject({ id: '123' });
     });
   });
-
-  describe('findByIds', () => {
-    it('should query the whole id set in one call, omitting missing ids rather than throwing', async () => {
-      subjectModel.findMany.mockResolvedValueOnce([{ id: '123' }]);
-      await expect(subjectsService.findByIds(['123', 'does-not-exist'])).resolves.toMatchObject([{ id: '123' }]);
-      expect(subjectModel.findMany).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({ where: expect.objectContaining({ id: { in: ['123', 'does-not-exist'] } }) })
-      );
-    });
-  });
 });

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -47,6 +47,29 @@ describe('SubjectsService', () => {
     prismaClient = moduleRef.get(PRISMA_CLIENT_TOKEN);
   });
 
+  describe('addGroupForSubjects', () => {
+    // The exclusion belongs in the query, not the caller: mongodb arrays admit duplicates, so a
+    // caller filtering against a list it read earlier would push the id twice under concurrency.
+    it('should skip subjects already in the group from within the query itself', async () => {
+      await subjectsService.addGroupForSubjects(['subject-1', 'subject-2'], 'group-1');
+
+      expect(subjectModel.updateMany.mock.lastCall?.[0]).toMatchObject({
+        data: { groupIds: { push: 'group-1' } },
+        where: {
+          id: { in: ['subject-1', 'subject-2'] },
+          NOT: { groupIds: { has: 'group-1' } }
+        }
+      });
+    });
+
+    it('should associate every subject in one write rather than one per subject', async () => {
+      await subjectsService.addGroupForSubjects(['subject-1', 'subject-2', 'subject-3'], 'group-1');
+
+      expect(subjectModel.updateMany).toHaveBeenCalledOnce();
+      expect(subjectModel.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe('create', () => {
     it('should call the subject model', async () => {
       const subject = {

--- a/apps/api/src/subjects/__tests__/subjects.service.spec.ts
+++ b/apps/api/src/subjects/__tests__/subjects.service.spec.ts
@@ -4,6 +4,7 @@ import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
 import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import type { Subject } from '@prisma/client';
 import { pick } from 'lodash-es';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -94,6 +95,36 @@ describe('SubjectsService', () => {
           sex: 'MALE'
         })
       ).rejects.toBeInstanceOf(ConflictException);
+    });
+  });
+
+  describe('createMany', () => {
+    // `demo.service.ts` hands `sessionsService.create` a whole row, which reaches this method.
+    it('should keep the demographics of a new subject and drop the fields the caller may not set', async () => {
+      subjectModel.findMany.mockResolvedValueOnce([]);
+      const row: Subject = {
+        createdAt: new Date(0),
+        dateOfBirth: new Date(2000, 0, 1),
+        firstName: 'Ada',
+        groupIds: ['group-9'],
+        id: 'subject-1',
+        lastName: 'Lovelace',
+        sex: 'FEMALE',
+        updatedAt: new Date(0)
+      };
+
+      await subjectsService.createMany([row]);
+
+      expect(subjectModel.createMany.mock.lastCall?.[0].data).toStrictEqual([
+        {
+          dateOfBirth: row.dateOfBirth,
+          firstName: 'Ada',
+          groupIds: [],
+          id: 'subject-1',
+          lastName: 'Lovelace',
+          sex: 'FEMALE'
+        }
+      ]);
     });
   });
 

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -16,14 +16,21 @@ export class SubjectsService {
     @InjectModel('Subject') private readonly subjectModel: Model<'Subject'>
   ) {}
 
-  async addGroupForSubject(subjectId: string, groupId: string, { ability }: EntityOperationOptions = {}) {
-    return this.subjectModel.update({
-      data: {
-        groupIds: {
-          push: groupId
-        }
-      },
-      where: { ...accessibleQuery(ability, 'update', 'Subject'), id: subjectId }
+  /**
+   * Associate each of the given subjects with a group, in one write rather than one per subject.
+   *
+   * The membership check is part of the query rather than done by the caller: mongodb arrays admit
+   * duplicates, so a caller filtering against a list it read earlier would push the same group id
+   * twice if a concurrent request associated the subject in between.
+   */
+  async addGroupForSubjects(subjectIds: string[], groupId: string, { ability }: EntityOperationOptions = {}) {
+    return this.subjectModel.updateMany({
+      data: { groupIds: { push: groupId } },
+      where: {
+        AND: [accessibleQuery(ability, 'update', 'Subject')],
+        id: { in: subjectIds },
+        NOT: { groupIds: { has: groupId } }
+      }
     });
   }
 
@@ -53,42 +60,45 @@ export class SubjectsService {
   }
 
   async createMany(data: CreateSubjectDto[], { ability }: EntityOperationOptions = {}) {
-    //filter out all duplicate ids that are planned to be created via a set
-    const noDuplicatesSet = new Set(
-      data.map((record) => {
-        return record.id;
-      })
-    );
-
-    const subjectIds = Array.from(noDuplicatesSet);
+    // keyed by id so duplicates within the request collapse, keeping the first entry for each
+    const requested = new Map<string, CreateSubjectDto>();
+    for (const subject of data) {
+      if (!requested.has(subject.id)) {
+        requested.set(subject.id, subject);
+      }
+    }
 
     //find the list of subject ids that already exist
     const existingSubjects = await this.subjectModel.findMany({
       select: { id: true },
       where: {
         AND: [accessibleQuery(ability, 'read', 'Subject')],
-        id: { in: subjectIds }
+        id: { in: Array.from(requested.keys()) }
       }
     });
 
     //create a set of existing ids in the database to filter our to-be-created ids with
     const existingIds = new Set(existingSubjects.map((subj) => subj.id));
 
-    //Filter out records whose IDs already exist
-    const subjectsToCreateIds = subjectIds.filter((record) => !existingIds.has(record));
-
-    const subjectsToCreate: CreateSubjectDto[] = subjectsToCreateIds.map((record) => {
-      return {
-        id: record
-      };
-    });
+    // The whole entry is kept, not just the id: a subject identified by personal info carries
+    // demographics that would otherwise be dropped on creation.
+    const subjectsToCreate = Array.from(requested.values()).filter((subject) => !existingIds.has(subject.id));
 
     //if there are none left to create do not follow through with the command
     if (subjectsToCreate.length < 1) {
       return subjectsToCreate;
     }
     return this.subjectModel.createMany({
-      data: subjectsToCreate,
+      // Named explicitly rather than spread: callers hand this whole Prisma rows, and a spread would
+      // carry fields that are not the caller's to set.
+      data: subjectsToCreate.map(({ dateOfBirth, firstName, id, lastName, sex }) => ({
+        dateOfBirth,
+        firstName,
+        groupIds: [],
+        id,
+        lastName,
+        sex
+      })),
       ...accessibleQuery(ability, 'create', 'Subject')
     });
   }

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -168,13 +168,6 @@ export class SubjectsService {
     return subject;
   }
 
-  /** The subjects among `ids` that exist, in one query; a missing id is omitted rather than an error. */
-  async findByIds(ids: string[], { ability }: EntityOperationOptions = {}) {
-    return this.subjectModel.findMany({
-      where: { AND: [accessibleQuery(ability, 'read', 'Subject')], id: { in: ids } }
-    });
-  }
-
   private async querySubjectIdsWithRecords(groupId?: string): Promise<string[]> {
     const records = await this.prismaClient.instrumentRecord.findMany({
       distinct: ['subjectId'],

--- a/apps/api/src/subjects/subjects.service.ts
+++ b/apps/api/src/subjects/subjects.service.ts
@@ -168,6 +168,13 @@ export class SubjectsService {
     return subject;
   }
 
+  /** The subjects among `ids` that exist, in one query; a missing id is omitted rather than an error. */
+  async findByIds(ids: string[], { ability }: EntityOperationOptions = {}) {
+    return this.subjectModel.findMany({
+      where: { AND: [accessibleQuery(ability, 'read', 'Subject')], id: { in: ids } }
+    });
+  }
+
   private async querySubjectIdsWithRecords(groupId?: string): Promise<string[]> {
     const records = await this.prismaClient.instrumentRecord.findMany({
       distinct: ['subjectId'],

--- a/testing/src/specs/dashboard.spec.ts
+++ b/testing/src/specs/dashboard.spec.ts
@@ -1,4 +1,3 @@
-import { ApiClient } from '../support/api-client';
 import { expect, test } from '../support/fixtures';
 
 test.describe('dashboard', () => {
@@ -6,33 +5,5 @@ test.describe('dashboard', () => {
     const dashboardPage = await getPageModel('/dashboard');
     await expect(dashboardPage.pageHeader).toBeVisible();
     await expect(dashboardPage.pageHeader).toContainText('Dashboard');
-  });
-
-  // A session was previously given its groupId only when the subject was not already a member of
-  // that group, so every visit after a subject's first was created without one. A group manager's
-  // Session rule is `{ groupId: { in: [...] } }`, which made those sessions invisible to them and
-  // uncounted by every group-scoped query, this dashboard included.
-  //
-  // Seeded into a group of its own, so the count is exactly what this test created.
-  test('should keep a returning subject later sessions visible to their group manager', async ({
-    api,
-    apiRequestContext,
-    uniqueId
-  }) => {
-    const group = await api.createGroup();
-    const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
-    const accessToken = await ApiClient.login(apiRequestContext, credentials);
-    const subjectId = `revisit-${uniqueId}`;
-
-    await api.createSession(group.id, { id: subjectId });
-    await api.createSession(group.id, { id: subjectId });
-
-    const response = await apiRequestContext.get(`/api/v1/sessions?groupId=${group.id}`, {
-      headers: { Authorization: `Bearer ${accessToken}` }
-    });
-
-    expect(response.status()).toBe(200);
-    const sessions = (await response.json()) as { subjectId: string }[];
-    expect(sessions.filter((session) => session.subjectId === subjectId)).toHaveLength(2);
   });
 });

--- a/testing/src/specs/dashboard.spec.ts
+++ b/testing/src/specs/dashboard.spec.ts
@@ -1,3 +1,4 @@
+import { ApiClient } from '../support/api-client';
 import { expect, test } from '../support/fixtures';
 
 test.describe('dashboard', () => {
@@ -5,5 +6,33 @@ test.describe('dashboard', () => {
     const dashboardPage = await getPageModel('/dashboard');
     await expect(dashboardPage.pageHeader).toBeVisible();
     await expect(dashboardPage.pageHeader).toContainText('Dashboard');
+  });
+
+  // A session was previously given its groupId only when the subject was not already a member of
+  // that group, so every visit after a subject's first was created without one. A group manager's
+  // Session rule is `{ groupId: { in: [...] } }`, which made those sessions invisible to them and
+  // uncounted by every group-scoped query, this dashboard included.
+  //
+  // Seeded into a group of its own, so the count is exactly what this test created.
+  test('should keep a returning subject later sessions visible to their group manager', async ({
+    api,
+    apiRequestContext,
+    uniqueId
+  }) => {
+    const group = await api.createGroup();
+    const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
+    const accessToken = await ApiClient.login(apiRequestContext, credentials);
+    const subjectId = `revisit-${uniqueId}`;
+
+    await api.createSession(group.id, { id: subjectId });
+    await api.createSession(group.id, { id: subjectId });
+
+    const response = await apiRequestContext.get(`/api/v1/sessions?groupId=${group.id}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    const sessions = (await response.json()) as { subjectId: string }[];
+    expect(sessions.filter((session) => session.subjectId === subjectId)).toHaveLength(2);
   });
 });

--- a/testing/src/specs/dashboard.spec.ts
+++ b/testing/src/specs/dashboard.spec.ts
@@ -1,3 +1,4 @@
+import { ApiClient } from '../support/api-client';
 import { expect, test } from '../support/fixtures';
 
 test.describe('dashboard', () => {
@@ -41,5 +42,33 @@ test.describe('dashboard', () => {
       const dashboardPage = await getPageModel('/dashboard');
       await expect(dashboardPage.welcomeHeading).toContainText('Summary of Application State');
     });
+  });
+
+  // A session was previously given its groupId only when the subject was not already a member of
+  // that group, so every visit after a subject's first was created without one. A group manager's
+  // Session rule is `{ groupId: { in: [...] } }`, which made those sessions invisible to them and
+  // uncounted by every group-scoped query, this dashboard included.
+  //
+  // Seeded into a group of its own, so the count is exactly what this test created.
+  test('should keep a returning subject later sessions visible to their group manager', async ({
+    api,
+    apiRequestContext,
+    uniqueId
+  }) => {
+    const group = await api.createGroup();
+    const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
+    const accessToken = await ApiClient.login(apiRequestContext, credentials);
+    const subjectId = `revisit-${uniqueId}`;
+
+    await api.createSession(group.id, { id: subjectId });
+    await api.createSession(group.id, { id: subjectId });
+
+    const response = await apiRequestContext.get(`/api/v1/sessions?groupId=${group.id}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    const sessions = (await response.json()) as { subjectId: string }[];
+    expect(sessions.filter((session) => session.subjectId === subjectId)).toHaveLength(2);
   });
 });

--- a/testing/src/specs/dashboard.spec.ts
+++ b/testing/src/specs/dashboard.spec.ts
@@ -1,4 +1,3 @@
-import { ApiClient } from '../support/api-client';
 import { expect, test } from '../support/fixtures';
 
 test.describe('dashboard', () => {
@@ -42,33 +41,5 @@ test.describe('dashboard', () => {
       const dashboardPage = await getPageModel('/dashboard');
       await expect(dashboardPage.welcomeHeading).toContainText('Summary of Application State');
     });
-  });
-
-  // A session was previously given its groupId only when the subject was not already a member of
-  // that group, so every visit after a subject's first was created without one. A group manager's
-  // Session rule is `{ groupId: { in: [...] } }`, which made those sessions invisible to them and
-  // uncounted by every group-scoped query, this dashboard included.
-  //
-  // Seeded into a group of its own, so the count is exactly what this test created.
-  test('should keep a returning subject later sessions visible to their group manager', async ({
-    api,
-    apiRequestContext,
-    uniqueId
-  }) => {
-    const group = await api.createGroup();
-    const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
-    const accessToken = await ApiClient.login(apiRequestContext, credentials);
-    const subjectId = `revisit-${uniqueId}`;
-
-    await api.createSession(group.id, { id: subjectId });
-    await api.createSession(group.id, { id: subjectId });
-
-    const response = await apiRequestContext.get(`/api/v1/sessions?groupId=${group.id}`, {
-      headers: { Authorization: `Bearer ${accessToken}` }
-    });
-
-    expect(response.status()).toBe(200);
-    const sessions = (await response.json()) as { subjectId: string }[];
-    expect(sessions.filter((session) => session.subjectId === subjectId)).toHaveLength(2);
   });
 });

--- a/testing/src/specs/sessions.spec.ts
+++ b/testing/src/specs/sessions.spec.ts
@@ -1,0 +1,32 @@
+import { ApiClient } from '../support/api-client';
+import { expect, test } from '../support/fixtures';
+
+test.describe('sessions', () => {
+  // A session was previously given its groupId only when the subject was not already a member of
+  // that group, so every visit after a subject's first was created without one. A group manager's
+  // Session rule is `{ groupId: { in: [...] } }`, which made those sessions invisible to them and
+  // uncounted by every group-scoped query, the dashboard trends included.
+  //
+  // Seeded into a group of its own, so the count is exactly what this test created.
+  test('should keep a returning subject later sessions visible to their group manager', async ({
+    api,
+    apiRequestContext,
+    uniqueId
+  }) => {
+    const group = await api.createGroup();
+    const { credentials } = await api.createUser({ basePermissionLevel: 'GROUP_MANAGER', groupIds: [group.id] });
+    const accessToken = await ApiClient.login(apiRequestContext, credentials);
+    const subjectId = `revisit-${uniqueId}`;
+
+    await api.createSession(group.id, { id: subjectId });
+    await api.createSession(group.id, { id: subjectId });
+
+    const response = await apiRequestContext.get(`/api/v1/sessions?groupId=${group.id}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    const sessions = (await response.json()) as { subjectId: string }[];
+    expect(sessions.filter((session) => session.subjectId === subjectId)).toHaveLength(2);
+  });
+});

--- a/testing/src/specs/sessions.spec.ts
+++ b/testing/src/specs/sessions.spec.ts
@@ -1,3 +1,5 @@
+import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
+
 import { ApiClient } from '../support/api-client';
 import { expect, test } from '../support/fixtures';
 
@@ -8,7 +10,7 @@ test.describe('sessions', () => {
   // uncounted by every group-scoped query, the dashboard trends included.
   //
   // Seeded into a group of its own, so the count is exactly what this test created.
-  test('should keep a returning subject later sessions visible to their group manager', async ({
+  test("should keep a returning subject's later sessions visible to their group manager", async ({
     api,
     apiRequestContext,
     uniqueId
@@ -28,5 +30,36 @@ test.describe('sessions', () => {
     expect(response.status()).toBe(200);
     const sessions = (await response.json()) as { subjectId: string }[];
     expect(sessions.filter((session) => session.subjectId === subjectId)).toHaveLength(2);
+  });
+
+  // Session creation resolves its subjects in a batch, and the batched path once kept only their ids.
+  test('should create a new subject with the demographics its first session names', async ({
+    adminToken,
+    api,
+    apiRequestContext,
+    uniqueId
+  }) => {
+    const group = await api.createGroup();
+    const subjectData: CreateSubjectData = {
+      dateOfBirth: new Date('1990-05-17T00:00:00.000Z'),
+      firstName: 'Ada',
+      id: `clinical-${uniqueId}`,
+      lastName: 'Lovelace',
+      sex: 'FEMALE'
+    };
+
+    await api.createSession(group.id, subjectData);
+
+    const response = await apiRequestContext.get(`/api/v1/subjects/${subjectData.id}`, {
+      headers: { Authorization: `Bearer ${adminToken}` }
+    });
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toMatchObject({
+      dateOfBirth: '1990-05-17T00:00:00.000Z',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      sex: 'FEMALE'
+    });
   });
 });

--- a/testing/src/specs/upload.spec.ts
+++ b/testing/src/specs/upload.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '../support/fixtures';
+
+/** A minimal payload satisfying the seeded happiness questionnaire's validation schema. */
+const HAPPINESS_RECORD = {
+  isSatisfiedOverall: true,
+  personalLifeSatisfaction: 8,
+  professionalLifeSatisfaction: 7
+};
+
+test.describe('instrument record upload', () => {
+  // The response was previously every record in the group for the instrument, so a second upload
+  // leaked the first one's records back to the caller. An earlier upload to the same group and
+  // instrument is what distinguishes the scoped response from the group-wide one.
+  test('should answer a batch upload with exactly the records it created', async ({ api, uniqueId }) => {
+    const group = await api.createGroup();
+    const instrumentId = await api.findInstrumentIdByName('DNP_HAPPINESS_QUESTIONNAIRE');
+    await api.uploadRecords(group.id, instrumentId, [
+      { data: HAPPINESS_RECORD, date: new Date(), subjectId: `upload-${uniqueId}-earlier` }
+    ]);
+
+    const batch = ['a', 'b', 'c'].map((suffix) => `upload-${uniqueId}-${suffix}`);
+    const records = await api.uploadRecords(
+      group.id,
+      instrumentId,
+      batch.map((subjectId) => ({ data: HAPPINESS_RECORD, date: new Date(), subjectId }))
+    );
+
+    expect(records).toHaveLength(3);
+    expect(new Set(records.map((record) => record.subjectId))).toStrictEqual(new Set(batch));
+  });
+});

--- a/testing/src/specs/upload.spec.ts
+++ b/testing/src/specs/upload.spec.ts
@@ -1,3 +1,5 @@
+import type { UploadInstrumentRecordsData } from '@opendatacapture/schemas/instrument-records';
+
 import { UploadInstrumentPage } from '../pages/_app/upload/$instrumentId.page';
 import { expect, test } from '../support/fixtures';
 
@@ -86,5 +88,32 @@ test.describe('upload', () => {
 
     expect(records).toHaveLength(3);
     expect(new Set(records.map((record) => record.subjectId))).toStrictEqual(new Set(batch));
+  });
+
+  // The bulk payload has nowhere to carry a file, so a record for a file instrument could only ever
+  // be incomplete. The upload is refused before anything is written.
+  test('should refuse a batch upload for a file instrument without writing a session or record', async ({
+    adminToken,
+    api,
+    apiRequestContext,
+    uniqueId
+  }) => {
+    const group = await api.createGroup();
+    const headers = { Authorization: `Bearer ${adminToken}` };
+    const subjectId = `file-${uniqueId}`;
+    const data: UploadInstrumentRecordsData = {
+      groupId: group.id,
+      instrumentId: await api.findInstrumentIdByName('ARBITRARY_SINGLE_FILE'),
+      records: [{ data: {}, date: new Date(), subjectId }]
+    };
+
+    const response = await apiRequestContext.post('/api/v1/instrument-records/upload', { data, headers });
+
+    expect(response.status()).toBe(422);
+    // Sessions are created only after the subjects they name, so a missing subject means no session.
+    const subject = await apiRequestContext.get(`/api/v1/subjects/${subjectId}`, { headers });
+    expect(subject.status()).toBe(404);
+    const records = await apiRequestContext.get(`/api/v1/instrument-records?groupId=${group.id}`, { headers });
+    expect(await records.json()).toStrictEqual([]);
   });
 });

--- a/testing/src/specs/upload.spec.ts
+++ b/testing/src/specs/upload.spec.ts
@@ -5,6 +5,13 @@ import { expect, test } from '../support/fixtures';
 // exists in the catalog but is kind SERIES, so it never appears in the upload instrument list.
 const INSTRUMENT_TITLE = 'Happiness Questionnaire';
 
+/** A minimal payload satisfying the seeded happiness questionnaire's validation schema. */
+const HAPPINESS_RECORD = {
+  isSatisfiedOverall: true,
+  personalLifeSatisfaction: 8,
+  professionalLifeSatisfaction: 7
+};
+
 test.describe('upload', () => {
   test('should upload a valid CSV and create a record for the subject it names @smoke', async ({
     getPageModel,
@@ -58,5 +65,26 @@ test.describe('upload', () => {
     await uploadInstrumentPage.tryAgainButton.click();
     await expect(uploadInstrumentPage.errorHeading).not.toBeVisible();
     await expect(uploadInstrumentPage.submitButton).toBeVisible();
+  });
+
+  // The response was previously every record in the group for the instrument, so a second upload
+  // leaked the first one's records back to the caller. An earlier upload to the same group and
+  // instrument is what distinguishes the scoped response from the group-wide one.
+  test('should answer a batch upload with exactly the records it created', async ({ api, uniqueId }) => {
+    const group = await api.createGroup();
+    const instrumentId = await api.findInstrumentIdByName('DNP_HAPPINESS_QUESTIONNAIRE');
+    await api.uploadRecords(group.id, instrumentId, [
+      { data: HAPPINESS_RECORD, date: new Date(), subjectId: `upload-${uniqueId}-earlier` }
+    ]);
+
+    const batch = ['a', 'b', 'c'].map((suffix) => `upload-${uniqueId}-${suffix}`);
+    const records = await api.uploadRecords(
+      group.id,
+      instrumentId,
+      batch.map((subjectId) => ({ data: HAPPINESS_RECORD, date: new Date(), subjectId }))
+    );
+
+    expect(records).toHaveLength(3);
+    expect(new Set(records.map((record) => record.subjectId))).toStrictEqual(new Set(batch));
   });
 });

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,7 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
+import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, User } from '@opendatacapture/schemas/user';
 import type { APIRequestContext } from '@playwright/test';
 
@@ -45,6 +47,16 @@ export class ApiClient {
       'grant instrument access'
     );
     return group;
+  }
+
+  /** Creates a session, and with it the subject it names. */
+  async createSession(groupId: null | string, subjectData: CreateSubjectData): Promise<Session> {
+    const data: CreateSessionData = { date: new Date(), groupId, subjectData, type: 'IN_PERSON' };
+    return this.expectJson<Session>(
+      this.request.post(`${API}/sessions`, { data, headers: this.authHeaders }),
+      201,
+      'create session'
+    );
   }
 
   /** Creates a user (GROUP_MANAGER by default) and returns the login credentials for it. */

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,6 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { UploadInstrumentRecordsData } from '@opendatacapture/schemas/instrument-records';
 import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, User } from '@opendatacapture/schemas/user';
@@ -9,6 +10,8 @@ import { SEEDED_USER_PASSWORD } from './constants';
 import { randomId } from './unique';
 
 const API = '/api/v1';
+
+type UploadRecord = UploadInstrumentRecordsData['records'][number];
 
 /** Typed helper for seeding preconditions (groups, users) and authenticating over the API. */
 export class ApiClient {
@@ -78,6 +81,37 @@ export class ApiClient {
       'create user'
     );
     return { credentials: { password, username }, user };
+  }
+
+  /** The id of a seeded instrument, looked up by the internal name its source file declares. */
+  async findInstrumentIdByName(name: string): Promise<string> {
+    const instruments = await this.expectJson<{ id: string; internal?: { name: string } }[]>(
+      this.request.get(`${API}/instruments/info`, { headers: this.authHeaders }),
+      200,
+      'list instruments'
+    );
+    const instrument = instruments.find((candidate) => candidate.internal?.name === name);
+    if (!instrument) {
+      throw new Error(`No instrument named '${name}' among ${instruments.length} returned`);
+    }
+    return instrument.id;
+  }
+
+  /**
+   * Bulk-creates one record per entry, and with them the subjects and sessions they name. Returns
+   * the records the api reports created, which the upload contract scopes to this request alone.
+   */
+  async uploadRecords(
+    groupId: string,
+    instrumentId: string,
+    records: UploadRecord[]
+  ): Promise<{ subjectId: string }[]> {
+    const data: UploadInstrumentRecordsData = { groupId, instrumentId, records };
+    return this.expectJson<{ subjectId: string }[]>(
+      this.request.post(`${API}/instrument-records/upload`, { data, headers: this.authHeaders }),
+      201,
+      'upload instrument records'
+    );
   }
 
   private async expectJson<T>(

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,6 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { UploadInstrumentRecordsData } from '@opendatacapture/schemas/instrument-records';
 import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
 import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, UpdateUserData, User } from '@opendatacapture/schemas/user';
@@ -9,6 +10,8 @@ import { E2E_MAIL_CONFIG, SEEDED_USER_PASSWORD } from './constants';
 import { randomId } from './unique';
 
 const API = '/api/v1';
+
+type UploadRecord = UploadInstrumentRecordsData['records'][number];
 
 /** Typed helper for seeding preconditions (groups, users) and authenticating over the API. */
 export class ApiClient {
@@ -89,6 +92,20 @@ export class ApiClient {
     );
   }
 
+  /** The id of a seeded instrument, looked up by the internal name its source file declares. */
+  async findInstrumentIdByName(name: string): Promise<string> {
+    const instruments = await this.expectJson<{ id: string; internal?: { name: string } }[]>(
+      this.request.get(`${API}/instruments/info`, { headers: this.authHeaders }),
+      200,
+      'list instruments'
+    );
+    const instrument = instruments.find((candidate) => candidate.internal?.name === name);
+    if (!instrument) {
+      throw new Error(`No instrument named '${name}' among ${instruments.length} returned`);
+    }
+    return instrument.id;
+  }
+
   /**
    * Switch outgoing mail on or off instance-wide, (re)seeding {@link E2E_MAIL_CONFIG}. Every
    * caller must switch it back off — `isMailEnabled` is global, and leaving it on changes the UI
@@ -114,6 +131,23 @@ export class ApiClient {
       throw new Error(`Failed to update user '${id}' (${response.status()}): ${await response.text()}`);
     }
     return (await response.json()) as User;
+  }
+
+  /**
+   * Bulk-creates one record per entry, and with them the subjects and sessions they name. Returns
+   * the records the api reports created, which the upload contract scopes to this request alone.
+   */
+  async uploadRecords(
+    groupId: string,
+    instrumentId: string,
+    records: UploadRecord[]
+  ): Promise<{ subjectId: string }[]> {
+    const data: UploadInstrumentRecordsData = { groupId, instrumentId, records };
+    return this.expectJson<{ subjectId: string }[]>(
+      this.request.post(`${API}/instrument-records/upload`, { data, headers: this.authHeaders }),
+      201,
+      'upload instrument records'
+    );
   }
 
   private async expectJson<T>(

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,5 +1,7 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
+import type { CreateSessionData, Session } from '@opendatacapture/schemas/session';
+import type { CreateSubjectData } from '@opendatacapture/schemas/subject';
 import type { CreateUserData, UpdateUserData, User } from '@opendatacapture/schemas/user';
 import type { APIRequestContext } from '@playwright/test';
 
@@ -45,6 +47,16 @@ export class ApiClient {
       'grant instrument access'
     );
     return group;
+  }
+
+  /** Creates a session, and with it the subject it names. */
+  async createSession(groupId: null | string, subjectData: CreateSubjectData): Promise<Session> {
+    const data: CreateSessionData = { date: new Date(), groupId, subjectData, type: 'IN_PERSON' };
+    return this.expectJson<Session>(
+      this.request.post(`${API}/sessions`, { data, headers: this.authHeaders }),
+      201,
+      'create session'
+    );
   }
 
   /** Creates a user (GROUP_MANAGER by default) and returns the login credentials for it. */


### PR DESCRIPTION
**Alternative to #1424.** Same issue (#1414), but this one takes the `SessionsService` refactor that #1424 deliberately deferred. Merge one or the other, not both.

## What #1424 does, and what this adds

| | #1424 | this PR |
|---|---|---|
| Response scoped to the upload | ✅ | ✅ |
| Validate before writing | ✅ | ✅ |
| Remove the re-read in `SessionsService.create` | ✅ | ✅ (subsumed by the rewrite) |
| **Batch session creation (the N+1)** | ❌ deferred | ✅ |
| **Fix the session `groupId` bug** | ❌ | ✅ |

## The refactor

`SessionsService.createMany` resolves subjects, the user and the group **once for the whole batch**, associates subjects with the group in a single `updateMany`, and inserts every session in one call. Session ids are generated up front so results come back in input order and a caller can pair each session with the entry that produced it by index. `create` now delegates to it, so there is one implementation rather than two that can drift.

## Measured over HTTP, live instance, uploading 25 records

| | records returned | bytes | mongo ops |
|---|---|---|---|
| `main` | 85 → 110 (grows every upload) | 51–66 KB | **~242–276** |
| this branch | **25** (flat) | **14.8 KB** | **~95** |

For reference, #1424 measured ~216 ops on the same workload — it removed one query per session but kept the per-record loop.

Correctness verified on the same run: 25 records → 25 distinct sessions, every record paired with the session holding its own subject.

## The bug this fixes

`create` set a session's `groupId` **only when the subject was not already a member** of that group:

```ts
let group: Group | null = null;
if (groupId && !subject.groupIds.includes(groupId)) { group = await this.groupsService.findById(groupId); … }
// …
group: group ? { connect: { id: group.id } } : undefined,
```

So every visit after a subject's first produced a session with no `groupId`. A `GROUP_MANAGER`'s Session rule is `{ groupId: { in: groupIds } }` — **those sessions were invisible to them**, and uncounted by every group-scoped query including the dashboard summary.

Reproduced on a live instance, two sessions for one subject in one group:

```
main behaviour  (quirk-subject): set, MISSING
this branch     (fixed-subject): set, set
```

This is the same class of problem as #1404 ("old data not visible"), and it is why I did not want to batch inside `upload` in #1424 — doing so would have duplicated the quirk into a second place rather than settling it.

**This is a behaviour change, and it is the reason to review this PR carefully.** Sessions created from now on will carry a `groupId` where they previously would not. Nothing becomes less visible; some previously-hidden sessions become visible to group managers and appear in group-scoped counts. Existing rows are untouched — a backfill for historical sessions would be a separate migration, and is worth considering.

## One more thing found on the way

`SubjectsService.createMany` kept only the `id` of each entry and discarded the demographics a clinical subject carries:

```ts
const subjectsToCreate: CreateSubjectDto[] = subjectsToCreateIds.map((record) => ({ id: record }));
```

Harmless while its only caller passed ids alone, but the batched session path resolves subjects through it, so it now persists what it is given.

## Tests

The existing upload tests are updated to the batched call and keep their assertions. Added:

- every record goes into a **single** `createMany` call (25 records → 1 call, 25 entries) — the N+1 guard;
- each record is paired with its own session by position;
- the response is scoped to the sessions created;
- an invalid record rejects before any session is created.

## Checks

- `tsc --noEmit` on `apps/api` — clean
- `eslint src` — clean
- `prettier --check` — clean
- `vitest run` (whole workspace) — 256 passed, 1 skipped, 1 failed

The one failure is `upload > should create records with pending set`. This branch is cut from `main`, so it carries that pre-existing failure; **#1422 fixes it**. These two PRs touch adjacent lines and will need a trivial rebase depending on merge order.

## Still not done

The transaction wrapper (item 5 of #1414). Sessions are now created in one call and records in another, so a failure between them still leaves orphaned sessions — the `catch` still compensates by deleting them, as before. `prismaClient.$transaction` would make that atomic; the replica set is already configured for it.

---

## Rebased onto `main`, review items addressed

Rebased onto `26ec89168`; conflicts resolved, CI green. Still mutually exclusive with #1424 — that
choice is yours, and the comparison table in #1424 still holds.

**Copilot: the rollback spanned the response read-back.** Fixed. Only the record insert is inside the
`catch` now; deleting the sessions after the insert had succeeded would have stranded the records that
reference them. Both directions are pinned by tests.

**Copilot: bulk records omitted `pending`.** This was a genuine regression against `main`, which
writes it since `573f307c9`. Restored, and written per instrument kind as `create` does, so a file
record stays pending until its files arrive.

**Copilot: `console.error` on validation failure.** Removed; the exception carries the zod issues and
names the offending record's index.

**Copilot: a concurrent `groupIds` push could duplicate.** Fixed. The subject list is a snapshot read
before the write, so the `updateMany` now re-checks membership in its own `where`
(`NOT: { groupIds: { has: group.id } }`), making the write itself the arbiter.

**`SessionsService` had no test file at all**, which is a poor state for a PR that rewrites it. Added
one covering the `groupId` fix, input-order pairing, single-call batching, the association guard, and
one-user-per-batch resolution. Verified by mutation — reverting the `groupId` fix or the association
guard turns it red.

---

## Round 2: rebased onto `5bfe4b2dc`, review items addressed

Conflict was a one-line import clash with #1420, now merged.

**1. End-to-end.** Added to `dashboard.spec.ts`: two sessions for the same subject in the same group,
asserted visible to that group's manager. This is the sharpest pin available for the `groupId` fix —
reinstating the old behaviour returns **one of the two** sessions, verified by mutation.

**2. File instruments.** `upload` now rejects them with `UnprocessableEntityException` alongside the
existing series rejection, and `pending: instrument.kind === 'FILE'` is gone. Agreed with the
reasoning — the payload cannot carry a file, the path never attaches one, and the client discards the
response ids, so the record could only ever be incomplete. Pinned by a test asserting the rejection
and that no session or record is written.

**3. `CreateManySessionsData`.** Now derived: `Pick<CreateSessionData, 'groupId' | 'type' | 'username'>`
plus per-entry `Pick<CreateSessionData, 'date' | 'subjectData'>`, so it cannot drift.

**4. The retrospective comment.** Removed — that reasoning lives in the commit message. Did the same
to the response-scoping comment in `instrument-records.service.ts`, which #1424's review flagged for
the same reason.

**5. `{ ...subject, groupIds: [] }`.** Now names the `CreateSubjectDto` fields explicitly. Good
catch on `demo.service.ts:126` handing it a full Prisma row.

**6. Reaching into `prismaClient.subject`.** The batched association moved behind `SubjectsService`,
next to the other subject writes.

**7. `addGroupForSubject`.** Removed — item 6 replaces it with the batched `addGroupForSubjects`, so
the single-subject version has no callers and no remaining reason to exist.

Also carried over from #1424's review, since that PR is being closed: the rollback no longer spans
the response read-back (already fixed here), and `SessionsService` now has the test file it lacked.
And from #1422: the stale spec comment `722f0a0b0` left behind is deleted here, so it is not lost
with that PR.

Both `isolatedGroupManager`-style seeding and `createSession` on the api client also appear in #1425
— trivial to reconcile, but worth knowing before merging both.

---

## Round 3: rebased onto `f97706ea8`, review items addressed

The five items from the review at `ab5728b7c`:

**1. The subject read-back in `resolveSubjects`.** Removed. `createMany` gives the entry ids
directly to `addGroupForSubjects`, whose `where` already checks membership again.
`SubjectsService.findByIds` had no other caller, so it is removed too.

**2. The "two queries" comment.** Removed with the read-back. The doc comment now says "a fixed
number of queries rather than a fixed number per entry".

**3. A gap in the session read-back.** `createMany` now throws `InternalServerErrorException` when
the read-back does not return every id it wrote. So `POST /sessions` cannot answer 201 with an
empty body. A unit test covers this.

**4. The HTTP assertion in `dashboard.spec.ts`.** Moved to its own `sessions.spec.ts`.
`dashboard.spec.ts` now has no change from this PR.

**5. End-to-end coverage of the upload.** Added. The test uploads one record, then a batch of three
to the same group and instrument. It asserts that the response carries exactly the three. The
old group-wide response would also return the first upload's record, so the test would fail.

**Rebase.** The app code did not change. Its patch is byte-identical to the reviewed one. `main`
added its own `upload.spec.ts` with two UI tests. The API-level test from item 5 is now in the same
`describe('upload')` block. The two UI tests upload through the web client, so they also run the
batched path from end to end. `api-client.ts` keeps `main`'s new helpers next to this branch's.

**Ordering.** This PR still overlaps #1426 (`subjects.service.ts`, `api-client.ts`) and #1425
(`api-client.ts`). I checked with `git merge-tree`: after both land, the only conflict left is in
`api-client.ts`. The `subjects.service.ts` changes merge cleanly. As planned, this PR gets one more
rebase when its turn comes.

**Checks** at `8cf7f03bd`:

- `pnpm lint`: 34/34 tasks, no files rewritten
- `pnpm test`: 143 files, 1176 tests passed
- `pnpm test:e2e`: `chromium` 158/158 and `firefox` 23/23 passed, run as two separate passes
- `commitlint --from origin/main`: clean

---

## Round 4: Copilot review of `8cf7f03bd`

- **Nothing tested that `createMany` keeps demographics.** Fixed. `076ba7cb4` adds a unit test that
  gives `createMany` a whole Prisma row and asserts the exact write. `1e5ddf289` adds an e2e test
  that creates a clinical subject through `POST /sessions` and reads it back. Both fail when the
  mapping goes back to the id-only form.
- **The FILE rejection had no e2e test.** Added in `bcbab1c24`. It asserts the 422, that the
  named subject was never created, and that the group holds no record. It fails when the guard is
  removed.
- **Test title possessive.** Fixed in `1e5ddf289`.
- **`POST /sessions` passes no ability.** Not changed here. I answered on the thread and left it
  open. The behaviour is identical on `main`, and this PR does not make it wider. A fix needs your
  decisions (404 or 403 for a foreign group, whether a caller may name another `username`, and
  keeping the internal subject writes unscoped), so I suggest a separate issue.

**Checks** at `bcbab1c24`: `pnpm lint` 34/34 tasks, `pnpm test` 1177 passed, `sessions.spec.ts` and
`upload.spec.ts` 12/12 on Chromium. CI green at this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZEJLwa7jwD8sKzcE4PfSc
https://claude.ai/code/session_01KLfKsdHT1arfrc2fdT1fWq

