### PR TITLE
test(e2e): add coverage for instruments, authz, admin and the gateway (stage 2)

### DIFF
--- a/testing/src/pages/_app/dashboard.page.ts
+++ b/testing/src/pages/_app/dashboard.page.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-import { AppPage } from './_app.page';
+import { AppPage } from './route.page';
 
 export class DashboardPage extends AppPage {
   readonly pageHeader: Locator;

--- a/testing/src/pages/_app/datahub/$subjectId/table/index.page.ts
+++ b/testing/src/pages/_app/datahub/$subjectId/table/index.page.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-import { AppPage } from '../_app.page';
+import { AppPage } from '../../../route.page';
 
 export class SubjectDataTablePage extends AppPage {
   constructor(page: Page) {

--- a/testing/src/pages/_app/datahub/index.page.ts
+++ b/testing/src/pages/_app/datahub/index.page.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-import { AppPage } from '../_app.page';
+import { AppPage } from '../route.page';
 
 export class DatahubPage extends AppPage {
   readonly pageHeader: Locator;

--- a/testing/src/pages/_app/instruments/accessible-instruments.page.ts
+++ b/testing/src/pages/_app/instruments/accessible-instruments.page.ts
@@ -1,0 +1,25 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { AppPage } from '../route.page';
+
+export class AccessibleInstrumentsPage extends AppPage {
+  readonly instrumentShowcase: Locator;
+  readonly pageHeader: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.pageHeader = page.getByTestId('page-header');
+    this.instrumentShowcase = page.getByTestId('instrument-showcase');
+  }
+
+  /** Cards carry a content-hash testid, so match on the visible title instead. */
+  instrumentCard(title: string): Locator {
+    return this.instrumentShowcase.locator('[data-testid^="instrument-card-"]').filter({ hasText: title }).first();
+  }
+
+  async openInstrument(title: string): Promise<void> {
+    const card = this.instrumentCard(title);
+    await card.waitFor({ state: 'visible' });
+    await card.click();
+  }
+}

--- a/testing/src/pages/_app/instruments/render/$id.page.ts
+++ b/testing/src/pages/_app/instruments/render/$id.page.ts
@@ -1,0 +1,47 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { AppPage } from '../../route.page';
+
+/**
+ * The instrument runner. Overview, content and summary are three states behind the same URL, so
+ * this page object is constructed directly after clicking an instrument card rather than navigated to.
+ */
+export class RenderInstrumentPage extends AppPage {
+  readonly beginButton: Locator;
+  readonly submitButton: Locator;
+  readonly summaryHeading: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.beginButton = page.getByRole('button', { name: 'Begin' });
+    this.submitButton = page.getByRole('button', { name: 'Submit' });
+    this.summaryHeading = page.getByRole('heading', { name: /Summary of Results/i });
+  }
+
+  async begin(): Promise<void> {
+    await this.beginButton.waitFor({ state: 'visible' });
+    await this.beginButton.click();
+  }
+
+  /**
+   * Answers the Happiness Questionnaire: both 1-10 sliders and "Yes" overall, which leaves the
+   * conditional follow-up fields unrendered. Sliders can't be set by `fill`, and dragging is
+   * unreliable headless, so nudge them with arrow keys instead.
+   */
+  async completeHappinessQuestionnaire(steps = 4): Promise<void> {
+    const sliders = this.$ref.getByTestId('slider-thumb');
+    await sliders.first().waitFor({ state: 'visible' });
+    for (let index = 0; index < (await sliders.count()); index++) {
+      const slider = sliders.nth(index);
+      await slider.focus();
+      for (let step = 0; step < steps; step++) {
+        await slider.press('ArrowRight');
+      }
+    }
+    await this.$ref.getByRole('radio', { name: 'Yes' }).click();
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+}

--- a/testing/src/pages/_app/route.page.ts
+++ b/testing/src/pages/_app/route.page.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-import { RootPage } from './__root.page';
+import { RootPage } from '../__root.page';
 
 export abstract class AppPage extends RootPage {
   readonly _requiresAuth = true;

--- a/testing/src/pages/_app/session/remote-assignment.page.ts
+++ b/testing/src/pages/_app/session/remote-assignment.page.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-import { AppPage } from './_app.page';
+import { AppPage } from '../route.page';
 
 export class RemoteAssignmentPage extends AppPage {
   readonly createDialog: Locator;

--- a/testing/src/pages/_app/session/start-session.page.ts
+++ b/testing/src/pages/_app/session/start-session.page.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-import { AppPage } from './_app.page';
+import { AppPage } from '../route.page';
 
 export class StartSessionPage extends AppPage {
   readonly pageHeader: Locator;

--- a/testing/src/specs/admin-management.spec.ts
+++ b/testing/src/specs/admin-management.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '../support/fixtures';
+
+test.describe('admin management', () => {
+  test.use({ actingRole: 'ADMIN' });
+
+  test('should create a group through the UI @smoke', async ({ authenticateAs, page, uniqueId }) => {
+    const groupName = `E2E Group ${uniqueId}`;
+
+    await authenticateAs('ADMIN');
+    await page.goto('/admin/groups/create');
+
+    await page.getByLabel('Group Name').fill(groupName);
+    await page.getByRole('combobox').first().click();
+    await page.getByRole('option', { name: 'Clinical' }).click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    // Success toast + redirect are the app's own success signals. Deliberately not asserting the
+    // group then shows up in /admin/groups: that list appears to be scoped to groups the actor
+    // belongs to, and creating one does not add the creator as a member.
+    await expect(page.getByRole('heading', { name: 'Success' })).toBeVisible();
+    await expect(page).toHaveURL('/admin/groups');
+  });
+
+  test('should list users for an admin', async ({ authenticateAs, page }) => {
+    await authenticateAs('ADMIN');
+    await page.goto('/admin/users');
+
+    await expect(page.getByTestId('data-table')).toBeVisible();
+    // The admin created during setup is always present.
+    await expect(page.getByTestId('data-table-body')).toContainText('admin');
+  });
+});

--- a/testing/src/specs/authorization.spec.ts
+++ b/testing/src/specs/authorization.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '../support/fixtures';
+
+/** Sidebar destinations a GROUP_MANAGER gets but a STANDARD user must not. */
+const GROUP_MANAGER_ONLY_ROUTES = ['/dashboard', '/datahub', '/group/manage', '/session/remote-assignment'] as const;
+
+test.describe('authorization', () => {
+  test('should give a group manager the management navigation @smoke', async ({ getPageModel, page }) => {
+    await getPageModel('/dashboard');
+    await expect(page.getByTestId('sidebar')).toBeVisible();
+    for (const route of GROUP_MANAGER_ONLY_ROUTES) {
+      await expect(page.getByTestId(`nav-button-${route}`)).toBeVisible();
+    }
+  });
+
+  test.describe('standard user', () => {
+    test.use({ actingRole: 'STANDARD' });
+
+    test('should not expose management navigation', async ({ authenticateAs, page }) => {
+      await authenticateAs('STANDARD');
+      await page.goto('/session/start-session');
+
+      await expect(page.getByTestId('sidebar')).toBeVisible();
+      await expect(page.getByTestId('nav-button-/session/start-session')).toBeVisible();
+      for (const route of GROUP_MANAGER_ONLY_ROUTES) {
+        await expect(page.getByTestId(`nav-button-${route}`)).toHaveCount(0);
+      }
+    });
+
+    // Uses `authenticateAs` + a raw goto rather than `getPageModel`, which asserts it landed on the
+    // requested route -- here the whole point is that it does not.
+    test('should be redirected away from the dashboard', async ({ authenticateAs, page }) => {
+      await authenticateAs('STANDARD');
+      await page.goto('/dashboard');
+      await expect(page).toHaveURL('/session/start-session');
+    });
+
+    test('should be redirected away from remote assignment', async ({ authenticateAs, page }) => {
+      await authenticateAs('STANDARD');
+      await page.goto('/session/remote-assignment');
+      await expect(page).toHaveURL('/session/start-session');
+    });
+  });
+});

--- a/testing/src/specs/gateway-assignment.spec.ts
+++ b/testing/src/specs/gateway-assignment.spec.ts
@@ -1,0 +1,74 @@
+import { RenderInstrumentPage } from '../pages/_app/instruments/render/$id.page';
+import { expect, test } from '../support/fixtures';
+
+const INSTRUMENT_TITLE = 'Happiness Questionnaire';
+
+test.describe('gateway remote assignment', () => {
+  // Spans two origins and waits on the Cap proof-of-work, so it needs more than the default budget.
+  test.describe.configure({ timeout: 180_000 });
+
+  test('should let a patient complete an assignment and report it back to the clinician', async ({
+    context,
+    getPageModel,
+    page,
+    uniqueId
+  }) => {
+    const startSessionPage = await getPageModel('/session/start-session');
+    await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+    await startSessionPage.selectIdentificationMethod('PERSONAL_INFO');
+    await startSessionPage.fillSessionForm(`Gateway${uniqueId}`, `Patient${uniqueId}`, 'Female');
+    await startSessionPage.submitForm();
+    await expect(startSessionPage.successMessage).toBeVisible();
+
+    await page.getByTestId('nav-button-/session/remote-assignment').click();
+    await page.waitForURL('**/session/remote-assignment');
+
+    const card = page.locator('[data-testid^="instrument-card-"]').filter({ hasText: INSTRUMENT_TITLE }).first();
+    await expect(card).toBeVisible();
+    await card.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('Create Remote Assignment');
+    await dialog.getByRole('button', { name: 'Submit' }).click();
+
+    // The dialog swaps in place to reveal the gateway link (a different origin than the web app).
+    const linkInput = page.locator('input[readonly]');
+    await expect(linkInput).toBeVisible();
+    const assignmentUrl = await linkInput.inputValue();
+    expect(assignmentUrl).toMatch(/^https?:\/\/.+\/assignments\/.+/);
+
+    // Dismiss the dialog: its overlay covers the sidebar and would swallow later nav clicks.
+    await dialog.getByRole('button', { name: 'Close' }).first().click();
+    await expect(dialog).toBeHidden();
+
+    // The patient receives the link out of band, so drive it from a separate page.
+    const gatewayPage = await context.newPage();
+    await gatewayPage.goto(assignmentUrl);
+
+    // The gateway gates submission behind a Cap proof-of-work widget (a custom element, which
+    // Playwright reaches through its open shadow root). Solving it is what enables "Begin".
+    const capWidget = gatewayPage.locator('cap-widget');
+    await capWidget.waitFor({ state: 'visible' });
+    await capWidget.click();
+
+    const gatewayInstrument = new RenderInstrumentPage(gatewayPage);
+    await expect(gatewayInstrument.beginButton).toBeEnabled({ timeout: 120_000 });
+    await gatewayInstrument.begin();
+    await gatewayInstrument.completeHappinessQuestionnaire();
+    await gatewayInstrument.submit();
+    await expect(gatewayInstrument.summaryHeading).toBeVisible();
+    await gatewayPage.close();
+
+    // Back on the clinician side the assignment should now read as complete.
+    await page.locator('[data-testid^="nav-button-/datahub/"]').click();
+    await page.waitForURL('**/datahub/**/table');
+    await page.getByRole('link', { name: 'Assignments' }).click();
+    await page.waitForURL('**/datahub/**/assignments');
+
+    // The completion posts back from the gateway asynchronously, and assertion retries re-query the
+    // locator rather than refetching, so reload to pick up the settled state. Safe here: the page is
+    // addressed by subject id, so it does not depend on the (now irrelevant) in-memory session.
+    await page.reload();
+    await expect(page.getByRole('table')).toContainText('Complete');
+  });
+});

--- a/testing/src/specs/gateway-assignment.spec.ts
+++ b/testing/src/specs/gateway-assignment.spec.ts
@@ -65,10 +65,13 @@ test.describe('gateway remote assignment', () => {
     await page.getByRole('link', { name: 'Assignments' }).click();
     await page.waitForURL('**/datahub/**/assignments');
 
-    // The completion posts back from the gateway asynchronously, and assertion retries re-query the
-    // locator rather than refetching, so reload to pick up the settled state. Safe here: the page is
-    // addressed by subject id, so it does not depend on the (now irrelevant) in-memory session.
-    await page.reload();
-    await expect(page.getByRole('table')).toContainText('Complete');
+    // The completion posts back from the gateway asynchronously (it can still read "Outstanding"
+    // for a while on a slow runner), and assertion retries re-query the locator rather than
+    // refetching -- so retry the reload itself until the status settles. Reloading is safe here:
+    // the page is addressed by subject id, not the (now irrelevant) in-memory session.
+    await expect(async () => {
+      await page.reload();
+      await expect(page.getByRole('table')).toContainText('Complete', { timeout: 5_000 });
+    }).toPass({ timeout: 90_000 });
   });
 });

--- a/testing/src/specs/instrument-completion.spec.ts
+++ b/testing/src/specs/instrument-completion.spec.ts
@@ -1,0 +1,47 @@
+import { RenderInstrumentPage } from '../pages/_app/instruments/render/$id.page';
+import { expect, test } from '../support/fixtures';
+
+// Title shown on the instrument card in the showcase (`details.title`), which differs from the
+// title shown while running it (`clientDetails.title`, "Questionnaire on Happiness").
+const INSTRUMENT_TITLE = 'Happiness Questionnaire';
+
+test.describe('instrument completion', () => {
+  test('should administer an instrument and surface the record for the subject @smoke', async ({
+    getPageModel,
+    page,
+    uniqueId
+  }) => {
+    const startSessionPage = await getPageModel('/session/start-session');
+    await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+    await startSessionPage.selectIdentificationMethod('PERSONAL_INFO');
+    await startSessionPage.fillSessionForm(`Instrument${uniqueId}`, `Subject${uniqueId}`, 'Female');
+    await startSessionPage.submitForm();
+    await expect(startSessionPage.successMessage).toBeVisible();
+
+    // The active session lives in memory, so every step from here navigates via the sidebar; a
+    // hard navigation would drop the session and disable these nav buttons.
+    await page.getByTestId('nav-button-/instruments/accessible-instruments').click();
+    await page.waitForURL('**/instruments/accessible-instruments');
+
+    const card = page.locator('[data-testid^="instrument-card-"]').filter({ hasText: INSTRUMENT_TITLE }).first();
+    await expect(card).toBeVisible();
+    await card.click();
+
+    const instrumentPage = new RenderInstrumentPage(page);
+    await instrumentPage.begin();
+    await instrumentPage.completeHappinessQuestionnaire();
+    await instrumentPage.submit();
+
+    await expect(instrumentPage.summaryHeading).toBeVisible();
+
+    // "View Current Subject" targets the active subject's record table directly, which is far more
+    // robust than matching a hashed row in the data hub list.
+    await page.locator('[data-testid^="nav-button-/datahub/"]').click();
+    await page.waitForURL('**/datahub/**/table');
+
+    await page.getByRole('combobox').first().click();
+    await page.getByRole('option', { name: INSTRUMENT_TITLE }).click();
+
+    await expect(page.getByTestId('data-table-body').getByTestId('data-table-row').first()).toBeVisible();
+  });
+});

--- a/testing/src/specs/remote-assignment.spec.ts
+++ b/testing/src/specs/remote-assignment.spec.ts
@@ -1,4 +1,4 @@
-import { RemoteAssignmentPage } from '../pages/remote-assignment.page';
+import { RemoteAssignmentPage } from '../pages/_app/session/remote-assignment.page';
 import { expect, test } from '../support/fixtures';
 
 import type { GetPageModel } from '../support/fixtures';

--- a/testing/src/support/fixtures.ts
+++ b/testing/src/support/fixtures.ts
@@ -3,12 +3,13 @@
 import { request as apiRequestFactory, test as base, expect } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 
+import { DashboardPage } from '../pages/_app/dashboard.page';
+import { SubjectDataTablePage } from '../pages/_app/datahub/$subjectId/table/index.page';
+import { DatahubPage } from '../pages/_app/datahub/index.page';
+import { AccessibleInstrumentsPage } from '../pages/_app/instruments/accessible-instruments.page';
+import { RemoteAssignmentPage } from '../pages/_app/session/remote-assignment.page';
+import { StartSessionPage } from '../pages/_app/session/start-session.page';
 import { LoginPage } from '../pages/auth/login.page';
-import { DashboardPage } from '../pages/dashboard.page';
-import { DatahubPage } from '../pages/datahub/datahub.page';
-import { SubjectDataTablePage } from '../pages/datahub/subject-data-table.page';
-import { RemoteAssignmentPage } from '../pages/remote-assignment.page';
-import { StartSessionPage } from '../pages/start-session.page';
 import { ApiClient } from './api-client';
 import { ADMIN } from './constants';
 import { baseURL } from './env';
@@ -21,6 +22,7 @@ const pageModels = {
   '/dashboard': DashboardPage,
   '/datahub': DatahubPage,
   '/datahub/$subjectId/table': SubjectDataTablePage,
+  '/instruments/accessible-instruments': AccessibleInstrumentsPage,
   '/session/remote-assignment': RemoteAssignmentPage,
   '/session/start-session': StartSessionPage
 } satisfies { [K in RouteTo]?: any };
@@ -48,6 +50,12 @@ type TestFixtures = {
   actingRole: Role;
   /** First-run gating written to localStorage; override per file with `test.use({ appState })`. */
   appState: AppState;
+  /**
+   * Injects a role's token without navigating, so the test can drive navigation itself. Use this
+   * (rather than `getPageModel`) when the expected outcome is a redirect, since `getPageModel`
+   * asserts it landed on the requested route.
+   */
+  authenticateAs: (role: Role) => Promise<void>;
   /** Navigates to a route as `actingRole` and returns its page object. */
   getPageModel: GetPageModel;
   /** Short run-unique suffix for naming seeded data in this test. */
@@ -77,19 +85,24 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     { scope: 'worker' }
   ],
   appState: [{ isDisclaimerAccepted: true, isWalkthroughComplete: true }, { option: true }],
-  getPageModel: async ({ actingRole, appState, page, roleToken }, use) => {
+  authenticateAs: async ({ appState, page, roleToken }, use) => {
+    await use(async (role) => {
+      const accessToken = await roleToken(role);
+      await page.addInitScript(
+        (injected) => {
+          window.__PLAYWRIGHT_ACCESS_TOKEN__ = injected.accessToken;
+          localStorage.setItem('app', JSON.stringify({ state: injected.state, version: 1 }));
+        },
+        { accessToken, state: appState }
+      );
+    });
+  },
+  getPageModel: async ({ actingRole, authenticateAs, page }, use) => {
     await use(
       async <TKey extends Extract<keyof PageModels, RouteTo>>(key: TKey, ...args: NavigateVariadicArgs<TKey>) => {
         const pageModel = new pageModels[key](page) as InstanceType<PageModels[TKey]>;
         if (pageModel._requiresAuth) {
-          const accessToken = await roleToken(actingRole);
-          await page.addInitScript(
-            (injected) => {
-              window.__PLAYWRIGHT_ACCESS_TOKEN__ = injected.accessToken;
-              localStorage.setItem('app', JSON.stringify({ state: injected.state, version: 1 }));
-            },
-            { accessToken, state: appState }
-          );
+          await authenticateAs(actingRole);
         }
         await pageModel.goto(key, ...args);
         return pageModel;


### PR DESCRIPTION
## Summary

**Stage 2 of the e2e work** — new coverage on top of the stage-one structure (#1429), plus a `pages/` layout that mirrors `apps/web`'s TanStack route tree.

### New specs
| Spec | Covers |
|---|---|
| `instrument-completion` | Start a session → administer the Happiness Questionnaire (sliders via arrow keys) → submit → confirm the record via **View Current Subject** |
| `authorization` | `GROUP_MANAGER` gets the management nav; `STANDARD` does not, and is redirected off `/dashboard` and `/session/remote-assignment` |
| `admin-management` | `ADMIN` creates a group through the UI; lists users |
| `gateway-assignment` | Create a remote assignment → complete it as the patient on the **gateway origin** (solving the Cap proof-of-work) → clinician sees it as **Complete** |

### Supporting changes
- `authenticateAs(role)` fixture: injects a role's token **without navigating**, which redirect probes need (`getPageModel` asserts its landing route).
- Page objects for the instrument showcase and the instrument runner.
- `pages/` now mirrors the route tree 1:1 — e.g. `_app/session/start-session.page.ts` ↔ `_app/session/start-session.tsx` — so a route tells you exactly where its page object lives.

### App behaviour these encode
- Multi-step flows navigate via **sidebar clicks**, not `page.goto()`: the active session is memory-only and does not survive a hard navigation.
- Group creation asserts the **success toast + redirect** rather than list membership — `/admin/groups` appears to be scoped to groups the actor belongs to, and creating one does not add the creator as a member. Flagged rather than asserted.

## Verification

**32 passed**, both parallel and with `CI=1` (serial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)