### PR TITLE
chore(deps): bump vendored runtime libs (dompurify, lodash-es)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1574,8 +1574,8 @@ importers:
   vendor/dompurify@3.x:
     dependencies:
       dompurify:
-        specifier: 3.1.6
-        version: 3.1.6
+        specifier: 3.4.12
+        version: 3.4.12
 
   vendor/jquery-ui@1.x:
     dependencies:
@@ -1616,8 +1616,8 @@ importers:
   vendor/lodash-es@4.x:
     dependencies:
       lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
 
   vendor/normalize.css@8.x:
     dependencies:
@@ -6235,6 +6235,10 @@ packages:
     resolution:
       { integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w== }
 
+  '@types/trusted-types@2.0.7':
+    resolution:
+      { integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw== }
+
   '@types/unist@2.0.11':
     resolution:
       { integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA== }
@@ -7786,9 +7790,9 @@ packages:
       { integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w== }
     engines: { node: '>= 4' }
 
-  dompurify@3.1.6:
+  dompurify@3.4.12:
     resolution:
-      { integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ== }
+      { integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg== }
 
   domutils@3.2.2:
     resolution:
@@ -9655,10 +9659,6 @@ packages:
     resolution:
       { integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw== }
     engines: { node: '>=10' }
-
-  lodash-es@4.17.21:
-    resolution:
-      { integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw== }
 
   lodash-es@4.18.1:
     resolution:
@@ -17401,6 +17401,9 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.10
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -18886,7 +18889,9 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.6: {}
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -20818,8 +20823,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash-es@4.18.1: {}
 

--- a/vendor/dompurify@3.x/package.json
+++ b/vendor/dompurify@3.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dompurify__3.x",
   "type": "module",
-  "version": "3.1.6",
+  "version": "3.4.12",
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -11,6 +11,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "dompurify": "3.1.6"
+    "dompurify": "3.4.12"
   }
 }

--- a/vendor/lodash-es@4.x/package.json
+++ b/vendor/lodash-es@4.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lodash-es__4.x",
   "type": "module",
-  "version": "4.17.21",
+  "version": "4.18.1",
   "license": "MIT",
   "exports": {
     ".": {
@@ -11,6 +11,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.18.1"
   }
 }


### PR DESCRIPTION
Part 2 of 2 of the Dependabot security sweep. This PR bumps the **vendored instrument-runtime libraries** — the versions that authored instruments load at runtime via `runtime/v1`.

| Vendored package | Change | Advisories |
|---|---|---|
| `vendor/dompurify@3.x` | 3.1.6 → **3.4.12** | 15 (sanitizer/`IN_PLACE`/`SAFE_FOR_TEMPLATES` bypasses, `ADD_TAGS`/`USE_PROFILES` prototype pollution, mutation-XSS) |
| `vendor/lodash-es@4.x` | 4.17.21 → **4.18.1** | 2 (code injection via `_.template`, prototype pollution in `_.unset`/`_.omit`) |

### Why these are safe to bump
Both stay **within the vendored major line** (`dompurify@3.x`, `lodash-es@4.x`), so the runtime API contract instruments depend on is unchanged. `jquery@1.12.4` is deliberately **not** touched — it is an intentional legacy pin and its advisory is being resolved separately (instruments are trusted, same-origin code, so it adds no attack surface).

### Verification
- Delta is exactly `dompurify 3.1.6→3.4.12` (+ its new `@types/trusted-types` types dep) and `lodash-es 4.17.21→4.18.1` (dedupes onto the 4.18.1 already in the tree) — nothing else.
- `runtime/v1` bundles successfully (`runtime-bundler` → "Success!").
- `pnpm lint` ✅ (33/33) · `pnpm test` ✅ (307 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)