### PR TITLE
feat(i18n): add Spanish language support and per-instance active languages

### DIFF
--- a/apps/api/src/setup/dto/update-setup-state.dto.ts
+++ b/apps/api/src/setup/dto/update-setup-state.dto.ts
@@ -6,6 +6,9 @@ import type { BrandingConfig, UpdateSetupStateData } from '@opendatacapture/sche
 @ValidationSchema($UpdateSetupStateData)
 export class UpdateSetupStateDto implements UpdateSetupStateData {
   @ApiProperty({ required: false })
+  activeLanguages?: string[];
+
+  @ApiProperty({ required: false })
   branding?: BrandingConfig | null;
 
   @ApiProperty({ required: false })

--- a/apps/gateway/src/Root.tsx
+++ b/apps/gateway/src/Root.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { LanguageToggle, ThemeToggle } from '@douglasneuroinformatics/libui/components';
-import { useNotificationsStore } from '@douglasneuroinformatics/libui/hooks';
+import { useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import type { Language } from '@douglasneuroinformatics/libui/i18n';
 import { CoreProvider } from '@douglasneuroinformatics/libui/providers';
 import { Branding, InstrumentRenderer } from '@opendatacapture/react-core';
 import type { InstrumentSubmitHandler } from '@opendatacapture/react-core';
@@ -14,21 +15,30 @@ import CapWidget from './components/Cap';
 import './services/axios';
 import './services/i18n';
 
+const GATEWAY_LANGUAGES: { [key: string]: string } = { en: 'English', fr: 'Français' };
+const VALID_LANGUAGES = ['en', 'es', 'fr'];
+
 export type RootProps = {
   id: string;
   initialSeriesIndex?: number;
+  lang?: string;
   target: InstrumentBundleContainer;
   token: string;
 };
 
-export const Root = ({ id, initialSeriesIndex, target, token }: RootProps) => {
+export const Root = ({ id, initialSeriesIndex, lang, target, token }: RootProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const notifications = useNotificationsStore();
+  const { changeLanguage } = useTranslation();
 
   const [verified, setVerified] = useState(false);
 
   useEffect(() => {
     ref.current!.style.display = 'flex';
+    const targetLang = lang ?? new URLSearchParams(window.location.search).get('lang') ?? undefined;
+    if (targetLang && VALID_LANGUAGES.includes(targetLang)) {
+      changeLanguage(targetLang as Language);
+    }
   }, []);
 
   // Solving the Cap challenge redeems a short-lived token; exchange it immediately for a
@@ -79,13 +89,7 @@ export const Root = ({ id, initialSeriesIndex, target, token }: RootProps) => {
             <Branding className="[&>span]:hidden sm:[&>span]:block" fontSize="md" />
             <div className="flex gap-3">
               <ThemeToggle className="h-9 w-9" />
-              <LanguageToggle
-                options={{
-                  en: 'English',
-                  fr: 'Français'
-                }}
-                triggerClassName="h-9 w-9"
-              />
+              <LanguageToggle options={GATEWAY_LANGUAGES} triggerClassName="h-9 w-9" />
             </div>
           </div>
         </header>

--- a/apps/gateway/src/entry-client.tsx
+++ b/apps/gateway/src/entry-client.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
+import { i18n } from '@douglasneuroinformatics/libui/i18n';
+import type { Language } from '@douglasneuroinformatics/libui/i18n';
+
 import { Root } from './Root';
 
 import '@opendatacapture/react-core/globals.css';
 import './globals.css';
 
 const ROOT_PROPS = window.__ROOT_PROPS__;
+
+const lang = ROOT_PROPS.lang ?? new URLSearchParams(window.location.search).get('lang') ?? undefined;
+if (lang && ['en', 'es', 'fr'].includes(lang)) {
+  i18n.changeLanguage(lang as Language);
+}
 
 ReactDOM.hydrateRoot(
   document.getElementById('root')!,

--- a/apps/gateway/src/entry-server.tsx
+++ b/apps/gateway/src/entry-server.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
+import { i18n } from '@douglasneuroinformatics/libui/i18n';
+import type { Language } from '@douglasneuroinformatics/libui/i18n';
+
 import { Root } from './Root';
 
 import type { RootProps } from './Root';
@@ -8,6 +11,9 @@ import type { RootProps } from './Root';
 export type RenderFunction = (props: RootProps) => { html: string };
 
 export const render: RenderFunction = (props) => {
+  if (props.lang && ['en', 'es', 'fr'].includes(props.lang)) {
+    i18n.changeLanguage(props.lang as Language);
+  }
   const html = ReactDOMServer.renderToString(
     <React.StrictMode>
       <Root {...props} />

--- a/apps/gateway/src/routers/root.router.ts
+++ b/apps/gateway/src/routers/root.router.ts
@@ -41,9 +41,11 @@ router.get(
     }
 
     const token = generateToken(assignment.id);
+    const lang = typeof req.query.lang === 'string' ? req.query.lang : undefined;
     const html = res.locals.loadRoot({
       id,
       initialSeriesIndex,
+      lang,
       target: targetParseResult.data,
       token
     } satisfies RootProps);

--- a/apps/gateway/src/services/i18n.ts
+++ b/apps/gateway/src/services/i18n.ts
@@ -1,5 +1,32 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/no-namespace */
+
 import { i18n } from '@douglasneuroinformatics/libui/i18n';
+import type { Language } from '@douglasneuroinformatics/libui/i18n';
+
+declare module '@douglasneuroinformatics/libui/i18n' {
+  export namespace UserConfig {
+    export interface LanguageOptions {
+      en: true;
+      es: true;
+      fr: true;
+    }
+  }
+}
+
+const VALID_LANGUAGES = ['en', 'es', 'fr'];
+
+function detectLanguage(): Language {
+  if (typeof window !== 'undefined') {
+    const param = new URLSearchParams(window.location.search).get('lang');
+    if (param && VALID_LANGUAGES.includes(param)) {
+      return param as Language;
+    }
+  }
+  return 'en';
+}
 
 i18n.init({
+  defaultLanguage: detectLanguage(),
   translations: {}
 });

--- a/apps/web/src/components/AppErrorComponent.tsx
+++ b/apps/web/src/components/AppErrorComponent.tsx
@@ -45,22 +45,24 @@ export const AppErrorComponent = ({ error, reset }: ErrorComponentProps) => {
         <WifiOff aria-hidden className="text-muted-foreground h-8! w-8!" />
       )}
       <h1 className="mt-4 text-2xl font-extrabold tracking-tight sm:text-3xl">
-        {t({ en: 'Connection Problem', fr: 'Problème de connexion' })}
+        {t({ en: 'Connection Problem', es: 'Problema de conexión', fr: 'Problème de connexion' })}
       </h1>
       <p className="text-muted-foreground mt-2 max-w-prose text-sm sm:text-base">
         {isOnline
           ? t({
               en: "We couldn't reach the server. This is usually temporary — please try again.",
+              es: 'No se pudo conectar con el servidor. Esto suele ser temporal — por favor, inténtelo de nuevo.',
               fr: 'Impossible de joindre le serveur. Le problème est généralement temporaire — veuillez réessayer.'
             })
           : t({
               en: "You appear to be offline. We'll reconnect automatically as soon as your connection returns.",
+              es: 'Parece que está desconectado. La reconexión se realizará automáticamente en cuanto vuelva la conexión.',
               fr: 'Vous semblez être hors ligne. La reconnexion se fera automatiquement dès le retour de votre connexion.'
             })}
       </p>
       <div className="mt-6">
         <Button type="button" variant="primary" onClick={handleRetry}>
-          {t({ en: 'Try again', fr: 'Réessayer' })}
+          {t({ en: 'Try again', es: 'Intentar de nuevo', fr: 'Réessayer' })}
         </Button>
       </div>
     </div>

--- a/apps/web/src/components/AssignmentEmailForm/AssignmentEmailForm.tsx
+++ b/apps/web/src/components/AssignmentEmailForm/AssignmentEmailForm.tsx
@@ -51,7 +51,7 @@ export const AssignmentEmailForm: React.FC<{
   const selectedTemplate = templateChoice ?? activeValue;
   const templateOptions = [
     {
-      label: t({ en: 'Built-in default', fr: 'Modèle par défaut' }),
+      label: t({ en: 'Built-in default', es: 'Predeterminado integrado', fr: 'Modèle par défaut' }),
       value: DEFAULT_TEMPLATE_OPTION
     },
     ...remoteTemplates.map((tpl) => ({ label: tpl.name, value: tpl.id }))
@@ -80,12 +80,13 @@ export const AssignmentEmailForm: React.FC<{
         onError: () => {
           const message = t({
             en: 'The email could not be sent',
+            es: 'No se pudo enviar el correo electrónico',
             fr: "Le courriel n'a pas pu être envoyé"
           });
           setFeedback({ message, tone: 'error' });
           addNotification({
             message,
-            title: t({ en: 'Email failed', fr: 'Échec du courriel' }),
+            title: t({ en: 'Email failed', es: 'Error de correo electrónico', fr: 'Échec du courriel' }),
             type: 'error'
           });
         },
@@ -93,12 +94,13 @@ export const AssignmentEmailForm: React.FC<{
           if (result.status === 'SENT') {
             const message = t({
               en: `Assignment link sent to ${recipient}`,
+              es: `Enlace de evaluación enviado a ${recipient}`,
               fr: `Lien d'évaluation envoyé à ${recipient}`
             });
             setFeedback({ message, tone: 'success' });
             addNotification({
               message,
-              title: t({ en: 'Email sent', fr: 'Courriel envoyé' }),
+              title: t({ en: 'Email sent', es: 'Correo electrónico enviado', fr: 'Courriel envoyé' }),
               type: 'success'
             });
             setRecipient('');
@@ -107,12 +109,13 @@ export const AssignmentEmailForm: React.FC<{
               result.error ??
               t({
                 en: 'The email could not be sent',
+                es: 'No se pudo enviar el correo electrónico',
                 fr: "Le courriel n'a pas pu être envoyé"
               });
             setFeedback({ message, tone: 'error' });
             addNotification({
               message,
-              title: t({ en: 'Email failed', fr: 'Échec du courriel' }),
+              title: t({ en: 'Email failed', es: 'Error de correo electrónico', fr: 'Échec du courriel' }),
               type: 'error'
             });
           }
@@ -134,7 +137,9 @@ export const AssignmentEmailForm: React.FC<{
     <div className="flex flex-col gap-2">
       {remoteTemplates.length > 0 && (
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="assignment-template">{t({ en: 'Email template', fr: 'Modèle de courriel' })}</Label>
+          <Label htmlFor="assignment-template">
+            {t({ en: 'Email template', es: 'Plantilla de correo electrónico', fr: 'Modèle de courriel' })}
+          </Label>
           <Select value={selectedTemplate} onValueChange={setTemplateChoice}>
             <Select.Trigger className="w-full" id="assignment-template">
               <Select.Value />
@@ -151,7 +156,7 @@ export const AssignmentEmailForm: React.FC<{
       )}
       <div className="flex flex-col gap-1.5">
         <div className="flex items-center gap-1.5">
-          <Label>{t({ en: 'Email language', fr: 'Langue du courriel' })}</Label>
+          <Label>{t({ en: 'Email language', es: 'Idioma del correo', fr: 'Langue du courriel' })}</Label>
           <Tooltip>
             <Tooltip.Trigger className="p-0 hover:bg-transparent" size="icon" variant="ghost">
               <CircleHelpIcon className="text-muted-foreground h-4 w-4" />
@@ -160,6 +165,7 @@ export const AssignmentEmailForm: React.FC<{
               <p>
                 {t({
                   en: 'Emails and assignments are sent in the selected language when available. However, subjects may still choose a different preferred language on the gateway.',
+                  es: 'Los correos y las evaluaciones se envían en el idioma seleccionado cuando está disponible. Sin embargo, los sujetos aún pueden elegir un idioma preferido diferente en el portal.',
                   fr: "Les courriels et les évaluations sont envoyés dans la langue sélectionnée lorsqu'elle est disponible. Cependant, les sujets peuvent toujours choisir une langue préférée différente sur le portail."
                 })}
               </p>
@@ -184,6 +190,7 @@ export const AssignmentEmailForm: React.FC<{
       <Label htmlFor="assignment-email">
         {t({
           en: 'Email link to participant',
+          es: 'Enviar enlace al participante por correo electrónico',
           fr: 'Envoyer le lien au participant par courriel'
         })}
       </Label>
@@ -193,6 +200,7 @@ export const AssignmentEmailForm: React.FC<{
           id="assignment-email"
           placeholder={t({
             en: 'recipient@example.org',
+            es: 'destinatario@ejemplo.org',
             fr: 'destinataire@exemple.org'
           })}
           type="email"
@@ -207,8 +215,8 @@ export const AssignmentEmailForm: React.FC<{
           onClick={sendEmail}
         >
           {sendEmailMutation.isPending
-            ? t({ en: 'Sending…', fr: 'Envoi en cours…' })
-            : t({ en: 'Email assignment', fr: 'Envoyer par courriel' })}
+            ? t({ en: 'Sending…', es: 'Enviando…', fr: 'Envoi en cours…' })
+            : t({ en: 'Email assignment', es: 'Enviar por correo electrónico', fr: 'Envoyer par courriel' })}
         </Button>
       </div>
       {feedback && (

--- a/apps/web/src/components/ConnectivityBanner.tsx
+++ b/apps/web/src/components/ConnectivityBanner.tsx
@@ -29,10 +29,12 @@ export const ConnectivityBanner = () => {
           {isOnline
             ? t({
                 en: 'Reconnecting…',
+                es: 'Reconectando…',
                 fr: 'Reconnexion…'
               })
             : t({
                 en: 'Offline — waiting for connection…',
+                es: 'Sin conexión — esperando conexión…',
                 fr: 'Hors ligne — en attente de connexion…'
               })}
         </span>

--- a/apps/web/src/components/GroupEmailTemplates/GroupEmailTemplates.tsx
+++ b/apps/web/src/components/GroupEmailTemplates/GroupEmailTemplates.tsx
@@ -38,12 +38,14 @@ const templateErrorMessage = (
   if (issue === 'incomplete') {
     return t({
       en: 'Fill in the subject and body in each language.',
+      es: 'Complete el asunto y el cuerpo en cada idioma.',
       fr: "Remplissez l'objet et le corps dans chaque langue."
     });
   }
   if (issue === 'missing-vars') {
     return t({
       en: 'Remote assignment templates must include {{url}} and {{expiresAt}}.',
+      es: 'Las plantillas de evaluación remota deben incluir {{url}} y {{expiresAt}}.',
       fr: "Les modèles d'évaluation à distance doivent inclure {{url}} et {{expiresAt}}."
     });
   }
@@ -102,7 +104,7 @@ const TemplateFields = ({
   return (
     <React.Fragment>
       <div className="flex flex-col gap-1.5">
-        <Label>{t({ en: 'Category', fr: 'Catégorie' })}</Label>
+        <Label>{t({ en: 'Category', es: 'Categoría', fr: 'Catégorie' })}</Label>
         <SegmentedControl<GroupEmailTemplateCategory>
           className="w-full max-w-md"
           options={[
@@ -114,11 +116,11 @@ const TemplateFields = ({
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="tpl-name">{t({ en: 'Name', fr: 'Nom' })}</Label>
+        <Label htmlFor="tpl-name">{t({ en: 'Name', es: 'Nombre', fr: 'Nom' })}</Label>
         <Input id="tpl-name" value={name} onChange={(event) => setName(event.target.value)} />
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label>{t({ en: 'Language', fr: 'Langue' })}</Label>
+        <Label>{t({ en: 'Language', es: 'Idioma', fr: 'Langue' })}</Label>
         <Select value={lang} onValueChange={setLang}>
           <Select.Trigger className="w-[180px] border-sky-700 bg-sky-700 text-white hover:bg-sky-800 dark:border-sky-700 dark:bg-sky-700 dark:text-white dark:hover:bg-sky-800">
             <Select.Value />
@@ -135,7 +137,7 @@ const TemplateFields = ({
         </Select>
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="tpl-subject">{t({ en: 'Subject', fr: 'Objet' })}</Label>
+        <Label htmlFor="tpl-subject">{t({ en: 'Subject', es: 'Asunto', fr: 'Objet' })}</Label>
         <Input
           id="tpl-subject"
           value={currentSubject}
@@ -144,10 +146,12 @@ const TemplateFields = ({
       </div>
       <div className="flex flex-col gap-1.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <Label htmlFor="tpl-body">{t({ en: 'Body', fr: 'Corps' })}</Label>
+          <Label htmlFor="tpl-body">{t({ en: 'Body', es: 'Cuerpo', fr: 'Corps' })}</Label>
           {AVAILABLE_VARS[category].length > 0 && (
             <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-muted-foreground text-xs">{t({ en: 'Insert:', fr: 'Insérer :' })}</span>
+              <span className="text-muted-foreground text-xs">
+                {t({ en: 'Insert:', es: 'Insertar:', fr: 'Insérer :' })}
+              </span>
               {AVAILABLE_VARS[category].map((variable) => (
                 <Button
                   className="h-6 px-2 font-mono text-xs"
@@ -218,6 +222,7 @@ const EditTemplateForm = ({
 
   const duplicateNameMessage = t({
     en: 'A template with this name already exists',
+    es: 'Ya existe una plantilla con este nombre',
     fr: 'Un modèle avec ce nom existe déjà'
   });
 
@@ -225,7 +230,7 @@ const EditTemplateForm = ({
     event.preventDefault();
     if (!name.trim()) {
       addNotification({
-        message: t({ en: 'A name is required', fr: 'Un nom est requis' }),
+        message: t({ en: 'A name is required', es: 'Se requiere un nombre', fr: 'Un nom est requis' }),
         type: 'error'
       });
       return;
@@ -316,8 +321,8 @@ export const GroupEmailTemplates = () => {
 
   const categoryLabel = (value: GroupEmailTemplateCategory) =>
     value === 'REMOTE_ASSIGNMENT'
-      ? t({ en: 'Remote assignment', fr: 'Évaluation à distance' })
-      : t({ en: 'Information', fr: 'Information' });
+      ? t({ en: 'Remote assignment', es: 'Evaluación remota', fr: 'Évaluation à distance' })
+      : t({ en: 'Information', es: 'Información', fr: 'Information' });
 
   const activeIdFor = (value: GroupEmailTemplateCategory) =>
     value === 'REMOTE_ASSIGNMENT' ? activeIds.assignment : activeIds.information;
@@ -359,7 +364,7 @@ export const GroupEmailTemplates = () => {
     event.preventDefault();
     if (!name.trim()) {
       addNotification({
-        message: t({ en: 'A name is required', fr: 'Un nom est requis' }),
+        message: t({ en: 'A name is required', es: 'Se requiere un nombre', fr: 'Un nom est requis' }),
         type: 'error'
       });
       return;
@@ -369,6 +374,7 @@ export const GroupEmailTemplates = () => {
       addNotification({
         message: t({
           en: 'A template with this name already exists',
+          es: 'Ya existe una plantilla con este nombre',
           fr: 'Un modèle avec ce nom existe déjà'
         }),
         type: 'error'
@@ -422,7 +428,7 @@ export const GroupEmailTemplates = () => {
       >
         <span className="flex-1 text-sm font-medium">{tpl.name}</span>
         <Button
-          aria-label={t({ en: 'Edit', fr: 'Modifier' })}
+          aria-label={t({ en: 'Edit', es: 'Editar', fr: 'Modifier' })}
           size="icon"
           type="button"
           variant="outline"
@@ -447,7 +453,7 @@ export const GroupEmailTemplates = () => {
             type="button"
             variant="primary"
           >
-            {t({ en: 'Default', fr: 'Par défaut' })}
+            {t({ en: 'Default', es: 'Predeterminado', fr: 'Par défaut' })}
           </Button>
         ) : (
           <Button
@@ -457,7 +463,7 @@ export const GroupEmailTemplates = () => {
             variant="outline"
             onClick={() => void handleSetActive(tpl)}
           >
-            {t({ en: 'Set default', fr: 'Définir par défaut' })}
+            {t({ en: 'Set default', es: 'Predeterminar', fr: 'Définir par défaut' })}
           </Button>
         )}
       </div>
@@ -471,11 +477,12 @@ export const GroupEmailTemplates = () => {
         <span className="flex-1 text-sm font-medium">
           {t({
             en: 'Your Open Data Capture Assignment (built-in)',
+            es: 'Su evaluación de Open Data Capture (integrado)',
             fr: 'Votre évaluation Open Data Capture (intégré)'
           })}
         </span>
         <Button
-          aria-label={t({ en: 'View', fr: 'Voir' })}
+          aria-label={t({ en: 'View', es: 'Ver', fr: 'Voir' })}
           size="icon"
           type="button"
           variant="outline"
@@ -491,7 +498,7 @@ export const GroupEmailTemplates = () => {
             type="button"
             variant="primary"
           >
-            {t({ en: 'Default', fr: 'Par défaut' })}
+            {t({ en: 'Default', es: 'Predeterminado', fr: 'Par défaut' })}
           </Button>
         ) : (
           <Button
@@ -501,7 +508,7 @@ export const GroupEmailTemplates = () => {
             variant="outline"
             onClick={() => void persist(templates, { assignment: null, information: activeIds.information })}
           >
-            {t({ en: 'Set default', fr: 'Définir par défaut' })}
+            {t({ en: 'Set default', es: 'Predeterminar', fr: 'Définir par défaut' })}
           </Button>
         )}
       </div>
@@ -524,12 +531,14 @@ export const GroupEmailTemplates = () => {
         <Heading className="mb-2" variant="h4">
           {t({
             en: 'Remote Assignment Templates',
+            es: 'Plantillas de evaluación remota',
             fr: "Modèles d'évaluation à distance"
           })}
         </Heading>
         <p className="text-muted-foreground mb-3 text-sm">
           {t({
             en: 'Used when emailing a remote assignment link.',
+            es: 'Se usa al enviar un enlace de evaluación remota por correo electrónico.',
             fr: "Utilisés lors de l'envoi d'un lien d'évaluation à distance."
           })}
         </p>
@@ -541,11 +550,12 @@ export const GroupEmailTemplates = () => {
 
       <div>
         <Heading className="mb-2" variant="h4">
-          {t({ en: 'Information Templates', fr: "Modèles d'information" })}
+          {t({ en: 'Information Templates', es: 'Plantillas de información', fr: "Modèles d'information" })}
         </Heading>
         <p className="text-muted-foreground mb-3 text-sm">
           {t({
             en: 'General study-related messages for your participants.',
+            es: 'Mensajes generales relacionados con el estudio para sus participantes.',
             fr: "Messages généraux liés à l'étude pour vos participants."
           })}
         </p>
@@ -555,6 +565,7 @@ export const GroupEmailTemplates = () => {
           <EmptyState>
             {t({
               en: 'No information templates yet — create one to get started.',
+              es: 'Aún no hay plantillas de información — cree una para comenzar.',
               fr: "Aucun modèle d'information — créez-en un pour commencer."
             })}
           </EmptyState>
@@ -565,7 +576,7 @@ export const GroupEmailTemplates = () => {
         className="flex flex-col gap-3 rounded-2xl border border-slate-200/60 p-5 dark:border-slate-700/60"
         onSubmit={(event) => void handleCreate(event)}
       >
-        <Heading variant="h5">{t({ en: 'New template', fr: 'Nouveau modèle' })}</Heading>
+        <Heading variant="h5">{t({ en: 'New template', es: 'Nueva plantilla', fr: 'Nouveau modèle' })}</Heading>
         <TemplateFields
           activeLanguages={activeLanguages}
           body={body}
@@ -581,7 +592,7 @@ export const GroupEmailTemplates = () => {
         />
         <div>
           <Button disabled={updateGroupMutation.isPending || Boolean(createBodyError)} type="submit">
-            {t({ en: 'Add template', fr: 'Ajouter le modèle' })}
+            {t({ en: 'Add template', es: 'Agregar plantilla', fr: 'Ajouter le modèle' })}
           </Button>
         </div>
       </form>
@@ -592,19 +603,21 @@ export const GroupEmailTemplates = () => {
             <Dialog.Title>
               {t({
                 en: 'Built-in default template',
+                es: 'Plantilla predeterminada integrada',
                 fr: 'Modèle par défaut intégré'
               })}
             </Dialog.Title>
             <Dialog.Description>
               {t({
                 en: 'This is the message sent for remote assignments when no custom template is active.',
+                es: 'Este es el mensaje enviado para las evaluaciones remotas cuando no hay una plantilla personalizada activa.',
                 fr: "Il s'agit du message envoyé pour les évaluations à distance lorsqu'aucun modèle personnalisé n'est actif."
               })}
             </Dialog.Description>
           </Dialog.Header>
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1.5">
-              <Label>{t({ en: 'Language', fr: 'Langue' })}</Label>
+              <Label>{t({ en: 'Language', es: 'Idioma', fr: 'Langue' })}</Label>
               <Select value={defaultViewLang} onValueChange={setDefaultViewLang}>
                 <Select.Trigger className="w-[180px] border-sky-700 bg-sky-700 text-white hover:bg-sky-800 dark:border-sky-700 dark:bg-sky-700 dark:text-white dark:hover:bg-sky-800">
                   <Select.Value />
@@ -621,17 +634,17 @@ export const GroupEmailTemplates = () => {
               </Select>
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="default-tpl-subject">{t({ en: 'Subject', fr: 'Objet' })}</Label>
+              <Label htmlFor="default-tpl-subject">{t({ en: 'Subject', es: 'Asunto', fr: 'Objet' })}</Label>
               <Input readOnly id="default-tpl-subject" value={defaultTemplateSubject[defaultViewLang] ?? ''} />
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="default-tpl-body">{t({ en: 'Body', fr: 'Corps' })}</Label>
+              <Label htmlFor="default-tpl-body">{t({ en: 'Body', es: 'Cuerpo', fr: 'Corps' })}</Label>
               <TextArea readOnly id="default-tpl-body" rows={8} value={defaultTemplateBody[defaultViewLang] ?? ''} />
             </div>
           </div>
           <Dialog.Footer>
             <Button type="button" variant="outline" onClick={() => setViewingDefault(false)}>
-              {t({ en: 'Close', fr: 'Fermer' })}
+              {t({ en: 'Close', es: 'Cerrar', fr: 'Fermer' })}
             </Button>
           </Dialog.Footer>
         </Dialog.Content>
@@ -640,7 +653,7 @@ export const GroupEmailTemplates = () => {
       <Dialog open={editing !== null} onOpenChange={(open) => !open && setEditing(null)}>
         <Dialog.Content className="max-w-lg">
           <Dialog.Header>
-            <Dialog.Title>{t({ en: 'Edit template', fr: 'Modifier le modèle' })}</Dialog.Title>
+            <Dialog.Title>{t({ en: 'Edit template', es: 'Editar plantilla', fr: 'Modifier le modèle' })}</Dialog.Title>
           </Dialog.Header>
           {editing && (
             <EditTemplateForm
@@ -660,12 +673,15 @@ export const GroupEmailTemplates = () => {
       <Dialog open={confirmCreate} onOpenChange={setConfirmCreate}>
         <Dialog.Content className="max-w-md">
           <Dialog.Header>
-            <Dialog.Title>{t({ en: 'Missing translations', fr: 'Traductions manquantes' })}</Dialog.Title>
+            <Dialog.Title>
+              {t({ en: 'Missing translations', es: 'Traducciones faltantes', fr: 'Traductions manquantes' })}
+            </Dialog.Title>
           </Dialog.Header>
           <Dialog.Description>
             {t(
               {
                 en: 'Warning: This template is missing translations for: {}.',
+                es: 'Advertencia: Esta plantilla no tiene traducciones para: {}.',
                 fr: 'Attention : Ce modèle est sans traduction pour : {}.'
               },
               { args: [missingLanguages.map((code) => ALL_LANGUAGES[code] ?? code).join(', ')] }
@@ -683,7 +699,7 @@ export const GroupEmailTemplates = () => {
                 void doCreate();
               }}
             >
-              {t({ en: 'Add anyway', fr: 'Ajouter quand même' })}
+              {t({ en: 'Add anyway', es: 'Agregar de todos modos', fr: 'Ajouter quand même' })}
             </Button>
           </Dialog.Footer>
         </Dialog.Content>

--- a/apps/web/src/components/GroupSwitcher/GroupSwitcher.tsx
+++ b/apps/web/src/components/GroupSwitcher/GroupSwitcher.tsx
@@ -38,7 +38,9 @@ export const GroupSwitcher = ({ className }: { className?: string }) => {
   }
 
   const label = (
-    <span className="text-[10px] font-medium tracking-tight text-sky-400">{t({ en: 'Group', fr: 'Groupe' })}</span>
+    <span className="text-[10px] font-medium tracking-tight text-sky-400">
+      {t({ en: 'Group', es: 'Grupo', fr: 'Groupe' })}
+    </span>
   );
 
   // A user in exactly one group has nothing to switch between, so show the group as static text styled

--- a/apps/web/src/components/InstrumentCard/InstrumentCard.tsx
+++ b/apps/web/src/components/InstrumentCard/InstrumentCard.tsx
@@ -30,6 +30,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'text',
       label: t({
         en: 'Authors',
+        es: 'Autores',
         fr: 'Auteurs'
       }),
       text: instrument.details.authors?.join(', ')
@@ -38,6 +39,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'text',
       label: t({
         en: 'Description',
+        es: 'Descripción',
         fr: 'Description'
       }),
       text: instrument.details.description
@@ -46,6 +48,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'text',
       label: t({
         en: 'Edition',
+        es: 'Edición',
         fr: 'Édition'
       }),
       text: instrument.kind === 'SERIES' ? undefined : instrument.internal.edition.toString()
@@ -54,6 +57,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'text',
       label: t({
         en: 'Languages',
+        es: 'Idiomas',
         fr: 'Langues'
       }),
       text: instrument.supportedLanguages
@@ -71,6 +75,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'text',
       label: t({
         en: 'License',
+        es: 'Licencia',
         fr: 'Licence'
       }),
       text: license?.name ?? 'NA',
@@ -88,10 +93,12 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
               {license?.isOpenSource
                 ? t({
                     en: 'This is a free and open-source license',
+                    es: 'Esta es una licencia libre y de código abierto',
                     fr: "Il s'agit d'une licence libre"
                   })
                 : t({
                     en: 'This is not a free and open source license',
+                    es: 'Esta no es una licencia libre y de código abierto',
                     fr: "Il ne s'agit pas d'une licence libre"
                   })}
             </p>
@@ -104,6 +111,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'link',
       label: t({
         en: 'Reference Link',
+        es: 'Enlace de referencia',
         fr: 'Lien vers la référence'
       })
     },
@@ -112,6 +120,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
       kind: 'link',
       label: t({
         en: 'Source Link',
+        es: 'Enlace al código fuente',
         fr: 'Lien vers le code source'
       })
     },
@@ -148,7 +157,7 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
             return (
               <div className="flex items-center gap-1" key={item.label}>
                 <p className="line-clamp-3 leading-tight">
-                  <span className="font-medium">{item.label + t({ en: ': ', fr: ' : ' })}</span>
+                  <span className="font-medium">{item.label + t({ en: ': ', es: ': ', fr: ' : ' })}</span>
                   {item.kind === 'text' && <span className="text-muted-foreground">{item.text}</span>}
                   {item.kind === 'link' && (
                     <a

--- a/apps/web/src/components/InstrumentShowcase/InstrumentKindDropdown.tsx
+++ b/apps/web/src/components/InstrumentShowcase/InstrumentKindDropdown.tsx
@@ -23,6 +23,7 @@ export const InstrumentKindDropdown: React.FC<{
             key: 'FORM',
             label: t({
               en: 'Form',
+              es: 'Formulario',
               fr: 'Formulaire'
             })
           },
@@ -30,6 +31,7 @@ export const InstrumentKindDropdown: React.FC<{
             key: 'INTERACTIVE',
             label: t({
               en: 'Interactive',
+              es: 'Interactivo',
               fr: 'Interactif'
             })
           },
@@ -43,6 +45,7 @@ export const InstrumentKindDropdown: React.FC<{
       setSelected={setSelected}
       title={t({
         en: 'Kind',
+        es: 'Tipo',
         fr: 'Type'
       })}
     />

--- a/apps/web/src/components/LoginBranding/LoginBrandingPanel.tsx
+++ b/apps/web/src/components/LoginBranding/LoginBrandingPanel.tsx
@@ -222,7 +222,8 @@ export const LoginBrandingPanel = ({
   preview = false
 }: LoginBrandingPanelProps) => {
   const { resolvedLanguage } = useTranslation();
-  const lang = langOverride ?? resolvedLanguage;
+  const lang: 'en' | 'fr' =
+    langOverride ?? (resolvedLanguage === 'en' || resolvedLanguage === 'fr' ? resolvedLanguage : 'en');
 
   const tl = (obj: { en: string; fr: string }): string => obj[lang];
 

--- a/apps/web/src/components/LoginPageEditor/LoginPageEditor.tsx
+++ b/apps/web/src/components/LoginPageEditor/LoginPageEditor.tsx
@@ -40,7 +40,11 @@ export const LoginPageEditor = () => {
       <div className="w-full overflow-x-clip">
         <PageHeader>
           <Heading className="text-center" variant="h2">
-            {t({ en: 'Customize Login Page', fr: 'Personnaliser la page de connexion' })}
+            {t({
+              en: 'Customize Login Page',
+              es: 'Personalizar página de inicio de sesión',
+              fr: 'Personnaliser la page de connexion'
+            })}
           </Heading>
         </PageHeader>
 

--- a/apps/web/src/components/LoginPageEditor/UnsavedChangesDialog.tsx
+++ b/apps/web/src/components/LoginPageEditor/UnsavedChangesDialog.tsx
@@ -12,20 +12,23 @@ export const UnsavedChangesDialog = ({ blocker }: { blocker: BrandingEditor['blo
   return (
     <Dialog open={blocker.status === 'blocked'} onOpenChange={() => blocker.reset?.()}>
       <Dialog.Content>
-        <Dialog.Title>{t({ en: 'Unsaved Changes', fr: 'Modifications non enregistrées' })}</Dialog.Title>
+        <Dialog.Title>
+          {t({ en: 'Unsaved Changes', es: 'Cambios sin guardar', fr: 'Modifications non enregistrées' })}
+        </Dialog.Title>
         <Dialog.Description>
           {t({
             en: 'You have unsaved changes. Are you sure you want to leave? Your changes will be lost. Select "No" and click the X in the top-right corner to keep your changes.',
+            es: 'Tiene cambios sin guardar. ¿Está seguro de que desea salir? Sus cambios se perderán. Seleccione "No" y haga clic en la X en la esquina superior derecha para conservar sus cambios.',
             fr: 'Vous avez des modifications non enregistrées. Voulez-vous vraiment quitter ? Vos modifications seront perdues. Sélectionnez « Non » et cliquez sur le X en haut à droite pour conserver vos modifications.'
           })}
         </Dialog.Description>
         <div className="mt-4 flex justify-end gap-3">
           <Button type="button" variant="outline" onClick={() => blocker.proceed?.()}>
-            {t({ en: 'Yes', fr: 'Oui' })}
+            {t({ en: 'Yes', es: 'Sí', fr: 'Oui' })}
           </Button>
           {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Button autoFocus type="button" onClick={() => blocker.reset?.()}>
-            {t({ en: 'No', fr: 'Non' })}
+            {t({ en: 'No', es: 'No', fr: 'Non' })}
           </Button>
         </div>
       </Dialog.Content>

--- a/apps/web/src/components/LoginPageEditor/fields/BoldToggle.tsx
+++ b/apps/web/src/components/LoginPageEditor/fields/BoldToggle.tsx
@@ -14,7 +14,7 @@ export const BoldToggle = ({ checked, id, onChange }: BoldToggleProps) => {
     <div className="flex items-center gap-2">
       <Checkbox checked={checked} id={id} onCheckedChange={(c) => onChange(c === true)} />
       <Label className="cursor-pointer text-sm font-normal" htmlFor={id}>
-        {t({ en: 'Bold', fr: 'Gras' })}
+        {t({ en: 'Bold', es: 'Negrita', fr: 'Gras' })}
       </Label>
     </div>
   );

--- a/apps/web/src/components/LoginPageEditor/fields/ColorField.tsx
+++ b/apps/web/src/components/LoginPageEditor/fields/ColorField.tsx
@@ -44,7 +44,11 @@ export const ColorField = ({
       </div>
       {isInvalid && (
         <p className="text-destructive text-xs">
-          {t({ en: 'Enter a valid hex color.', fr: 'Entrez une couleur hexadécimale valide.' })}
+          {t({
+            en: 'Enter a valid hex color.',
+            es: 'Ingrese un color hexadecimal válido.',
+            fr: 'Entrez une couleur hexadécimale valide.'
+          })}
         </p>
       )}
     </div>

--- a/apps/web/src/components/LoginPageEditor/fields/FontSizeField.tsx
+++ b/apps/web/src/components/LoginPageEditor/fields/FontSizeField.tsx
@@ -15,7 +15,7 @@ export const FontSizeField = ({ id, onChange, value }: FontSizeFieldProps) => {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-2">
-      <Label htmlFor={id}>{t({ en: 'Font size', fr: 'Taille de police' })}</Label>
+      <Label htmlFor={id}>{t({ en: 'Font size', es: 'Tamaño de fuente', fr: 'Taille de police' })}</Label>
       <Select
         value={value === null ? FONT_SIZE_DEFAULT : String(value)}
         onValueChange={(v) => onChange(v === FONT_SIZE_DEFAULT ? null : Number(v))}
@@ -25,7 +25,9 @@ export const FontSizeField = ({ id, onChange, value }: FontSizeFieldProps) => {
         </Select.Trigger>
         <Select.Content>
           <Select.Group>
-            <Select.Item value={FONT_SIZE_DEFAULT}>{t({ en: 'Default', fr: 'Par défaut' })}</Select.Item>
+            <Select.Item value={FONT_SIZE_DEFAULT}>
+              {t({ en: 'Default', es: 'Predeterminado', fr: 'Par défaut' })}
+            </Select.Item>
             {FONT_SIZES.map((s) => (
               <Select.Item key={s} value={String(s)}>{`${s} px`}</Select.Item>
             ))}

--- a/apps/web/src/components/LoginPageEditor/fields/SectionHeader.tsx
+++ b/apps/web/src/components/LoginPageEditor/fields/SectionHeader.tsx
@@ -30,7 +30,7 @@ const OrderButtons = ({ editor, section }: { editor: BrandingEditor; section: Pa
   return (
     <div className="flex shrink-0 gap-0.5">
       <Button
-        aria-label={t({ en: 'Move up', fr: 'Haut' })}
+        aria-label={t({ en: 'Move up', es: 'Subir', fr: 'Haut' })}
         disabled={idx <= 0}
         size="sm"
         type="button"
@@ -40,7 +40,7 @@ const OrderButtons = ({ editor, section }: { editor: BrandingEditor; section: Pa
         <ChevronUpIcon className="h-4 w-4" />
       </Button>
       <Button
-        aria-label={t({ en: 'Move down', fr: 'Bas' })}
+        aria-label={t({ en: 'Move down', es: 'Bajar', fr: 'Bas' })}
         disabled={idx >= form.sectionsOrder.length - 1}
         size="sm"
         type="button"
@@ -69,7 +69,7 @@ export const SectionHeader = ({ bold, description, editor, section, show, title 
               <div className="flex items-center gap-2">
                 <Checkbox checked={show.checked} id={show.id} onCheckedChange={(c) => show.onChange(c === true)} />
                 <Label className="cursor-pointer text-sm font-normal" htmlFor={show.id}>
-                  {t({ en: 'Show', fr: 'Afficher' })}
+                  {t({ en: 'Show', es: 'Mostrar', fr: 'Afficher' })}
                 </Label>
               </div>
             )}

--- a/apps/web/src/components/LoginPageEditor/hooks.ts
+++ b/apps/web/src/components/LoginPageEditor/hooks.ts
@@ -99,8 +99,12 @@ export const useBrandingForm = () => {
 
   const updateSetupStateMutation = useUpdateSetupStateMutation({
     successNotification: {
-      message: t({ en: 'The login page has been updated.', fr: 'La page de connexion a été mise à jour.' }),
-      title: t({ en: 'Success', fr: 'Succès' })
+      message: t({
+        en: 'The login page has been updated.',
+        es: 'La página de inicio de sesión ha sido actualizada.',
+        fr: 'La page de connexion a été mise à jour.'
+      }),
+      title: t({ en: 'Success', es: 'Éxito', fr: 'Succès' })
     }
   });
 
@@ -191,9 +195,14 @@ export const useBrandingForm = () => {
       addNotification({
         message: t({
           en: 'The selected file must be an SVG, PNG, JPEG, or WebP image.',
+          es: 'El archivo seleccionado debe ser una imagen SVG, PNG, JPEG o WebP.',
           fr: 'Le fichier sélectionné doit être une image SVG, PNG, JPEG ou WebP.'
         }),
-        title: t({ en: 'Unsupported file type', fr: 'Type de fichier non pris en charge' }),
+        title: t({
+          en: 'Unsupported file type',
+          es: 'Tipo de archivo no compatible',
+          fr: 'Type de fichier non pris en charge'
+        }),
         type: 'error'
       });
       return;
@@ -201,8 +210,12 @@ export const useBrandingForm = () => {
       // Checked against the file as picked; the stored copy is usually far
       // smaller, since a raster upload is re-encoded to WebP below.
       addNotification({
-        message: t({ en: 'The selected image is larger than 2 MB.', fr: "L'image sélectionnée dépasse 2 Mo." }),
-        title: t({ en: 'File too large', fr: 'Fichier trop volumineux' }),
+        message: t({
+          en: 'The selected image is larger than 2 MB.',
+          es: 'La imagen seleccionada supera los 2 MB.',
+          fr: "L'image sélectionnée dépasse 2 Mo."
+        }),
+        title: t({ en: 'File too large', es: 'Archivo demasiado grande', fr: 'Fichier trop volumineux' }),
         type: 'error'
       });
       return;
@@ -214,9 +227,10 @@ export const useBrandingForm = () => {
         addNotification({
           message: t({
             en: 'The selected file could not be read as an image.',
+            es: 'El archivo seleccionado no se pudo leer como una imagen.',
             fr: "Le fichier sélectionné n'a pas pu être lu comme une image."
           }),
-          title: t({ en: 'Invalid image', fr: 'Image invalide' }),
+          title: t({ en: 'Invalid image', es: 'Imagen no válida', fr: 'Image invalide' }),
           type: 'error'
         });
       });

--- a/apps/web/src/components/LoginPageEditor/preview/FullscreenPreviewDialog.tsx
+++ b/apps/web/src/components/LoginPageEditor/preview/FullscreenPreviewDialog.tsx
@@ -32,11 +32,16 @@ export const FullscreenPreviewDialog = ({ editor, onOpenChange, open, previewLan
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <Dialog.Title className="sr-only">
-          {t({ en: 'Login page fullscreen preview', fr: 'Aperçu plein écran de la page de connexion' })}
+          {t({
+            en: 'Login page fullscreen preview',
+            es: 'Vista previa a pantalla completa de la página de inicio de sesión',
+            fr: 'Aperçu plein écran de la page de connexion'
+          })}
         </Dialog.Title>
         <Dialog.Description className="sr-only">
           {t({
             en: 'A full-screen preview of how the login page will appear to users with the current branding settings.',
+            es: 'Una vista previa a pantalla completa de cómo aparecerá la página de inicio de sesión para los usuarios con la configuración de personalización actual.',
             fr: 'Un aperçu plein écran de la page de connexion telle que les utilisateurs la verront avec les paramètres de personnalisation actuels.'
           })}
         </Dialog.Description>

--- a/apps/web/src/components/LoginPageEditor/preview/PreviewColumn.tsx
+++ b/apps/web/src/components/LoginPageEditor/preview/PreviewColumn.tsx
@@ -30,7 +30,9 @@ export const PreviewColumn = ({ editor, onOpenFullscreen, onPreviewLangChange, p
     <div className="lg:sticky lg:top-6 lg:self-start">
       {/* Preview header */}
       <div className="mb-2 flex items-center justify-between">
-        <Label className="text-muted-foreground">{t({ en: 'Live Preview', fr: 'Aperçu en direct' })}</Label>
+        <Label className="text-muted-foreground">
+          {t({ en: 'Live Preview', es: 'Vista previa en vivo', fr: 'Aperçu en direct' })}
+        </Label>
         <div className="flex items-center gap-1">
           {/* Language toggle — drives `previewLang` state; no content panes needed */}
           <Tabs value={previewLang} onValueChange={(v) => onPreviewLangChange(v as 'en' | 'fr')}>
@@ -44,7 +46,11 @@ export const PreviewColumn = ({ editor, onOpenFullscreen, onPreviewLangChange, p
             </Tabs.List>
           </Tabs>
           <Button
-            aria-label={t({ en: 'Fullscreen preview', fr: 'Aperçu plein écran' })}
+            aria-label={t({
+              en: 'Fullscreen preview',
+              es: 'Vista previa a pantalla completa',
+              fr: 'Aperçu plein écran'
+            })}
             size="sm"
             type="button"
             variant="ghost"

--- a/apps/web/src/components/LoginPageEditor/sections/EnableBrandingCard.tsx
+++ b/apps/web/src/components/LoginPageEditor/sections/EnableBrandingCard.tsx
@@ -11,11 +11,16 @@ export const EnableBrandingCard = ({ editor }: { editor: BrandingEditor }) => {
     <Card>
       <Card.Header>
         <Card.Title>
-          {t({ en: 'Enable Custom Login Page', fr: 'Activer la page de connexion personnalisée' })}
+          {t({
+            en: 'Enable Custom Login Page',
+            es: 'Activar página de inicio de sesión personalizada',
+            fr: 'Activer la page de connexion personnalisée'
+          })}
         </Card.Title>
         <Card.Description>
           {t({
             en: 'When disabled, the classic Open Data Capture login page is shown instead.',
+            es: 'Cuando está desactivado, se muestra la página de inicio de sesión clásica de Open Data Capture.',
             fr: "Lorsque désactivé, la page de connexion classique d'Open Data Capture est affichée."
           })}
         </Card.Description>
@@ -28,7 +33,7 @@ export const EnableBrandingCard = ({ editor }: { editor: BrandingEditor }) => {
             onCheckedChange={(checked) => update('enableBranding', checked === true)}
           />
           <Label className="cursor-pointer" htmlFor="enableBranding">
-            {t({ en: 'Enable', fr: 'Activer' })}
+            {t({ en: 'Enable', es: 'Activar', fr: 'Activer' })}
           </Label>
         </div>
       </Card.Content>

--- a/apps/web/src/components/LoginPageEditor/sections/FooterCard.tsx
+++ b/apps/web/src/components/LoginPageEditor/sections/FooterCard.tsx
@@ -10,7 +10,7 @@ export const FooterCard = ({ editor }: { editor: BrandingEditor }) => {
   return (
     <Card>
       <Card.Header>
-        <Card.Title>{t({ en: 'Footer', fr: 'Pied de page' })}</Card.Title>
+        <Card.Title>{t({ en: 'Footer', es: 'Pie de página', fr: 'Pied de page' })}</Card.Title>
       </Card.Header>
       <Card.Content>
         <div className="flex items-center gap-3">
@@ -20,7 +20,11 @@ export const FooterCard = ({ editor }: { editor: BrandingEditor }) => {
             onCheckedChange={(checked) => update('showFooterLinks', checked === true)}
           />
           <Label className="cursor-pointer" htmlFor="showFooterLinks">
-            {t({ en: 'Show GitHub and documentation links', fr: 'Afficher les liens GitHub et documentation' })}
+            {t({
+              en: 'Show GitHub and documentation links',
+              es: 'Mostrar enlaces de GitHub y documentación',
+              fr: 'Afficher les liens GitHub et documentation'
+            })}
           </Label>
         </div>
       </Card.Content>

--- a/apps/web/src/components/LoginPageEditor/sections/LeftPanelThemeCard.tsx
+++ b/apps/web/src/components/LoginPageEditor/sections/LeftPanelThemeCard.tsx
@@ -19,11 +19,16 @@ export const LeftPanelThemeCard = ({ editor }: { editor: BrandingEditor }) => {
     <Card>
       <Card.Header>
         <Card.Title>
-          {t({ en: 'Background Theme - Left Panel', fr: "Thème d'arrière-plan - Panneau gauche" })}
+          {t({
+            en: 'Background Theme - Left Panel',
+            es: 'Tema de fondo - Panel izquierdo',
+            fr: "Thème d'arrière-plan - Panneau gauche"
+          })}
         </Card.Title>
         <Card.Description>
           {t({
             en: 'The gradient shown behind the branding panel.',
+            es: 'El degradado que se muestra detrás del panel de marca.',
             fr: 'Le dégradé affiché derrière le panneau.'
           })}
         </Card.Description>
@@ -54,14 +59,14 @@ export const LeftPanelThemeCard = ({ editor }: { editor: BrandingEditor }) => {
           <div className="grid gap-4 sm:grid-cols-2">
             <ColorField
               id="customPrimaryColor"
-              label={t({ en: 'Gradient Start', fr: 'Début du dégradé' })}
+              label={t({ en: 'Gradient Start', es: 'Inicio del degradado', fr: 'Début du dégradé' })}
               swatchFallback="#000000"
               value={form.customPrimaryColor}
               onChange={(v) => update('customPrimaryColor', v)}
             />
             <ColorField
               id="customSecondaryColor"
-              label={t({ en: 'Gradient End', fr: 'Fin du dégradé' })}
+              label={t({ en: 'Gradient End', es: 'Fin del degradado', fr: 'Fin du dégradé' })}
               swatchFallback="#000000"
               value={form.customSecondaryColor}
               onChange={(v) => update('customSecondaryColor', v)}

--- a/apps/web/src/components/LoginPageEditor/sections/RightPanelThemeCard.tsx
+++ b/apps/web/src/components/LoginPageEditor/sections/RightPanelThemeCard.tsx
@@ -17,11 +17,16 @@ export const RightPanelThemeCard = ({ editor }: { editor: BrandingEditor }) => {
     <Card>
       <Card.Header>
         <Card.Title>
-          {t({ en: 'Background Theme - Right Panel', fr: "Thème d'arrière-plan - Panneau droit" })}
+          {t({
+            en: 'Background Theme - Right Panel',
+            es: 'Tema de fondo - Panel derecho',
+            fr: "Thème d'arrière-plan - Panneau droit"
+          })}
         </Card.Title>
         <Card.Description>
           {t({
             en: 'The gradient applied behind the login form.',
+            es: 'El degradado aplicado detrás del formulario de inicio de sesión.',
             fr: 'Le dégradé appliqué derrière le formulaire de connexion.'
           })}
         </Card.Description>
@@ -58,14 +63,14 @@ export const RightPanelThemeCard = ({ editor }: { editor: BrandingEditor }) => {
           <div className="grid gap-4 sm:grid-cols-2">
             <ColorField
               id="rightPanelPrimaryColor"
-              label={t({ en: 'Gradient Start', fr: 'Début du dégradé' })}
+              label={t({ en: 'Gradient Start', es: 'Inicio del degradado', fr: 'Début du dégradé' })}
               swatchFallback="#ffffff"
               value={form.rightPanelPrimaryColor}
               onChange={(v) => update('rightPanelPrimaryColor', v)}
             />
             <ColorField
               id="rightPanelSecondaryColor"
-              label={t({ en: 'Gradient End', fr: 'Fin du dégradé' })}
+              label={t({ en: 'Gradient End', es: 'Fin del degradado', fr: 'Fin du dégradé' })}
               swatchFallback="#ffffff"
               value={form.rightPanelSecondaryColor}
               onChange={(v) => update('rightPanelSecondaryColor', v)}

--- a/apps/web/src/components/LoginPageEditor/sections/SectionCards.tsx
+++ b/apps/web/src/components/LoginPageEditor/sections/SectionCards.tsx
@@ -43,6 +43,7 @@ const DetailsCard = ({ editor }: CardProps) => {
         bold={{ checked: form.boldDetails, id: 'boldDetails', onChange: (b) => update('boldDetails', b) }}
         description={t({
           en: 'Additional notes shown on the branding panel',
+          es: 'Notas adicionales que se muestran en el panel de marca',
           fr: 'Remarques supplémentaires figurant sur le panneau de marque.'
         })}
         editor={editor}
@@ -54,7 +55,7 @@ const DetailsCard = ({ editor }: CardProps) => {
         <Card.Content className="flex flex-col gap-4">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col gap-2">
-              <Label htmlFor="instanceDetails-en">{t({ en: 'English', fr: 'Anglais' })}</Label>
+              <Label htmlFor="instanceDetails-en">{t({ en: 'English', es: 'Inglés', fr: 'Anglais' })}</Label>
               <TextArea
                 id="instanceDetails-en"
                 maxLength={300}
@@ -64,7 +65,7 @@ const DetailsCard = ({ editor }: CardProps) => {
               />
             </div>
             <div className="flex flex-col gap-2">
-              <Label htmlFor="instanceDetails-fr">{t({ en: 'French', fr: 'Français' })}</Label>
+              <Label htmlFor="instanceDetails-fr">{t({ en: 'French', es: 'Francés', fr: 'Français' })}</Label>
               <TextArea
                 id="instanceDetails-fr"
                 maxLength={300}
@@ -93,6 +94,7 @@ const LogoCard = ({ editor }: CardProps) => {
       <SectionHeader
         description={t({
           en: 'Upload an image up to 2 MB (SVG, PNG, JPEG, WebP) or link to one. PNG and JPEG uploads are converted to WebP to save space.',
+          es: 'Cargue una imagen de hasta 2 MB (SVG, PNG, JPEG, WebP) o enlace a una. Las cargas PNG y JPEG se convierten a WebP para ahorrar espacio.',
           fr: "Téléversez une image jusqu'à 2 Mo (SVG, PNG, JPEG, WebP) ou indiquez un lien. Les téléversements PNG et JPEG sont convertis en WebP pour économiser de l'espace."
         })}
         editor={editor}
@@ -117,7 +119,7 @@ const LogoCard = ({ editor }: CardProps) => {
               <div className="flex items-center gap-2">
                 <RadioGroup.Item id="logoSource-upload" value="upload" />
                 <Label className="cursor-pointer font-medium" htmlFor="logoSource-upload">
-                  {t({ en: 'Uploaded image', fr: 'Image téléversée' })}
+                  {t({ en: 'Uploaded image', es: 'Imagen cargada', fr: 'Image téléversée' })}
                 </Label>
               </div>
               <div className="pl-6">
@@ -147,14 +149,14 @@ const LogoCard = ({ editor }: CardProps) => {
                           style={CHECKERBOARD_STYLE}
                         />
                         <span className="text-muted-foreground text-xs">
-                          {t({ en: 'Click to replace', fr: 'Cliquez pour remplacer' })}
+                          {t({ en: 'Click to replace', es: 'Haga clic para reemplazar', fr: 'Cliquez pour remplacer' })}
                         </span>
                       </React.Fragment>
                     ) : (
                       <React.Fragment>
                         <UploadIcon className="text-muted-foreground h-5 w-5" />
                         <span className="text-muted-foreground text-xs">
-                          {t({ en: 'Click to upload', fr: 'Cliquez pour téléverser' })}
+                          {t({ en: 'Click to upload', es: 'Haga clic para cargar', fr: 'Cliquez pour téléverser' })}
                         </span>
                       </React.Fragment>
                     )}
@@ -162,7 +164,7 @@ const LogoCard = ({ editor }: CardProps) => {
                   {/* Clears only the uploaded image; the saved URL is left intact. */}
                   {form.customLogoSrc && (
                     <Button
-                      aria-label={t({ en: 'Remove', fr: 'Retirer' })}
+                      aria-label={t({ en: 'Remove', es: 'Eliminar', fr: 'Retirer' })}
                       className="bg-background/80 hover:bg-background absolute right-1.5 top-1.5 h-7 w-7 rounded-full border p-0 shadow-sm backdrop-blur-sm"
                       size="sm"
                       type="button"
@@ -181,12 +183,12 @@ const LogoCard = ({ editor }: CardProps) => {
               <div className="flex items-center gap-2">
                 <RadioGroup.Item id="logoSource-url" value="url" />
                 <Label className="cursor-pointer font-medium" htmlFor="logoSource-url">
-                  {t({ en: 'Image URL', fr: "URL de l'image" })}
+                  {t({ en: 'Image URL', es: 'URL de la imagen', fr: "URL de l'image" })}
                 </Label>
               </div>
               <div className="pl-6">
                 <Input
-                  aria-label={t({ en: 'Image URL', fr: "URL de l'image" })}
+                  aria-label={t({ en: 'Image URL', es: 'URL de la imagen', fr: "URL de l'image" })}
                   maxLength={2000}
                   placeholder="https://example.org/logo.png"
                   value={form.customLogoUrl}
@@ -197,7 +199,7 @@ const LogoCard = ({ editor }: CardProps) => {
           </RadioGroup>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col gap-2">
-              <Label htmlFor="logoSize">{t({ en: 'Size', fr: 'Taille' })}</Label>
+              <Label htmlFor="logoSize">{t({ en: 'Size', es: 'Tamaño', fr: 'Taille' })}</Label>
               <Select value={form.logoSize} onValueChange={(v) => update('logoSize', v as LogoSize)}>
                 <Select.Trigger id="logoSize">
                   <Select.Value />
@@ -214,7 +216,7 @@ const LogoCard = ({ editor }: CardProps) => {
               </Select>
             </div>
             <div className="flex flex-col gap-2">
-              <Label htmlFor="logoAlignment">{t({ en: 'Alignment', fr: 'Alignement' })}</Label>
+              <Label htmlFor="logoAlignment">{t({ en: 'Alignment', es: 'Alineación', fr: 'Alignement' })}</Label>
               <Select value={form.logoAlignment} onValueChange={(v) => update('logoAlignment', v as LogoAlignment)}>
                 <Select.Trigger id="logoAlignment">
                   <Select.Value />
@@ -233,20 +235,26 @@ const LogoCard = ({ editor }: CardProps) => {
           </div>
           {form.logoSize === 'custom' && (
             <div className="flex flex-col gap-2">
-              <Label>{t({ en: 'Custom dimensions (pixels)', fr: 'Dimensions personnalisées (pixels)' })}</Label>
+              <Label>
+                {t({
+                  en: 'Custom dimensions (pixels)',
+                  es: 'Dimensiones personalizadas (píxeles)',
+                  fr: 'Dimensions personnalisées (pixels)'
+                })}
+              </Label>
               <div className="flex items-center gap-2">
                 <Input
-                  aria-label={t({ en: 'Width', fr: 'Largeur' })}
+                  aria-label={t({ en: 'Width', es: 'Ancho', fr: 'Largeur' })}
                   inputMode="numeric"
-                  placeholder={t({ en: 'Width', fr: 'Largeur' })}
+                  placeholder={t({ en: 'Width', es: 'Ancho', fr: 'Largeur' })}
                   value={form.customLogoWidth}
                   onChange={(e) => update('customLogoWidth', e.target.value.replace(/[^0-9]/g, ''))}
                 />
                 <span className="text-muted-foreground text-sm">×</span>
                 <Input
-                  aria-label={t({ en: 'Height', fr: 'Hauteur' })}
+                  aria-label={t({ en: 'Height', es: 'Alto', fr: 'Hauteur' })}
                   inputMode="numeric"
-                  placeholder={t({ en: 'Height', fr: 'Hauteur' })}
+                  placeholder={t({ en: 'Height', es: 'Alto', fr: 'Hauteur' })}
                   value={form.customLogoHeight}
                   onChange={(e) => update('customLogoHeight', e.target.value.replace(/[^0-9]/g, ''))}
                 />
@@ -255,6 +263,7 @@ const LogoCard = ({ editor }: CardProps) => {
                 <p className="text-destructive text-xs">
                   {t({
                     en: 'Enter at least one positive value (1–5000).',
+                    es: 'Ingrese al menos un valor positivo (1–5000).',
                     fr: 'Entrez au moins une valeur positive (1–5000).'
                   })}
                 </p>
@@ -276,6 +285,7 @@ const NameCard = ({ editor }: CardProps) => {
         bold={{ checked: form.boldName, id: 'boldName', onChange: (b) => update('boldName', b) }}
         description={t({
           en: 'The primary name shown on the login page.',
+          es: 'El nombre principal que se muestra en la página de inicio de sesión.',
           fr: 'Le nom principal affiché sur la page de connexion.'
         })}
         editor={editor}
@@ -285,7 +295,7 @@ const NameCard = ({ editor }: CardProps) => {
       <Card.Content className="flex flex-col gap-4">
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="instanceName-en">{t({ en: 'English', fr: 'Anglais' })}</Label>
+            <Label htmlFor="instanceName-en">{t({ en: 'English', es: 'Inglés', fr: 'Anglais' })}</Label>
             <Input
               id="instanceName-en"
               maxLength={60}
@@ -295,7 +305,7 @@ const NameCard = ({ editor }: CardProps) => {
             />
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="instanceName-fr">{t({ en: 'French', fr: 'Français' })}</Label>
+            <Label htmlFor="instanceName-fr">{t({ en: 'French', es: 'Francés', fr: 'Français' })}</Label>
             <Input
               id="instanceName-fr"
               maxLength={60}
@@ -307,7 +317,7 @@ const NameCard = ({ editor }: CardProps) => {
         </div>
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="nameAlignment">{t({ en: 'Alignment', fr: 'Alignement' })}</Label>
+            <Label htmlFor="nameAlignment">{t({ en: 'Alignment', es: 'Alineación', fr: 'Alignement' })}</Label>
             <Select value={form.nameAlignment} onValueChange={(v) => update('nameAlignment', v as LogoAlignment)}>
               <Select.Trigger id="nameAlignment">
                 <Select.Value />
@@ -341,7 +351,11 @@ const ResourcesCard = ({ editor }: CardProps) => {
           id: 'boldResourceLinks',
           onChange: (b) => update('boldResourceLinks', b)
         }}
-        description={t({ en: 'Optional links shown on the branding panel.', fr: 'Liens optionnels sur le panneau.' })}
+        description={t({
+          en: 'Optional links shown on the branding panel.',
+          es: 'Enlaces opcionales que se muestran en el panel de marca.',
+          fr: 'Liens optionnels sur le panneau.'
+        })}
         editor={editor}
         section="resources"
         show={{
@@ -355,7 +369,11 @@ const ResourcesCard = ({ editor }: CardProps) => {
         <Card.Content className="flex flex-col gap-3">
           {form.resourceLinks.length === 0 && (
             <p className="text-muted-foreground text-sm">
-              {t({ en: 'No links yet. Add one to get started.', fr: "Aucun lien pour l'instant." })}
+              {t({
+                en: 'No links yet. Add one to get started.',
+                es: 'Aún no hay enlaces. Agregue uno para comenzar.',
+                fr: "Aucun lien pour l'instant."
+              })}
             </p>
           )}
           {form.resourceLinks.map((link, index) => {
@@ -364,10 +382,10 @@ const ResourcesCard = ({ editor }: CardProps) => {
               <div className="flex flex-col gap-2 rounded-md border p-3" key={index}>
                 <div className="flex items-start justify-between gap-2">
                   <Label className="text-sm font-medium">
-                    {t({ en: `Link ${index + 1}`, fr: `Lien ${index + 1}` })}
+                    {t({ en: `Link ${index + 1}`, es: `Enlace ${index + 1}`, fr: `Lien ${index + 1}` })}
                   </Label>
                   <Button
-                    aria-label={t({ en: 'Remove', fr: 'Retirer' })}
+                    aria-label={t({ en: 'Remove', es: 'Eliminar', fr: 'Retirer' })}
                     size="sm"
                     type="button"
                     variant="ghost"
@@ -378,16 +396,16 @@ const ResourcesCard = ({ editor }: CardProps) => {
                 </div>
                 <div className="grid gap-2 sm:grid-cols-2">
                   <Input
-                    aria-label={t({ en: 'Label (English)', fr: 'Libellé (anglais)' })}
+                    aria-label={t({ en: 'Label (English)', es: 'Etiqueta (inglés)', fr: 'Libellé (anglais)' })}
                     maxLength={120}
-                    placeholder={t({ en: 'Label (English)', fr: 'Libellé (anglais)' })}
+                    placeholder={t({ en: 'Label (English)', es: 'Etiqueta (inglés)', fr: 'Libellé (anglais)' })}
                     value={link.label.en}
                     onChange={(e) => updateResourceLinkLabel(index, 'en', e.target.value)}
                   />
                   <Input
-                    aria-label={t({ en: 'Label (French)', fr: 'Libellé (français)' })}
+                    aria-label={t({ en: 'Label (French)', es: 'Etiqueta (francés)', fr: 'Libellé (français)' })}
                     maxLength={120}
-                    placeholder={t({ en: 'Label (French)', fr: 'Libellé (français)' })}
+                    placeholder={t({ en: 'Label (French)', es: 'Etiqueta (francés)', fr: 'Libellé (français)' })}
                     value={link.label.fr}
                     onChange={(e) => updateResourceLinkLabel(index, 'fr', e.target.value)}
                   />
@@ -404,6 +422,7 @@ const ResourcesCard = ({ editor }: CardProps) => {
                   <p className="text-destructive text-xs">
                     {t({
                       en: 'URL must start with http:// or https:// and include a domain (e.g. example.com).',
+                      es: 'La URL debe comenzar con http:// o https:// e incluir un dominio (ej. example.com).',
                       fr: "L'URL doit commencer par http:// ou https:// et inclure un domaine (ex. example.com)."
                     })}
                   </p>
@@ -413,7 +432,7 @@ const ResourcesCard = ({ editor }: CardProps) => {
           })}
           <Button className="self-start" size="sm" type="button" variant="outline" onClick={addResourceLink}>
             <PlusIcon className="mr-1.5 h-4 w-4" />
-            {t({ en: 'Add link', fr: 'Ajouter un lien' })}
+            {t({ en: 'Add link', es: 'Agregar enlace', fr: 'Ajouter un lien' })}
           </Button>
           <FontSizeField
             id="resourceLinksFontSize"
@@ -435,6 +454,7 @@ const TaglineCard = ({ editor }: CardProps) => {
         bold={{ checked: form.boldTagline, id: 'boldTagline', onChange: (b) => update('boldTagline', b) }}
         description={t({
           en: 'A short description shown on the branding panel',
+          es: 'Una breve descripción que se muestra en el panel de marca',
           fr: 'Une courte description figurant sur le panneau de marque.'
         })}
         editor={editor}
@@ -446,7 +466,7 @@ const TaglineCard = ({ editor }: CardProps) => {
         <Card.Content className="flex flex-col gap-4">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col gap-2">
-              <Label htmlFor="instanceTagline-en">{t({ en: 'English', fr: 'Anglais' })}</Label>
+              <Label htmlFor="instanceTagline-en">{t({ en: 'English', es: 'Inglés', fr: 'Anglais' })}</Label>
               <TextArea
                 id="instanceTagline-en"
                 maxLength={300}
@@ -456,7 +476,7 @@ const TaglineCard = ({ editor }: CardProps) => {
               />
             </div>
             <div className="flex flex-col gap-2">
-              <Label htmlFor="instanceTagline-fr">{t({ en: 'French', fr: 'Français' })}</Label>
+              <Label htmlFor="instanceTagline-fr">{t({ en: 'French', es: 'Francés', fr: 'Français' })}</Label>
               <TextArea
                 id="instanceTagline-fr"
                 maxLength={300}

--- a/apps/web/src/components/LoginPageEditor/sections/TextColorCard.tsx
+++ b/apps/web/src/components/LoginPageEditor/sections/TextColorCard.tsx
@@ -17,10 +17,17 @@ export const TextColorCard = ({ editor }: { editor: BrandingEditor }) => {
   return (
     <Card>
       <Card.Header>
-        <Card.Title>{t({ en: 'Text Color - Left Panel', fr: 'Couleur du texte - Panneau gauche' })}</Card.Title>
+        <Card.Title>
+          {t({
+            en: 'Text Color - Left Panel',
+            es: 'Color del texto - Panel izquierdo',
+            fr: 'Couleur du texte - Panneau gauche'
+          })}
+        </Card.Title>
         <Card.Description>
           {t({
             en: 'The color applied to all text on the branding panel.',
+            es: 'El color aplicado a todo el texto del panel de marca.',
             fr: 'La couleur appliquée à tout le texte du panneau.'
           })}
         </Card.Description>
@@ -29,7 +36,7 @@ export const TextColorCard = ({ editor }: { editor: BrandingEditor }) => {
         <div className="sm:max-w-xs">
           <ColorField
             id="panelTextColor"
-            label={t({ en: 'Text color', fr: 'Couleur du texte' })}
+            label={t({ en: 'Text color', es: 'Color del texto', fr: 'Couleur du texte' })}
             placeholder={DEFAULT_PANEL_TEXT_COLOR}
             swatchFallback={DEFAULT_PANEL_TEXT_COLOR}
             value={form.panelTextColor}

--- a/apps/web/src/components/Navbar/Navbar.tsx
+++ b/apps/web/src/components/Navbar/Navbar.tsx
@@ -8,7 +8,9 @@ import { MenuIcon, StopCircle } from 'lucide-react';
 
 import { useIsDesktop } from '@/hooks/useIsDesktop';
 import { useNavItems } from '@/hooks/useNavItems';
+import { useSetupStateQuery } from '@/hooks/useSetupStateQuery';
 import { useAppStore } from '@/store';
+import { ALL_LANGUAGES } from '@/utils/languages';
 
 import { GroupSwitcher, useIsGroupSwitcherVisible } from '../GroupSwitcher';
 import { NavButton } from '../NavButton';
@@ -23,6 +25,12 @@ export const Navbar = () => {
   const { t } = useTranslation('layout');
   const navigate = useNavigate();
   const endSession = useAppStore((store) => store.endSession);
+  const setupStateQuery = useSetupStateQuery();
+
+  const activeLanguages = setupStateQuery.data.activeLanguages ?? ['en', 'fr'];
+  const languageOptions = Object.fromEntries(
+    Object.entries(ALL_LANGUAGES).filter(([key]) => activeLanguages.includes(key))
+  );
 
   // This is to prevent ugly styling when resizing the viewport
   const isDesktop = useIsDesktop();
@@ -124,13 +132,9 @@ export const Navbar = () => {
           <div className="flex w-full justify-between gap-2 md:justify-end">
             <UserDropup />
             <div className="flex gap-2">
-              <LanguageToggle
-                options={{
-                  en: 'English',
-                  fr: 'Français'
-                }}
-                variant="outline"
-              />
+              {Object.keys(languageOptions).length > 1 && (
+                <LanguageToggle options={languageOptions} variant="outline" />
+              )}
               <ThemeToggle variant="outline" />
             </div>
           </div>

--- a/apps/web/src/components/SaveStatus.tsx
+++ b/apps/web/src/components/SaveStatus.tsx
@@ -13,12 +13,14 @@ export const SaveStatus = ({ state }: { state: 'idle' | 'saved' | 'saving' }) =>
       {state === 'saving' ? (
         <React.Fragment>
           <Loader2Icon className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
-          <span className="text-muted-foreground">{t({ en: 'Saving…', fr: 'Enregistrement…' })}</span>
+          <span className="text-muted-foreground">{t({ en: 'Saving…', es: 'Guardando…', fr: 'Enregistrement…' })}</span>
         </React.Fragment>
       ) : (
         <React.Fragment>
           <CheckIcon className="h-3.5 w-3.5 text-green-600" />
-          <span>{t({ en: 'All changes saved', fr: 'Modifications enregistrées' })}</span>
+          <span>
+            {t({ en: 'All changes saved', es: 'Todos los cambios guardados', fr: 'Modifications enregistrées' })}
+          </span>
         </React.Fragment>
       )}
     </div>

--- a/apps/web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar/Sidebar.tsx
@@ -10,7 +10,9 @@ import { StopCircle } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 import { useNavItems } from '@/hooks/useNavItems';
+import { useSetupStateQuery } from '@/hooks/useSetupStateQuery';
 import { useAppStore } from '@/store';
+import { ALL_LANGUAGES } from '@/utils/languages';
 
 import { GroupSwitcher, useIsGroupSwitcherVisible } from '../GroupSwitcher';
 import { NavButton } from '../NavButton';
@@ -27,8 +29,14 @@ export const Sidebar = () => {
   const endSession = useAppStore((store) => store.endSession);
   const location = useLocation();
   const navigate = useNavigate();
+  const setupStateQuery = useSetupStateQuery();
 
   const { t } = useTranslation();
+
+  const activeLanguages = setupStateQuery.data.activeLanguages ?? ['en', 'fr'];
+  const languageOptions = Object.fromEntries(
+    Object.entries(ALL_LANGUAGES).filter(([key]) => activeLanguages.includes(key))
+  );
 
   return (
     <div
@@ -138,16 +146,15 @@ export const Sidebar = () => {
       <div className="flex items-center justify-between py-2">
         <UserDropup />
         <div className="flex h-full items-center gap-2">
-          <LanguageToggle
-            contentClassName="bg-slate-800 border-slate-700 text-slate-300"
-            itemClassName="bg-slate-800 hover:bg-slate-700 focus:bg-slate-700 focus:text-slate-100"
-            options={{
-              en: 'English',
-              fr: 'Français'
-            }}
-            triggerClassName="hover:bg-slate-800 hover:text-slate-300 focus-visible:ring-0"
-            variant="ghost"
-          />
+          {Object.keys(languageOptions).length > 1 && (
+            <LanguageToggle
+              contentClassName="bg-slate-800 border-slate-700 text-slate-300"
+              itemClassName="bg-slate-800 hover:bg-slate-700 focus:bg-slate-700 focus:text-slate-100"
+              options={languageOptions}
+              triggerClassName="hover:bg-slate-800 hover:text-slate-300 focus-visible:ring-0"
+              variant="ghost"
+            />
+          )}
           <ThemeToggle className="hover:bg-slate-800 hover:text-slate-300" variant="ghost" />
         </div>
       </div>

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -171,6 +171,7 @@ export const StartSessionForm = ({
               (arg) => !arg.includes('$'),
               t({
                 en: 'Illegal character: $',
+                es: 'Carácter no permitido: $',
                 fr: 'Caractère non autorisé : $'
               })
             )
@@ -186,6 +187,7 @@ export const StartSessionForm = ({
               {
                 message: t({
                   en: `Subject must be above age of ${currentGroup?.settings.minimumAge}`,
+                  es: `El sujeto debe tener al menos ${currentGroup?.settings.minimumAge} años`,
                   fr: `Le sujet doit avoir au moins ${currentGroup?.settings.minimumAge} ans`
                 })
               }
@@ -212,9 +214,10 @@ export const StartSessionForm = ({
                   ctx.addIssue({
                     code: z.ZodIssueCode.custom,
                     message:
-                      currentGroup.settings.idValidationRegexErrorMessage?.[resolvedLanguage] ??
+                      currentGroup.settings.idValidationRegexErrorMessage?.[resolvedLanguage as 'en' | 'fr'] ??
                       t({
                         en: `Must match regular expression: ${regex.source}`,
+                        es: `Debe coincidir con la expresión regular: ${regex.source}`,
                         fr: `Doit correspondre à l'expression régulière : ${regex.source}`
                       }),
                     path: ['subjectId']

--- a/apps/web/src/components/UserDropup/UserDropup.tsx
+++ b/apps/web/src/components/UserDropup/UserDropup.tsx
@@ -59,6 +59,7 @@ export const UserDropup = () => {
             <Info />
             {t({
               en: 'About',
+              es: 'Acerca de',
               fr: 'Information'
             })}
           </DropdownMenu.Item>
@@ -72,6 +73,7 @@ export const UserDropup = () => {
             <SettingsIcon />
             {t({
               en: 'Preferences',
+              es: 'Preferencias',
               fr: 'Préférences'
             })}
           </DropdownMenu.Item>
@@ -86,6 +88,7 @@ export const UserDropup = () => {
             <SchoolIcon />
             {t({
               en: 'Tutorial',
+              es: 'Tutorial',
               fr: 'Tutoriel'
             })}
           </DropdownMenu.Item>
@@ -97,6 +100,7 @@ export const UserDropup = () => {
             <LogOutIcon />
             {t({
               en: 'Logout',
+              es: 'Cerrar sesión',
               fr: 'Se déconnecter'
             })}
           </DropdownMenu.Item>

--- a/apps/web/src/hooks/useCreateInstrumentRepoMutation.ts
+++ b/apps/web/src/hooks/useCreateInstrumentRepoMutation.ts
@@ -18,14 +18,22 @@ export function useCreateInstrumentRepoMutation() {
       addNotification({
         message: getApiErrorMessage(
           err,
-          t({ en: 'Failed to import repository', fr: "Échec de l'importation du dépôt" })
+          t({
+            en: 'Failed to import repository',
+            es: 'Error al importar el repositorio',
+            fr: "Échec de l'importation du dépôt"
+          })
         ),
         type: 'error'
       });
     },
     onSuccess() {
       addNotification({
-        message: t({ en: 'Repository imported successfully', fr: 'Dépôt importé avec succès' }),
+        message: t({
+          en: 'Repository imported successfully',
+          es: 'Repositorio importado exitosamente',
+          fr: 'Dépôt importé avec succès'
+        }),
         type: 'success'
       });
       void queryClient.invalidateQueries({ queryKey: [INSTRUMENT_REPOS_QUERY_KEY] });

--- a/apps/web/src/hooks/useCreateSeriesInstrumentMutation.ts
+++ b/apps/web/src/hooks/useCreateSeriesInstrumentMutation.ts
@@ -24,7 +24,11 @@ export function useCreateSeriesInstrumentMutation() {
       addNotification({
         message: getApiErrorMessage(
           err,
-          t({ en: 'Failed to create series instrument', fr: "Échec de la création de l'instrument en série" })
+          t({
+            en: 'Failed to create series instrument',
+            es: 'Error al crear el instrumento en serie',
+            fr: "Échec de la création de l'instrument en série"
+          })
         ),
         type: 'error'
       });

--- a/apps/web/src/hooks/useDeleteInstrumentRepoMutation.ts
+++ b/apps/web/src/hooks/useDeleteInstrumentRepoMutation.ts
@@ -17,7 +17,11 @@ export function useDeleteInstrumentRepoMutation() {
       addNotification({
         message: getApiErrorMessage(
           err,
-          t({ en: 'Failed to delete repository', fr: 'Échec de la suppression du dépôt' })
+          t({
+            en: 'Failed to delete repository',
+            es: 'Error al eliminar el repositorio',
+            fr: 'Échec de la suppression du dépôt'
+          })
         ),
         type: 'error'
       });

--- a/apps/web/src/hooks/useDeleteSeriesInstrumentMutation.ts
+++ b/apps/web/src/hooks/useDeleteSeriesInstrumentMutation.ts
@@ -27,7 +27,11 @@ export function useDeleteSeriesInstrumentMutation() {
       addNotification({
         message: getApiErrorMessage(
           err,
-          t({ en: 'Failed to delete instrument', fr: "Échec de la suppression de l'instrument" })
+          t({
+            en: 'Failed to delete instrument',
+            es: 'Error al eliminar el instrumento',
+            fr: "Échec de la suppression de l'instrument"
+          })
         ),
         type: 'error'
       });

--- a/apps/web/src/hooks/useInstrument.ts
+++ b/apps/web/src/hooks/useInstrument.ts
@@ -18,7 +18,14 @@ export function useInstrument(id: null | string) {
       const { bundle, id } = instrumentBundleQuery.data;
       interpreter
         .interpret(bundle, { id, validate: import.meta.env.DEV })
-        .then((instrument) => setInstrument(translateInstrument(instrument, resolvedLanguage)))
+        .then((instrument) =>
+          setInstrument(
+            translateInstrument(
+              instrument,
+              resolvedLanguage === 'en' || resolvedLanguage === 'fr' ? resolvedLanguage : 'en'
+            )
+          )
+        )
         .catch((err) => {
           console.error(err);
           setInstrument(null);

--- a/apps/web/src/hooks/useInstrumentInfoQuery.ts
+++ b/apps/web/src/hooks/useInstrumentInfoQuery.ts
@@ -26,7 +26,8 @@ export function useInstrumentInfoQuery<TKind extends InstrumentKind>({
         params: { ...params, groupId: currentGroupId }
       });
       const infos = await $InstrumentInfo.array().parseAsync(response.data);
-      return infos.map((instrument) => translateInstrumentInfo(instrument, resolvedLanguage ?? 'en'));
+      const instrumentLang = resolvedLanguage === 'en' || resolvedLanguage === 'fr' ? resolvedLanguage : 'en';
+      return infos.map((instrument) => translateInstrumentInfo(instrument, instrumentLang));
     },
     queryKey: [
       'instrument-info',

--- a/apps/web/src/hooks/useInstrumentVisualization.ts
+++ b/apps/web/src/hooks/useInstrumentVisualization.ts
@@ -246,6 +246,7 @@ export function useInstrumentVisualization({ params }: UseInstrumentVisualizatio
       notifications.addNotification({
         message: t({
           en: 'Error occurred finding records',
+          es: 'Ocurrió un error al buscar los registros',
           fr: "Une erreur s'est produite lors de la recherche des enregistrements."
         }),
         type: 'error'
@@ -284,7 +285,7 @@ export function useInstrumentVisualization({ params }: UseInstrumentVisualizatio
       .filter((info): info is typeof selected => info.kind !== 'SERIES' && info.internal.name === selectedName)
       .sort((a, b) => a.internal.edition - b.internal.edition)
       .forEach((info) => {
-        options[info.id] = `${t({ en: 'Edition', fr: 'Édition' })} ${info.internal.edition}`;
+        options[info.id] = `${t({ en: 'Edition', es: 'Edición', fr: 'Édition' })} ${info.internal.edition}`;
       });
     return options;
   }, [instrumentInfoQuery.data, instrumentId]);

--- a/apps/web/src/hooks/useNavItems.ts
+++ b/apps/web/src/hooks/useNavItems.ts
@@ -87,7 +87,7 @@ export function useNavItems() {
       if (setupStateQuery.data.isMailEnabled) {
         globalItems.push({
           icon: MailIcon,
-          label: t({ en: 'Email Templates', fr: 'Modèles de courriel' }),
+          label: t({ en: 'Email Templates', es: 'Plantillas de correo', fr: 'Modèles de courriel' }),
           url: '/group/email-templates'
         });
       }
@@ -98,6 +98,7 @@ export function useNavItems() {
         icon: UsersIcon,
         label: t({
           en: 'Manage Groups',
+          es: 'Administrar grupos',
           fr: 'Gérer les groupes'
         }),
         url: '/admin/groups'
@@ -106,6 +107,7 @@ export function useNavItems() {
         icon: UserCogIcon,
         label: t({
           en: 'Manage Users',
+          es: 'Administrar usuarios',
           fr: 'Gérer les utilisateurs'
         }),
         url: '/admin/users'
@@ -120,6 +122,7 @@ export function useNavItems() {
             icon: CogIcon,
             label: t({
               en: 'App Settings',
+              es: 'Configuración de la aplicación',
               fr: "Paramètres de l'application"
             }),
             url: '/admin/settings'
@@ -128,6 +131,7 @@ export function useNavItems() {
             icon: PaletteIcon,
             label: t({
               en: 'Branding',
+              es: 'Imagen de marca',
               fr: 'Image de marque'
             }),
             url: '/admin/branding'
@@ -141,18 +145,19 @@ export function useNavItems() {
             icon: PackageIcon,
             label: t({
               en: 'Instrument Repos',
+              es: 'Repositorios de instrumentos',
               fr: "Dépôts d'instruments"
             }),
             url: '/admin/instrument-repos'
           },
           {
             icon: MailIcon,
-            label: t({ en: 'Mail', fr: 'Courriel' }),
+            label: t({ en: 'Mail', es: 'Correo', fr: 'Courriel' }),
             url: '/admin/mail'
           }
         ],
         icon: ShieldIcon,
-        label: t({ en: 'Admin Panel', fr: "Panneau d'administration" })
+        label: t({ en: 'Admin Panel', es: 'Panel de administración', fr: "Panneau d'administration" })
       });
     }
 

--- a/apps/web/src/hooks/useSyncInstrumentRepoMutation.ts
+++ b/apps/web/src/hooks/useSyncInstrumentRepoMutation.ts
@@ -17,18 +17,33 @@ export function useSyncInstrumentRepoMutation() {
       addNotification({
         message: getApiErrorMessage(
           err,
-          t({ en: 'Failed to sync repository', fr: 'Échec de la synchronisation du dépôt' })
+          t({
+            en: 'Failed to sync repository',
+            es: 'Error al sincronizar el repositorio',
+            fr: 'Échec de la synchronisation du dépôt'
+          })
         ),
         type: 'error'
       });
     },
     onMutate() {
       // Immediate feedback that the (potentially slow) sync has started.
-      addNotification({ message: t({ en: 'Syncing repository...', fr: 'Synchronisation du dépôt...' }), type: 'info' });
+      addNotification({
+        message: t({
+          en: 'Syncing repository...',
+          es: 'Sincronizando repositorio...',
+          fr: 'Synchronisation du dépôt...'
+        }),
+        type: 'info'
+      });
     },
     onSuccess() {
       addNotification({
-        message: t({ en: 'Repository synced successfully', fr: 'Dépôt synchronisé avec succès' }),
+        message: t({
+          en: 'Repository synced successfully',
+          es: 'Repositorio sincronizado exitosamente',
+          fr: 'Dépôt synchronisé avec succès'
+        }),
         type: 'success'
       });
       void queryClient.invalidateQueries({ queryKey: [INSTRUMENT_REPOS_QUERY_KEY] });

--- a/apps/web/src/providers/DisclaimerProvider.tsx
+++ b/apps/web/src/providers/DisclaimerProvider.tsx
@@ -20,22 +20,24 @@ export const DisclaimerProvider: React.FC<{ children: React.ReactElement }> = ({
             <Dialog.Title>
               {t({
                 en: 'Disclaimer',
+                es: 'Aviso legal',
                 fr: 'Avis'
               })}
             </Dialog.Title>
             <Dialog.Description>
               {t({
                 en: 'This platform is not an Electronic Health Record. Our terms of service prohibit using this platform as the primary mechanism to store clinical data.',
+                es: 'Esta plataforma no es un expediente clínico electrónico. Nuestros términos de servicio prohíben utilizar esta plataforma como mecanismo principal para almacenar datos clínicos.',
                 fr: "Cette plateforme n'est pas un dossier médical électronique. Nos conditions de service interdisent l'utilisation de cette plateforme comme principal mécanisme de stockage des données cliniques."
               })}
             </Dialog.Description>
           </Dialog.Header>
           <Dialog.Footer>
             <Button data-test-id="accept-disclaimer" type="button" onClick={() => setIsDisclaimerAccepted(true)}>
-              {t({ en: 'Accept', fr: 'Accepter' })}
+              {t({ en: 'Accept', es: 'Aceptar', fr: 'Accepter' })}
             </Button>
             <Button data-test-id="decline-disclaimer" type="button" variant="outline" onClick={logout}>
-              {t({ en: 'Decline', fr: 'Refuser' })}
+              {t({ en: 'Decline', es: 'Rechazar', fr: 'Refuser' })}
             </Button>
           </Dialog.Footer>
         </Dialog.Content>

--- a/apps/web/src/providers/WalkthroughProvider.tsx
+++ b/apps/web/src/providers/WalkthroughProvider.tsx
@@ -74,16 +74,19 @@ const Walkthrough = () => {
           <p>
             {t({
               en: 'This tutorial provides a brief overview of how to use Open Data Capture.',
+              es: 'Este tutorial proporciona una breve descripción de cómo usar Open Data Capture.',
               fr: "Ce tutoriel donne un bref aperçu de l'utilisation de la plateforme Open Data Capture."
             })}{' '}
             <span className="font-bold">
               {t({
                 en: 'Please complete it before asking any questions about the platform.',
+                es: 'Por favor, complételo antes de hacer preguntas sobre la plataforma.',
                 fr: 'Veuillez le compléter avant de poser des questions sur la plateforme.'
               })}
             </span>{' '}
             {t({
               en: 'After completing the tutorial, this popup will no longer appear when you log in to Open Data Capture.',
+              es: 'Después de completar el tutorial, esta ventana ya no aparecerá cuando inicie sesión en Open Data Capture.',
               fr: "Après avoir suivi le tutoriel, cette fenêtre ne s'affichera plus lorsque vous vous connecterez à la plateforme."
             })}
           </p>
@@ -95,6 +98,7 @@ const Walkthrough = () => {
         target: '#sidebar-branding-container',
         title: t({
           en: 'Welcome to Open Data Capture 👋',
+          es: 'Bienvenido a Open Data Capture 👋',
           fr: 'Bienvenue sur Open Data Capture 👋'
         })
       },
@@ -103,6 +107,7 @@ const Walkthrough = () => {
           <p>
             {t({
               en: 'On this page, you can see an overview of the data collected by your group.',
+              es: 'En esta página, puede ver un resumen de los datos recopilados por su grupo.',
               fr: 'Sur cette page, vous pouvez voir un aperçu des données collectées par votre groupe.'
             })}
           </p>
@@ -114,6 +119,7 @@ const Walkthrough = () => {
         target: 'button[data-nav-url="/dashboard"]',
         title: t({
           en: 'Dashboard',
+          es: 'Panel de control',
           fr: 'Tableau de bord'
         })
       },
@@ -122,6 +128,7 @@ const Walkthrough = () => {
           <p>
             {t({
               en: 'On this page, you can view and export the data your group has collected.',
+              es: 'En esta página, puede ver y exportar los datos que su grupo ha recopilado.',
               fr: 'Sur cette page, vous pouvez visualiser et exporter les données collectées par votre groupe.'
             })}
           </p>
@@ -133,6 +140,7 @@ const Walkthrough = () => {
         target: 'button[data-nav-url="/datahub"]',
         title: t({
           en: 'Data Hub',
+          es: 'Centro de datos',
           fr: 'Centre de données'
         })
       },
@@ -141,6 +149,7 @@ const Walkthrough = () => {
           <p>
             {t({
               en: 'Here, you can search for subjects in the database. To begin, type in the search bar to find matching subject IDs',
+              es: 'Aquí puede buscar sujetos en la base de datos. Para comenzar, escriba en la barra de búsqueda para encontrar los identificadores de sujetos correspondientes.',
               fr: 'Ici, vous pouvez rechercher des sujets dans la base de données. Pour commencer, saisissez votre recherche dans la barre de recherche afin de trouver les identifiants de sujets correspondants.'
             })}
           </p>
@@ -152,6 +161,7 @@ const Walkthrough = () => {
         target: '#datahub-subject-search-bar',
         title: t({
           en: 'Subject Search Bar',
+          es: 'Barra de búsqueda de sujetos',
           fr: 'Barre de recherche de client'
         })
       },
@@ -160,6 +170,7 @@ const Walkthrough = () => {
           <p>
             {t({
               en: 'Here, you can search for subjects in the database. To begin, click on the Subject Lookup button, and a popup will appear where you can enter the search query.',
+              es: 'Aquí puede buscar sujetos en la base de datos. Para comenzar, haga clic en el botón de búsqueda de sujetos y aparecerá una ventana emergente donde puede ingresar la consulta de búsqueda.',
               fr: "Ici, vous pouvez rechercher des clients dans la base de données. Pour commencer, cliquez sur le bouton de recherche et une fenêtre contextuelle s'affichera pour vous permettre de saisir la requête de recherche."
             })}
           </p>
@@ -171,12 +182,14 @@ const Walkthrough = () => {
         target: '[data-spotlight-type="subject-lookup-search-button"]',
         title: t({
           en: 'Subject Lookup',
+          es: 'Búsqueda de sujetos',
           fr: 'Recherche de client'
         })
       },
       {
         content: t({
           en: 'Here, you can export all your data in various formats.',
+          es: 'Aquí puede exportar todos sus datos en varios formatos.',
           fr: 'Ici, vous pouvez exporter toutes vos données dans différents formats.'
         }),
         navigateOptions: {
@@ -186,12 +199,14 @@ const Walkthrough = () => {
         target: '[data-spotlight-type="export-data-dropdown"]',
         title: t({
           en: 'Bulk Data Export',
+          es: 'Exportación masiva de datos',
           fr: 'Exportation de données'
         })
       },
       {
         content: t({
           en: 'On this page, you can start a new session for a subject. Various options are available based on the identification method you choose and the type of session.',
+          es: 'En esta página, puede iniciar una nueva sesión para un sujeto. Hay varias opciones disponibles según el método de identificación que elija y el tipo de sesión.',
           fr: "Sur cette page, vous pouvez démarrer une nouvelle session pour un client. Différentes options sont disponibles en fonction de la méthode d'identification choisie et du type de session."
         }),
         navigateOptions: {
@@ -204,12 +219,14 @@ const Walkthrough = () => {
         target: 'button[data-nav-url="/session/start-session"]',
         title: t({
           en: 'Start Session',
+          es: 'Iniciar sesión de evaluación',
           fr: 'Démarrer une session'
         })
       },
       {
         content: t({
           en: "You can start a session with a custom ID or let the system create one using the subject's personal information. If you choose the auto-generate option, the ID is created in your browser, so the subject's first and last names are never sent to our server.",
+          es: 'Puede iniciar una sesión con un identificador personalizado o dejar que el sistema cree uno usando la información personal del sujeto. Si elige la opción de generación automática, el identificador se crea en su navegador, por lo que el nombre y apellido del sujeto nunca se envían a nuestro servidor.',
           fr: "Vous pouvez démarrer une session avec un identifiant personnalisé ou laisser le système en créer un à l'aide des informations personnelles du client. Si vous choisissez l'option de génération automatique, l'identifiant est créé dans votre navigateur, de sorte que les nom et prénom du client ne sont jamais envoyés à notre serveur."
         }),
         navigateOptions: {
@@ -219,12 +236,14 @@ const Walkthrough = () => {
         target: 'div[data-field-group="subjectIdentificationMethod"]',
         title: t({
           en: 'Identification Method',
+          es: 'Método de identificación',
           fr: "Méthode d'identification"
         })
       },
       {
         content: t({
           en: 'You can use any ID you like; your group name will automatically be appended to ensure it is unique.',
+          es: 'Puede usar cualquier identificador que desee; el nombre de su grupo se añadirá automáticamente para garantizar que sea único.',
           fr: "Vous pouvez utiliser l'identifiant de votre choix ; le nom de votre groupe sera automatiquement ajouté pour garantir son unicité."
         }),
         navigateOptions: {
@@ -234,12 +253,14 @@ const Walkthrough = () => {
         target: 'div[data-field-group="subjectId"]',
         title: t({
           en: 'Identifier',
+          es: 'Identificador',
           fr: 'Identification du client'
         })
       },
       {
         content: t({
           en: 'You can choose either an in-person session (the default) or a retrospective session to enter data previously collected using a different system.',
+          es: 'Puede elegir una sesión presencial (la opción predeterminada) o una sesión retrospectiva para ingresar datos previamente recopilados con otro sistema.',
           fr: "Vous pouvez choisir une session en personne (par défaut) ou une session rétrospective pour saisir des données précédemment collectées à l'aide d'un autre système."
         }),
         navigateOptions: {
@@ -249,12 +270,14 @@ const Walkthrough = () => {
         target: 'div[data-field-group="sessionType"]',
         title: t({
           en: 'Type of Assessment',
+          es: 'Tipo de evaluación',
           fr: "Type d'évaluation"
         })
       },
       {
         content: t({
           en: 'Here, you can see the current session in progress.',
+          es: 'Aquí puede ver la sesión actualmente en curso.',
           fr: 'Ici, vous pouvez voir la session en cours.'
         }),
         navigateOptions: {
@@ -267,12 +290,14 @@ const Walkthrough = () => {
         target: '#current-session-card',
         title: t({
           en: 'Session in Progress',
+          es: 'Sesión en curso',
           fr: 'Session en cours'
         })
       },
       {
         content: t({
           en: 'On this page, you can select the instrument you want to administer.',
+          es: 'En esta página, puede seleccionar el instrumento que desea administrar.',
           fr: "Sur cette page, vous pouvez sélectionner l'instrument que vous souhaitez administrer."
         }),
         navigateOptions: {
@@ -285,12 +310,14 @@ const Walkthrough = () => {
         target: 'button[data-nav-url="/instruments/accessible-instruments"]',
         title: t({
           en: 'Administer Instrument',
+          es: 'Administrar instrumento',
           fr: 'Administrer un instrument'
         })
       },
       {
         content: t({
           en: 'On this page, you can view the data for the subject of the current session. To access data for other subjects, use the lookup button on the Data Hub page.',
+          es: 'En esta página, puede ver los datos del sujeto de la sesión actual. Para acceder a los datos de otros sujetos, use el botón de búsqueda en la página del centro de datos.',
           fr: "Sur cette page, vous pouvez consulter les données du client pour lequel la session est en cours. Pour accéder aux données d'autres clients, utilisez le bouton de recherche sur la page du centre de données."
         }),
         navigateOptions: {
@@ -300,12 +327,14 @@ const Walkthrough = () => {
         target: 'button[data-nav-url="/datahub/123/table"]',
         title: t({
           en: 'View Subject',
+          es: 'Ver sujeto',
           fr: 'Voir le client'
         })
       },
       {
         content: t({
           en: 'Here, you can view the records this subject has completed for a given instrument.',
+          es: 'Aquí puede ver los registros que este sujeto ha completado para un instrumento determinado.',
           fr: 'Ici, vous pouvez voir les enregistrements que ce client a complétés pour un instrument donné'
         }),
         navigateOptions: {
@@ -315,12 +344,14 @@ const Walkthrough = () => {
         target: 'a[data-nav-url="/datahub/123/table"]',
         title: t({
           en: 'Table',
+          es: 'Tabla',
           fr: 'Tableau'
         })
       },
       {
         content: t({
           en: 'Here, you can export the data in the table to CSV or JSON format.',
+          es: 'Aquí puede exportar los datos de la tabla en formato CSV o JSON.',
           fr: 'Ici, vous pouvez exporter les données du tableau au format CSV ou JSON.'
         }),
         navigateOptions: {
@@ -330,12 +361,14 @@ const Walkthrough = () => {
         target: 'div[data-spotlight-type="export-data-dropdown"]',
         title: t({
           en: 'Data Export',
+          es: 'Exportación de datos',
           fr: 'Exportation de données'
         })
       },
       {
         content: t({
           en: 'Here, you can create custom graphs to visualize longitudinal data for a given subject.',
+          es: 'Aquí puede crear gráficos personalizados para visualizar los datos longitudinales de un sujeto determinado.',
           fr: "Ici, vous pouvez créer des graphiques personnalisés pour visualiser les données longitudinales d'un client donné."
         }),
         navigateOptions: {
@@ -345,12 +378,14 @@ const Walkthrough = () => {
         target: 'a[data-nav-url="/datahub/123/graph"]',
         title: t({
           en: 'Graph',
+          es: 'Gráfico',
           fr: 'Graphique'
         })
       },
       {
         content: t({
           en: 'Here, you can create and view assignments, which are instruments for a subject to complete at home.',
+          es: 'Aquí puede crear y ver asignaciones, que son instrumentos que el sujeto debe completar en casa.',
           fr: 'Ici, vous pouvez créer et visualiser des assignations, qui sont des instruments que le client doit compléter à la maison.'
         }),
         navigateOptions: {
@@ -360,6 +395,7 @@ const Walkthrough = () => {
         target: 'a[data-nav-url="/datahub/123/assignments"]',
         title: t({
           en: 'Assignments',
+          es: 'Asignaciones',
           fr: 'Assignations'
         })
       }
@@ -449,6 +485,7 @@ const Walkthrough = () => {
               >
                 {t({
                   en: "Don't show again",
+                  es: 'No mostrar de nuevo',
                   fr: 'Ne plus afficher'
                 })}
               </Button>
@@ -457,6 +494,7 @@ const Walkthrough = () => {
               <Button type="button" variant="outline" onClick={() => setIndex(index - 1)}>
                 {t({
                   en: 'Back',
+                  es: 'Atrás',
                   fr: 'Retour'
                 })}
               </Button>
@@ -475,10 +513,12 @@ const Walkthrough = () => {
               {isLastStep
                 ? t({
                     en: 'Done',
+                    es: 'Listo',
                     fr: 'Fin'
                   })
                 : t({
                     en: 'Next',
+                    es: 'Siguiente',
                     fr: 'Suivant'
                   })}
             </Button>

--- a/apps/web/src/routes/_app/about.tsx
+++ b/apps/web/src/routes/_app/about.tsx
@@ -15,44 +15,54 @@ import { setupStateQueryOptions, useSetupStateQuery } from '@/hooks/useSetupStat
 const translations = {
   branch: {
     en: 'Branch',
+    es: 'Rama',
     fr: 'Branche'
   },
   buildDate: {
     en: 'Build Date',
+    es: 'Fecha de compilación',
     fr: 'Date de construction'
   },
   buildType: {
     en: 'Build Type',
+    es: 'Tipo de compilación',
     fr: 'Type de construction'
   },
   buildTypes: {
     development: {
       en: 'Development',
+      es: 'Desarrollo',
       fr: 'Développement'
     },
     production: {
       en: 'Production',
+      es: 'Producción',
       fr: 'Production'
     },
     test: {
       en: 'Test',
+      es: 'Prueba',
       fr: 'Test'
     }
   },
   enabled: {
     en: 'Enabled',
+    es: 'Habilitado',
     fr: 'Activé'
   },
   status: {
     en: 'Status',
+    es: 'Estado',
     fr: 'Statut'
   },
   uptime: {
     en: 'Uptime',
+    es: 'Tiempo de actividad',
     fr: 'Temps de fonctionnement'
   },
   version: {
     en: 'Version',
+    es: 'Versión',
     fr: 'Version'
   }
 };
@@ -155,6 +165,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Platform Information',
+            es: 'Información de la plataforma',
             fr: 'Informations concernant la plateforme'
           })}
         </Heading>
@@ -165,12 +176,16 @@ const RouteComponent = () => {
           <Card.Description>
             {t({
               en: "This page provides technical information that you can share with your platform administrator if you encounter any issues. Don't worry if you don't understand the content; it's intended for technical support.",
+              es: 'Esta página proporciona información técnica que puede compartir con el administrador de su plataforma si encuentra algún problema. No se preocupe si no entiende el contenido; está destinado al soporte técnico.',
               fr: "Cette page fournit des informations techniques que vous pouvez partager avec l'administrateur de votre plateforme si vous rencontrez des problèmes. Ne vous inquiétez pas si vous ne comprenez pas le contenu ; il est destiné à l'assistance technique."
             })}
           </Card.Description>
         </Card.Header>
         <Card.Content className="flex flex-col gap-6 p-6 text-sm">
-          <InfoBlock items={translateReleaseInfo(__RELEASE__)} label={t({ en: 'Web Client', fr: 'Client Web' })} />
+          <InfoBlock
+            items={translateReleaseInfo(__RELEASE__)}
+            label={t({ en: 'Web Client', es: 'Cliente web', fr: 'Client Web' })}
+          />
           <InfoBlock
             items={{
               ...translateReleaseInfo(setupStateQuery.data.release),
@@ -178,6 +193,7 @@ const RouteComponent = () => {
             }}
             label={t({
               en: 'Core API',
+              es: 'API principal',
               fr: 'API de base'
             })}
           />
@@ -185,13 +201,18 @@ const RouteComponent = () => {
             items={getTranslatedGatewayInfo()}
             label={t({
               en: 'Gateway Service',
+              es: 'Servicio de pasarela',
               fr: 'Service de passerelle'
             })}
           />
         </Card.Content>
         <Card.Footer className="border-t px-6 py-3">
           <p className="text-muted-foreground text-xs">
-            {t({ en: `Generated on ${currentDateString}`, fr: `Généré le ${currentDateString}` })}
+            {t({
+              en: `Generated on ${currentDateString}`,
+              es: `Generado el ${currentDateString}`,
+              fr: `Généré le ${currentDateString}`
+            })}
           </p>
         </Card.Footer>
       </Card>

--- a/apps/web/src/routes/_app/admin/branding/index.tsx
+++ b/apps/web/src/routes/_app/admin/branding/index.tsx
@@ -32,7 +32,7 @@ const RouteComponent = () => {
     <div className="w-full">
       <PageHeader>
         <Heading className="text-center" variant="h2">
-          {t({ en: 'Branding', fr: 'Image de marque' })}
+          {t({ en: 'Branding', es: 'Imagen de marca', fr: 'Image de marque' })}
         </Heading>
       </PageHeader>
       <div className="mx-auto w-full max-w-4xl">
@@ -40,10 +40,13 @@ const RouteComponent = () => {
           <div className="flex items-center gap-5 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-lg backdrop-blur-sm transition-all duration-300 hover:border-sky-300/60 hover:shadow-xl dark:border-slate-700/60 dark:bg-slate-800/90 dark:hover:border-sky-600/60">
             <LoginPagePreview />
             <div className="min-w-0 flex-1">
-              <h3 className="text-foreground font-medium">{t({ en: 'Login Page', fr: 'Page de connexion' })}</h3>
+              <h3 className="text-foreground font-medium">
+                {t({ en: 'Login Page', es: 'Página de inicio de sesión', fr: 'Page de connexion' })}
+              </h3>
               <p className="text-muted-foreground mt-1 text-sm">
                 {t({
                   en: 'Customize the branding panel, colors, image, and text shown on the login page.',
+                  es: 'Personalice el panel de marca, los colores, la imagen y el texto que se muestran en la página de inicio de sesión.',
                   fr: "Personnalisez le panneau de marque, les couleurs, l'image et le texte affichés sur la page de connexion."
                 })}
               </p>

--- a/apps/web/src/routes/_app/admin/groups/create.tsx
+++ b/apps/web/src/routes/_app/admin/groups/create.tsx
@@ -23,6 +23,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Add Group',
+            es: 'Agregar grupo',
             fr: 'Ajouter un groupe'
           })}
         </Heading>

--- a/apps/web/src/routes/_app/admin/groups/index.tsx
+++ b/apps/web/src/routes/_app/admin/groups/index.tsx
@@ -43,7 +43,11 @@ const RouteComponent = () => {
       addNotification({
         message: getApiErrorMessage(
           err,
-          t({ en: 'Failed to update group repositories', fr: 'Échec de la mise à jour des dépôts du groupe' })
+          t({
+            en: 'Failed to update group repositories',
+            es: 'Error al actualizar los repositorios del grupo',
+            fr: 'Échec de la mise à jour des dépôts du groupe'
+          })
         ),
         type: 'error'
       });
@@ -91,6 +95,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Manage Groups',
+            es: 'Administrar grupos',
             fr: 'Gérer les groupes'
           })}
         </Heading>
@@ -136,6 +141,7 @@ const RouteComponent = () => {
             <Link to="/admin/groups/create">
               {t({
                 en: 'Add Group',
+                es: 'Agregar grupo',
                 fr: 'Ajouter un groupe'
               })}
             </Link>
@@ -154,6 +160,7 @@ const RouteComponent = () => {
             <Sheet.Description>
               {t({
                 en: 'Make changes to this group here. Click save when you are done.',
+                es: 'Realice cambios a este grupo aquí. Haga clic en guardar cuando haya terminado.',
                 fr: 'Apportez des modifications à ce groupe ici. Cliquez sur enregistrer lorsque vous avez terminé.'
               })}
             </Sheet.Description>
@@ -163,12 +170,14 @@ const RouteComponent = () => {
               <h3 className="mb-2 text-sm font-medium">
                 {t({
                   en: 'Instrument Repositories',
+                  es: 'Repositorios de instrumentos',
                   fr: "Dépôts d'instruments"
                 })}
               </h3>
               <p className="text-muted-foreground mb-3 text-xs">
                 {t({
                   en: 'Select which instrument repositories this group has access to.',
+                  es: 'Seleccione a qué repositorios de instrumentos tiene acceso este grupo.',
                   fr: "Sélectionnez les dépôts d'instruments auxquels ce groupe a accès."
                 })}
               </p>
@@ -176,6 +185,7 @@ const RouteComponent = () => {
                 <p className="text-muted-foreground text-sm italic">
                   {t({
                     en: 'No instrument repositories available. Add one from the admin menu.',
+                    es: 'No hay repositorios de instrumentos disponibles. Agregue uno desde el menú de administración.',
                     fr: "Aucun dépôt d'instruments disponible. Ajoutez-en un depuis le menu admin."
                   })}
                 </p>
@@ -193,7 +203,8 @@ const RouteComponent = () => {
                       <div>
                         <span className="text-sm font-medium">{repo.name}</span>
                         <span className="text-muted-foreground ml-2 text-xs">
-                          ({repo.instrumentIds.length} {t({ en: 'instruments', fr: 'instruments' })})
+                          ({repo.instrumentIds.length} {t({ en: 'instruments', es: 'instrumentos', fr: 'instruments' })}
+                          )
                         </span>
                       </div>
                     </div>
@@ -219,12 +230,14 @@ const RouteComponent = () => {
               <Dialog.Title>
                 {t({
                   en: 'Are you absolutely sure?',
+                  es: '¿Está completamente seguro?',
                   fr: 'Êtes-vous absolument sûr ?'
                 })}
               </Dialog.Title>
               <Dialog.Description>
                 {t({
                   en: 'This action will permanently delete this group and cannot be undone.',
+                  es: 'Esta acción eliminará permanentemente este grupo y no se puede deshacer.',
                   fr: 'Cette action supprimera définitivement ce groupe et ne pourra pas être annulée.'
                 })}
               </Dialog.Description>

--- a/apps/web/src/routes/_app/admin/instrument-repos/index.tsx
+++ b/apps/web/src/routes/_app/admin/instrument-repos/index.tsx
@@ -35,6 +35,7 @@ const AddRepoForm = ({
         <p className="text-muted-foreground text-sm">
           {t({
             en: 'Importing instruments from GitHub...',
+            es: 'Importando instrumentos desde GitHub...',
             fr: 'Importation des instruments depuis GitHub...'
           })}
         </p>
@@ -53,6 +54,7 @@ const AddRepoForm = ({
       setError(
         t({
           en: 'Please enter a valid GitHub repository URL.',
+          es: 'Por favor ingrese una URL de repositorio de GitHub válida.',
           fr: 'Veuillez entrer une URL de dépôt GitHub valide.'
         })
       );
@@ -66,7 +68,7 @@ const AddRepoForm = ({
     // autofilling the URL and token fields.
     <form autoComplete="off" className="flex flex-col gap-4" onSubmit={handleSubmit}>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="instrument-repo-url">{t({ en: 'GitHub URL', fr: 'URL GitHub' })}</Label>
+        <Label htmlFor="instrument-repo-url">{t({ en: 'GitHub URL', es: 'URL de GitHub', fr: 'URL GitHub' })}</Label>
         <Input
           autoComplete="off"
           id="instrument-repo-url"
@@ -78,7 +80,11 @@ const AddRepoForm = ({
       </div>
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="instrument-repo-token">
-          {t({ en: 'Personal Access Token (optional*)', fr: "Jeton d'accès personnel (facultatif*)" })}
+          {t({
+            en: 'Personal Access Token (optional*)',
+            es: 'Token de acceso personal (opcional*)',
+            fr: "Jeton d'accès personnel (facultatif*)"
+          })}
         </Label>
         <Input
           autoComplete="new-password"
@@ -91,13 +97,14 @@ const AddRepoForm = ({
         <p className="text-muted-foreground text-xs">
           {t({
             en: '*Required only for private repositories. Stored encrypted and reused when syncing.',
+            es: '*Requerido solo para repositorios privados. Almacenado de forma cifrada y reutilizado al sincronizar.',
             fr: '*Requis uniquement pour les dépôts privés. Stocké de manière chiffrée et réutilisé lors de la synchronisation.'
           })}
         </p>
       </div>
       {error && <p className="text-destructive text-sm">{error}</p>}
       <Button className="w-full" type="submit">
-        {t({ en: 'Import', fr: 'Importer' })}
+        {t({ en: 'Import', es: 'Importar', fr: 'Importer' })}
       </Button>
     </form>
   );
@@ -127,6 +134,7 @@ const RouteComponent = () => {
       addNotification({
         message: t({
           en: `"${repo.name}" is assigned to one or more groups. Remove it from those groups before deleting.`,
+          es: `"${repo.name}" está asignado a uno o más grupos. Retírelo de esos grupos antes de eliminarlo.`,
           fr: `« ${repo.name} » est assigné à un ou plusieurs groupes. Retirez-le de ces groupes avant de le supprimer.`
         }),
         type: 'warning'
@@ -154,6 +162,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Instrument Repositories',
+            es: 'Repositorios de instrumentos',
             fr: "Dépôts d'instruments"
           })}
         </Heading>
@@ -173,6 +182,7 @@ const RouteComponent = () => {
             },
             header: t({
               en: 'Repository Name',
+              es: 'Nombre del repositorio',
               fr: 'Nom du dépôt'
             })
           },
@@ -184,6 +194,7 @@ const RouteComponent = () => {
             accessorFn: (row: InstrumentRepo) => row.instrumentIds.length,
             header: t({
               en: 'Instruments',
+              es: 'Instrumentos',
               fr: 'Instruments'
             }),
             id: 'instrumentCount'
@@ -193,6 +204,7 @@ const RouteComponent = () => {
               row.lastSyncedAt ? new Date(row.lastSyncedAt).toLocaleDateString() : '-',
             header: t({
               en: 'Last Synced',
+              es: 'Última sincronización',
               fr: 'Dernière synchronisation'
             }),
             id: 'lastSynced'
@@ -203,6 +215,7 @@ const RouteComponent = () => {
           {
             label: t({
               en: 'Sync',
+              es: 'Sincronizar',
               fr: 'Synchroniser'
             }),
             onSelect: (repo: InstrumentRepo) => {
@@ -212,6 +225,7 @@ const RouteComponent = () => {
           {
             label: t({
               en: 'View',
+              es: 'Ver',
               fr: 'Voir'
             }),
             onSelect: (repo: InstrumentRepo) => {
@@ -228,6 +242,7 @@ const RouteComponent = () => {
           <Button variant="outline" onClick={() => setIsDialogOpen(true)}>
             {t({
               en: 'Add Repository',
+              es: 'Agregar repositorio',
               fr: 'Ajouter un dépôt'
             })}
           </Button>
@@ -244,12 +259,14 @@ const RouteComponent = () => {
             <Dialog.Title>
               {t({
                 en: 'Add Instrument Repository',
+                es: 'Agregar repositorio de instrumentos',
                 fr: "Ajouter un dépôt d'instruments"
               })}
             </Dialog.Title>
             <Dialog.Description>
               {t({
                 en: 'Enter the GitHub URL of the instrument repository. Importing may take a minute.',
+                es: 'Ingrese la URL de GitHub del repositorio de instrumentos. La importación puede tardar un minuto.',
                 fr: "Entrez l'URL GitHub du dépôt d'instruments. L'importation peut prendre une minute."
               })}
             </Dialog.Description>
@@ -268,6 +285,7 @@ const RouteComponent = () => {
             <Dialog.Title>
               {t({
                 en: `Instruments in "${repoToView.name}"`,
+                es: `Instrumentos en "${repoToView.name}"`,
                 fr: `Instruments dans « ${repoToView.name} »`
               })}
             </Dialog.Title>
@@ -288,6 +306,7 @@ const RouteComponent = () => {
                 <p className="text-muted-foreground py-4 text-center text-sm">
                   {t({
                     en: 'No instruments found in this repository.',
+                    es: 'No se encontraron instrumentos en este repositorio.',
                     fr: 'Aucun instrument trouvé dans ce dépôt.'
                   })}
                 </p>
@@ -296,9 +315,9 @@ const RouteComponent = () => {
             return (
               <div className="flex max-h-[60vh] flex-col gap-5 overflow-auto pr-3">
                 <div className="grid grid-cols-[1fr_8rem_5rem] gap-x-6 font-bold">
-                  <p>{t({ en: 'Title', fr: 'Titre' })}</p>
-                  <p>{t({ en: 'Kind', fr: 'Type' })}</p>
-                  <p>{t({ en: 'Edition', fr: 'Édition' })}</p>
+                  <p>{t({ en: 'Title', es: 'Título', fr: 'Titre' })}</p>
+                  <p>{t({ en: 'Kind', es: 'Tipo', fr: 'Type' })}</p>
+                  <p>{t({ en: 'Edition', es: 'Edición', fr: 'Édition' })}</p>
                 </div>
                 <hr />
                 <ul className="flex flex-col gap-5">
@@ -336,12 +355,14 @@ const RouteComponent = () => {
             <Dialog.Title>
               {t({
                 en: 'Are you absolutely sure?',
+                es: '¿Está completamente seguro?',
                 fr: 'Êtes-vous absolument sûr ?'
               })}
             </Dialog.Title>
             <Dialog.Description>
               {t({
                 en: `This will remove the repository "${repoToDelete.name}" from the system. Deletion is only possible if no groups currently have this repository assigned.`,
+                es: `Esto eliminará el repositorio "${repoToDelete.name}" del sistema. La eliminación solo es posible si ningún grupo tiene actualmente asignado este repositorio.`,
                 fr: `Cela supprimera le dépôt « ${repoToDelete.name} » du système. La suppression n'est possible que si aucun groupe n'utilise actuellement ce dépôt.`
               })}
             </Dialog.Description>

--- a/apps/web/src/routes/_app/admin/mail.tsx
+++ b/apps/web/src/routes/_app/admin/mail.tsx
@@ -199,7 +199,7 @@ const MailManager = ({
       if (!silent) {
         addNotification({
           message,
-          title: t({ en: 'Invalid configuration', fr: 'Configuration invalide' }),
+          title: t({ en: 'Invalid configuration', es: 'Configuración inválida', fr: 'Configuration invalide' }),
           type: 'error'
         });
       }
@@ -221,6 +221,7 @@ const MailManager = ({
         return fail(
           t({
             en: 'Enter your Mailgun sending domain (e.g. mg.example.org)',
+            es: 'Ingrese su dominio de envío de Mailgun (p. ej. mg.example.org)',
             fr: "Entrez votre domaine d'envoi Mailgun (p. ex. mg.example.org)"
           })
         );
@@ -230,6 +231,7 @@ const MailManager = ({
         return fail(
           t({
             en: 'Enter your AWS region (e.g. us-east-1)',
+            es: 'Ingrese su región de AWS (p. ej. us-east-1)',
             fr: 'Entrez votre région AWS (p. ex. us-east-1)'
           })
         );
@@ -238,6 +240,7 @@ const MailManager = ({
         return fail(
           t({
             en: 'Enter your AWS access key ID',
+            es: 'Ingrese su ID de clave de acceso de AWS',
             fr: "Entrez votre identifiant de clé d'accès AWS"
           })
         );
@@ -247,6 +250,7 @@ const MailManager = ({
         return fail(
           t({
             en: 'Enter a valid host (e.g. smtp.example.org)',
+            es: 'Ingrese un host válido (p. ej. smtp.example.org)',
             fr: 'Entrez un hôte valide (p. ex. smtp.example.org)'
           })
         );
@@ -255,6 +259,7 @@ const MailManager = ({
         return fail(
           t({
             en: 'Port must be a whole number between 1 and 65535',
+            es: 'El puerto debe ser un número entero entre 1 y 65535',
             fr: 'Le port doit être un nombre entier entre 1 et 65535'
           })
         );
@@ -263,6 +268,7 @@ const MailManager = ({
         return fail(
           t({
             en: 'Username is required',
+            es: 'El nombre de usuario es obligatorio',
             fr: "Le nom d'utilisateur est requis"
           })
         );
@@ -275,14 +281,15 @@ const MailManager = ({
     if (!secretStored && (!secretValue || secretValue === MASKED_SECRET)) {
       return fail(
         isHttp
-          ? t({ en: 'An API key is required', fr: 'Une clé API est requise' })
-          : t({ en: 'A password is required', fr: 'Un mot de passe est requis' })
+          ? t({ en: 'An API key is required', es: 'Se requiere una clave API', fr: 'Une clé API est requise' })
+          : t({ en: 'A password is required', es: 'Se requiere una contraseña', fr: 'Un mot de passe est requis' })
       );
     }
     if (!senderAddress || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(senderAddress)) {
       return fail(
         t({
           en: 'Enter a valid sender address (e.g. noreply@example.org)',
+          es: 'Ingrese una dirección de remitente válida (p. ej. noreply@example.org)',
           fr: "Entrez une adresse d'expéditeur valide (p. ex. noreply@example.org)"
         })
       );
@@ -309,7 +316,8 @@ const MailManager = ({
     const parsed = $UpdateMailConfigData.safeParse(candidate);
     if (!parsed.success) {
       return fail(
-        parsed.error.issues[0]?.message ?? t({ en: 'Please check the fields', fr: 'Veuillez vérifier les champs' })
+        parsed.error.issues[0]?.message ??
+          t({ en: 'Please check the fields', es: 'Por favor verifique los campos', fr: 'Veuillez vérifier les champs' })
       );
     }
     return parsed.data;
@@ -377,9 +385,10 @@ const MailManager = ({
       addNotification({
         message: t({
           en: 'Enter a valid recipient email address',
+          es: 'Ingrese una dirección de correo electrónico de destinatario válida',
           fr: 'Entrez une adresse courriel de destinataire valide'
         }),
-        title: t({ en: 'Invalid email', fr: 'Courriel invalide' }),
+        title: t({ en: 'Invalid email', es: 'Correo electrónico inválido', fr: 'Courriel invalide' }),
         type: 'error'
       });
       return;
@@ -389,13 +398,15 @@ const MailManager = ({
       message: withRecipient
         ? t({
             en: 'Sending a test email… this can take a few seconds.',
+            es: 'Enviando un correo de prueba… esto puede tardar unos segundos.',
             fr: "Envoi d'un courriel de test… cela peut prendre quelques secondes."
           })
         : t({
             en: 'Testing the connection… this can take a few seconds.',
+            es: 'Probando la conexión… esto puede tardar unos segundos.',
             fr: 'Test de la connexion… cela peut prendre quelques secondes.'
           }),
-      title: t({ en: 'Please wait', fr: 'Veuillez patienter' }),
+      title: t({ en: 'Please wait', es: 'Por favor espere', fr: 'Veuillez patienter' }),
       type: 'info'
     });
     testMutation.mutate(
@@ -405,9 +416,10 @@ const MailManager = ({
           addNotification({
             message: t({
               en: 'The test could not be completed (the server may be unreachable or the request timed out). Check the host, port, and credentials.',
+              es: 'No se pudo completar la prueba (el servidor puede ser inaccesible o la solicitud expiró). Verifique el host, el puerto y las credenciales.',
               fr: "Le test n'a pas pu être effectué (serveur injoignable ou délai dépassé). Vérifiez l'hôte, le port et les identifiants."
             }),
-            title: t({ en: 'Mail test failed', fr: 'Échec du test de courriel' }),
+            title: t({ en: 'Mail test failed', es: 'Prueba de correo fallida', fr: 'Échec du test de courriel' }),
             type: 'error'
           });
         },
@@ -418,19 +430,21 @@ const MailManager = ({
               message: withRecipient
                 ? t({
                     en: `Test email sent to ${recipient}`,
+                    es: `Correo de prueba enviado a ${recipient}`,
                     fr: `Courriel de test envoyé à ${recipient}`
                   })
                 : t({
                     en: 'Connected to the mail server successfully',
+                    es: 'Conexión al servidor de correo exitosa',
                     fr: 'Connexion au serveur de courriel réussie'
                   }),
-              title: t({ en: 'Mail test succeeded', fr: 'Test de courriel réussi' }),
+              title: t({ en: 'Mail test succeeded', es: 'Prueba de correo exitosa', fr: 'Test de courriel réussi' }),
               type: 'success'
             });
           } else {
             addNotification({
-              message: result.error ?? t({ en: 'Unknown error', fr: 'Erreur inconnue' }),
-              title: t({ en: 'Mail test failed', fr: 'Échec du test de courriel' }),
+              message: result.error ?? t({ en: 'Unknown error', es: 'Error desconocido', fr: 'Erreur inconnue' }),
+              title: t({ en: 'Mail test failed', es: 'Prueba de correo fallida', fr: 'Échec du test de courriel' }),
               type: 'error'
             });
           }
@@ -443,10 +457,10 @@ const MailManager = ({
   // Providers name their secret differently, so label the HTTP secret field accordingly.
   const secretLabel =
     values.provider === 'ses'
-      ? t({ en: 'AWS secret access key', fr: "Clé d'accès secrète AWS" })
+      ? t({ en: 'AWS secret access key', es: 'Clave de acceso secreta de AWS', fr: "Clé d'accès secrète AWS" })
       : values.provider === 'postmark'
-        ? t({ en: 'Server API token', fr: 'Jeton API du serveur' })
-        : t({ en: 'API key', fr: 'Clé API' });
+        ? t({ en: 'Server API token', es: 'Token API del servidor', fr: 'Jeton API du serveur' })
+        : t({ en: 'API key', es: 'Clave API', fr: 'Clé API' });
 
   // We never persist `enabled: true` without a working configuration, so when email is enabled
   // but the form isn't valid yet nothing is saved. Surface that so the toggle doesn't look broken.
@@ -459,12 +473,14 @@ const MailManager = ({
     if (issue === 'incomplete') {
       return t({
         en: 'Fill in the subject and body for each added language.',
+        es: 'Complete el asunto y el cuerpo para cada idioma agregado.',
         fr: "Remplissez l'objet et le corps pour chaque langue ajoutée."
       });
     }
     if (issue === 'missing-vars') {
       return t({
         en: 'The body must include {{username}} and {{password}}.',
+        es: 'El cuerpo debe incluir {{username}} y {{password}}.',
         fr: 'Le corps doit inclure {{username}} et {{password}}.'
       });
     }
@@ -476,11 +492,12 @@ const MailManager = ({
       <SaveStatus state={saveState} />
       <SectionCard>
         <Heading className="mb-1" variant="h4">
-          {t({ en: 'Email', fr: 'Courriel' })}
+          {t({ en: 'Email', es: 'Correo electrónico', fr: 'Courriel' })}
         </Heading>
         <p className="text-muted-foreground mb-4 text-sm">
           {t({
             en: 'Turn outgoing email on to configure your mail server and templates. When off, the application behaves as if email is not available. Changes on this page are saved automatically.',
+            es: 'Active el envío de correos electrónicos para configurar su servidor de correo y plantillas. Cuando está desactivado, la aplicación se comporta como si el correo no estuviera disponible. Los cambios en esta página se guardan automáticamente.',
             fr: "Activez l'envoi de courriels pour configurer votre serveur de messagerie et vos modèles. Lorsque c'est désactivé, l'application se comporte comme si le courriel n'était pas disponible. Les modifications de cette page sont enregistrées automatiquement."
           })}
         </p>
@@ -493,6 +510,7 @@ const MailManager = ({
           <span className="text-sm font-medium">
             {t({
               en: 'Enable email sending',
+              es: 'Activar el envío de correos electrónicos',
               fr: "Activer l'envoi de courriels"
             })}
           </span>
@@ -501,6 +519,7 @@ const MailManager = ({
           <p className="mt-2 text-xs font-medium text-amber-600 dark:text-amber-500">
             {t({
               en: 'Complete the configuration below to turn email on — your settings save automatically as you go, so there is no separate save button.',
+              es: 'Complete la configuración a continuación para activar el correo electrónico — sus ajustes se guardan automáticamente a medida que avanza, por lo que no hay un botón de guardar separado.',
               fr: "Complétez la configuration ci-dessous pour activer les courriels — vos paramètres sont enregistrés automatiquement au fur et à mesure, il n'y a donc pas de bouton d'enregistrement distinct."
             })}
           </p>
@@ -513,25 +532,27 @@ const MailManager = ({
             <Heading className="mb-1" variant="h4">
               {t({
                 en: 'Mail Server Configuration',
+                es: 'Configuración del servidor de correo',
                 fr: 'Configuration du serveur de courriel'
               })}
             </Heading>
             <p className="text-muted-foreground mb-4 text-sm">
               {t({
                 en: "Send email over a classic SMTP connection, or through a provider's HTTP sending API (useful when outbound SMTP ports are blocked).",
+                es: 'Envíe correos electrónicos a través de una conexión SMTP clásica o a través de la API de envío HTTP de un proveedor (útil cuando los puertos SMTP salientes están bloqueados).',
                 fr: "Envoyez des courriels via une connexion SMTP classique ou via l'API d'envoi HTTP d'un fournisseur (utile lorsque les ports SMTP sortants sont bloqués)."
               })}
             </p>
             {/* Changes autosave; new-password secrets keep the browser from autofilling the admin's login */}
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-1.5">
-                <Label>{t({ en: 'Delivery method', fr: "Méthode d'envoi" })}</Label>
+                <Label>{t({ en: 'Delivery method', es: 'Método de envío', fr: "Méthode d'envoi" })}</Label>
                 <SegmentedControl<MailTransport>
-                  ariaLabel={t({ en: 'Delivery method', fr: "Méthode d'envoi" })}
+                  ariaLabel={t({ en: 'Delivery method', es: 'Método de envío', fr: "Méthode d'envoi" })}
                   className="w-full max-w-md"
                   options={[
                     { label: 'SMTP', value: 'smtp' },
-                    { label: t({ en: 'HTTP API', fr: 'API HTTP' }), value: 'http' }
+                    { label: t({ en: 'HTTP API', es: 'API HTTP', fr: 'API HTTP' }), value: 'http' }
                   ]}
                   value={values.transport}
                   onChange={(value) => set('transport', value)}
@@ -541,7 +562,7 @@ const MailManager = ({
               {isHttp ? (
                 <React.Fragment>
                   <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="mail-provider">{t({ en: 'Provider', fr: 'Fournisseur' })}</Label>
+                    <Label htmlFor="mail-provider">{t({ en: 'Provider', es: 'Proveedor', fr: 'Fournisseur' })}</Label>
                     <Select
                       value={values.provider}
                       onValueChange={(value) => set('provider', $MailProvider.parse(value))}
@@ -563,10 +584,11 @@ const MailManager = ({
                       <Field
                         description={t({
                           en: 'The domain you send from in Mailgun (e.g. mg.example.org) — not the API base URL.',
+                          es: 'El dominio desde el que envía en Mailgun (p. ej. mg.example.org) — no la URL base de la API.',
                           fr: "Le domaine d'envoi configuré dans Mailgun (p. ex. mg.example.org) — pas l'URL de base de l'API."
                         })}
                         htmlFor="mail-domain"
-                        label={t({ en: 'Sending domain', fr: "Domaine d'envoi" })}
+                        label={t({ en: 'Sending domain', es: 'Dominio de envío', fr: "Domaine d'envoi" })}
                       >
                         <Input
                           autoComplete="off"
@@ -579,7 +601,7 @@ const MailManager = ({
                       </Field>
 
                       <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="mail-region">{t({ en: 'Region', fr: 'Région' })}</Label>
+                        <Label htmlFor="mail-region">{t({ en: 'Region', es: 'Región', fr: 'Région' })}</Label>
                         <Select
                           value={values.region}
                           onValueChange={(value) => set('region', $MailRegion.parse(value))}
@@ -588,8 +610,8 @@ const MailManager = ({
                             <Select.Value />
                           </Select.Trigger>
                           <Select.Content>
-                            <Select.Item value="us">{t({ en: 'US', fr: 'États-Unis' })}</Select.Item>
-                            <Select.Item value="eu">{t({ en: 'EU', fr: 'Europe' })}</Select.Item>
+                            <Select.Item value="us">{t({ en: 'US', es: 'EE. UU.', fr: 'États-Unis' })}</Select.Item>
+                            <Select.Item value="eu">{t({ en: 'EU', es: 'UE', fr: 'Europe' })}</Select.Item>
                           </Select.Content>
                         </Select>
                       </div>
@@ -601,10 +623,11 @@ const MailManager = ({
                       <Field
                         description={t({
                           en: 'The AWS region your SES account sends from (e.g. us-east-1).',
+                          es: 'La región de AWS desde la que envía su cuenta SES (p. ej. us-east-1).',
                           fr: 'La région AWS depuis laquelle votre compte SES envoie (p. ex. us-east-1).'
                         })}
                         htmlFor="mail-aws-region"
-                        label={t({ en: 'AWS region', fr: 'Région AWS' })}
+                        label={t({ en: 'AWS region', es: 'Región de AWS', fr: 'Région AWS' })}
                       >
                         <Input
                           autoComplete="off"
@@ -620,6 +643,7 @@ const MailManager = ({
                         htmlFor="mail-aws-access-key-id"
                         label={t({
                           en: 'AWS access key ID',
+                          es: 'ID de clave de acceso de AWS',
                           fr: "Identifiant de clé d'accès AWS"
                         })}
                       >
@@ -637,7 +661,7 @@ const MailManager = ({
                 </React.Fragment>
               ) : (
                 <React.Fragment>
-                  <Field htmlFor="mail-host" label={t({ en: 'Host', fr: 'Hôte' })}>
+                  <Field htmlFor="mail-host" label={t({ en: 'Host', es: 'Host', fr: 'Hôte' })}>
                     <Input
                       autoComplete="off"
                       id="mail-host"
@@ -650,11 +674,14 @@ const MailManager = ({
 
                   <div className="flex flex-col gap-1.5">
                     <div className="flex items-center gap-1.5">
-                      <Label htmlFor="mail-encryption">{t({ en: 'Encryption', fr: 'Chiffrement' })}</Label>
+                      <Label htmlFor="mail-encryption">
+                        {t({ en: 'Encryption', es: 'Cifrado', fr: 'Chiffrement' })}
+                      </Label>
                       <Tooltip>
                         <Tooltip.Trigger
                           aria-label={t({
                             en: 'About encryption options',
+                            es: 'Acerca de las opciones de cifrado',
                             fr: 'À propos des options de chiffrement'
                           })}
                           className="text-muted-foreground h-5 w-5 rounded-full p-0"
@@ -668,12 +695,14 @@ const MailManager = ({
                           <span>
                             {t({
                               en: 'STARTTLS (default port 587) is the modern default and recommended for most setups — it upgrades a plain connection to an encrypted one and has the best compatibility.',
+                              es: 'STARTTLS (puerto predeterminado 587) es el estándar moderno y recomendado para la mayoría de las configuraciones — actualiza una conexión simple a una cifrada y tiene la mejor compatibilidad.',
                               fr: 'STARTTLS (port par défaut 587) est la valeur par défaut moderne et recommandée — elle convertit une connexion en clair en connexion chiffrée et offre la meilleure compatibilité.'
                             })}
                           </span>
                           <span>
                             {t({
                               en: 'SSL/TLS (default port 465) is encrypted from the start, used by some providers and legacy systems. If unsure, choose STARTTLS.',
+                              es: 'SSL/TLS (puerto predeterminado 465) está cifrado desde el inicio, utilizado por algunos proveedores y sistemas heredados. En caso de duda, elija STARTTLS.',
                               fr: 'SSL/TLS (port par défaut 465) est chiffré dès le départ, utilisé par certains fournisseurs et systèmes hérités. En cas de doute, choisissez STARTTLS.'
                             })}
                           </span>
@@ -690,7 +719,7 @@ const MailManager = ({
                       <Select.Content>
                         <Select.Item value="starttls">STARTTLS</Select.Item>
                         <Select.Item value="ssl">SSL/TLS</Select.Item>
-                        <Select.Item value="none">{t({ en: 'None', fr: 'Aucun' })}</Select.Item>
+                        <Select.Item value="none">{t({ en: 'None', es: 'Ninguno', fr: 'Aucun' })}</Select.Item>
                       </Select.Content>
                     </Select>
                   </div>
@@ -698,10 +727,11 @@ const MailManager = ({
                   <Field
                     description={t({
                       en: `Suggested port for ${values.encryption.toUpperCase()}: ${PORT_DEFAULTS[values.encryption]}`,
+                      es: `Puerto sugerido para ${values.encryption.toUpperCase()}: ${PORT_DEFAULTS[values.encryption]}`,
                       fr: `Port suggéré pour ${values.encryption.toUpperCase()} : ${PORT_DEFAULTS[values.encryption]}`
                     })}
                     htmlFor="mail-port"
-                    label={t({ en: 'Port', fr: 'Port' })}
+                    label={t({ en: 'Port', es: 'Puerto', fr: 'Port' })}
                   >
                     <Input
                       autoComplete="off"
@@ -714,7 +744,10 @@ const MailManager = ({
                     />
                   </Field>
 
-                  <Field htmlFor="mail-username" label={t({ en: 'Username', fr: "Nom d'utilisateur" })}>
+                  <Field
+                    htmlFor="mail-username"
+                    label={t({ en: 'Username', es: 'Nombre de usuario', fr: "Nom d'utilisateur" })}
+                  >
                     <Input
                       autoComplete="off"
                       id="mail-username"
@@ -732,6 +765,7 @@ const MailManager = ({
                     config?.hasApiKey
                       ? t({
                           en: 'A secret is set (shown masked). Edit the field to replace it.',
+                          es: 'Se ha establecido un secreto (se muestra enmascarado). Edite el campo para reemplazarlo.',
                           fr: 'Un secret est défini (affiché masqué). Modifiez le champ pour le remplacer.'
                         })
                       : undefined
@@ -756,12 +790,13 @@ const MailManager = ({
                     config?.hasPassword
                       ? t({
                           en: 'A password is set (shown masked). Edit the field to replace it.',
+                          es: 'Se ha establecido una contraseña (se muestra enmascarada). Edite el campo para reemplazarla.',
                           fr: 'Un mot de passe est défini (affiché masqué). Modifiez le champ pour le remplacer.'
                         })
                       : undefined
                   }
                   htmlFor="mail-secret"
-                  label={t({ en: 'Password', fr: 'Mot de passe' })}
+                  label={t({ en: 'Password', es: 'Contraseña', fr: 'Mot de passe' })}
                 >
                   <Input
                     data-1p-ignore
@@ -776,7 +811,10 @@ const MailManager = ({
                 </Field>
               )}
 
-              <Field htmlFor="mail-sender-name" label={t({ en: 'Sender name', fr: "Nom de l'expéditeur" })}>
+              <Field
+                htmlFor="mail-sender-name"
+                label={t({ en: 'Sender name', es: 'Nombre del remitente', fr: "Nom de l'expéditeur" })}
+              >
                 <Input
                   autoComplete="off"
                   id="mail-sender-name"
@@ -786,7 +824,10 @@ const MailManager = ({
                 />
               </Field>
 
-              <Field htmlFor="mail-sender-address" label={t({ en: 'Sender address', fr: "Adresse de l'expéditeur" })}>
+              <Field
+                htmlFor="mail-sender-address"
+                label={t({ en: 'Sender address', es: 'Dirección del remitente', fr: "Adresse de l'expéditeur" })}
+              >
                 <Input
                   autoComplete="off"
                   id="mail-sender-address"
@@ -803,6 +844,7 @@ const MailManager = ({
             <Heading className="mb-5" variant="h4">
               {t({
                 en: 'Verify Your Configuration',
+                es: 'Verifique su configuración',
                 fr: 'Vérifiez votre configuration'
               })}
             </Heading>
@@ -810,10 +852,11 @@ const MailManager = ({
             <div className="flex flex-col gap-5">
               <div className="flex flex-col items-start gap-2">
                 <div>
-                  <p className="text-sm font-medium">{t({ en: 'Connection', fr: 'Connexion' })}</p>
+                  <p className="text-sm font-medium">{t({ en: 'Connection', es: 'Conexión', fr: 'Connexion' })}</p>
                   <p className="text-muted-foreground text-xs">
                     {t({
                       en: 'Check that the server accepts the connection and your credentials.',
+                      es: 'Verifique que el servidor acepta la conexión y sus credenciales.',
                       fr: 'Vérifiez que le serveur accepte la connexion et vos identifiants.'
                     })}
                   </p>
@@ -826,8 +869,8 @@ const MailManager = ({
                 >
                   {testingMode === 'connection' && <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />}
                   {testingMode === 'connection'
-                    ? t({ en: 'Testing…', fr: 'Test en cours…' })
-                    : t({ en: 'Test connection', fr: 'Tester la connexion' })}
+                    ? t({ en: 'Testing…', es: 'Probando…', fr: 'Test en cours…' })
+                    : t({ en: 'Test connection', es: 'Probar conexión', fr: 'Tester la connexion' })}
                 </Button>
               </div>
 
@@ -836,11 +879,12 @@ const MailManager = ({
               <div className="flex flex-col items-start gap-2">
                 <div>
                   <p className="text-sm font-medium">
-                    {t({ en: 'Send test email', fr: 'Envoyer un courriel de test' })}
+                    {t({ en: 'Send test email', es: 'Enviar correo de prueba', fr: 'Envoyer un courriel de test' })}
                   </p>
                   <p className="text-muted-foreground text-xs">
                     {t({
                       en: 'Deliver a real message to confirm everything works end to end.',
+                      es: 'Envíe un mensaje real para confirmar que todo funciona de extremo a extremo.',
                       fr: 'Envoyez un message réel pour confirmer que tout fonctionne de bout en bout.'
                     })}
                   </p>
@@ -852,6 +896,7 @@ const MailManager = ({
                   name="odc-smtp-test-recipient"
                   placeholder={t({
                     en: 'recipient@example.org',
+                    es: 'destinatario@ejemplo.org',
                     fr: 'destinataire@exemple.org'
                   })}
                   type="email"
@@ -866,8 +911,8 @@ const MailManager = ({
                 >
                   {testingMode === 'email' && <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />}
                   {testingMode === 'email'
-                    ? t({ en: 'Sending…', fr: 'Envoi en cours…' })
-                    : t({ en: 'Send test email', fr: 'Envoyer un courriel de test' })}
+                    ? t({ en: 'Sending…', es: 'Enviando…', fr: 'Envoi en cours…' })
+                    : t({ en: 'Send test email', es: 'Enviar correo de prueba', fr: 'Envoyer un courriel de test' })}
                 </Button>
               </div>
             </div>
@@ -878,6 +923,7 @@ const MailManager = ({
               <Heading variant="h4">
                 {t({
                   en: 'New User Email Template',
+                  es: 'Plantilla de correo para nuevos usuarios',
                   fr: 'Modèle de courriel pour les nouveaux utilisateurs'
                 })}
               </Heading>
@@ -893,12 +939,13 @@ const MailManager = ({
                   })
                 }
               >
-                {t({ en: 'Reset', fr: 'Réinitialiser' })}
+                {t({ en: 'Reset', es: 'Restablecer', fr: 'Réinitialiser' })}
               </Button>
             </div>
             <p className="text-muted-foreground mb-4 text-sm">
               {t({
                 en: 'Sent automatically when a new user with an email address is created. The sender chooses the language.',
+                es: 'Se envía automáticamente cuando se crea un nuevo usuario con dirección de correo electrónico. El remitente elige el idioma.',
                 fr: "Envoyé automatiquement lors de la création d'un nouvel utilisateur disposant d'une adresse courriel. L'expéditeur choisit la langue."
               })}
             </p>
@@ -906,13 +953,14 @@ const MailManager = ({
               <p className="mb-6 text-sm font-medium text-amber-600 dark:text-amber-400">
                 {t({
                   en: 'Remember to update the template in all active languages, not only the one currently selected.',
+                  es: 'Recuerde actualizar la plantilla en todos los idiomas activos, no solo en el seleccionado actualmente.',
                   fr: 'N’oubliez pas de mettre à jour le modèle dans toutes les langues actives, pas seulement celle actuellement sélectionnée.'
                 })}
               </p>
             )}
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-1.5">
-                <Label>{t({ en: 'Language', fr: 'Langue' })}</Label>
+                <Label>{t({ en: 'Language', es: 'Idioma', fr: 'Langue' })}</Label>
                 <Select value={templateLang} onValueChange={(v) => setTemplateLang($MailLanguage.parse(v))}>
                   <Select.Trigger className="w-[180px] border-sky-700 bg-sky-700 text-white hover:bg-sky-800 dark:border-sky-700 dark:bg-sky-700 dark:text-white dark:hover:bg-sky-800">
                     <Select.Value />
@@ -928,7 +976,7 @@ const MailManager = ({
                   </Select.Content>
                 </Select>
               </div>
-              <Field htmlFor="template-subject" label={t({ en: 'Subject', fr: 'Objet' })}>
+              <Field htmlFor="template-subject" label={t({ en: 'Subject', es: 'Asunto', fr: 'Objet' })}>
                 <Input
                   id="template-subject"
                   value={template.subject[templateLang] ?? ''}
@@ -942,9 +990,11 @@ const MailManager = ({
               </Field>
               <div className="flex flex-col gap-1.5">
                 <div className="flex flex-wrap items-center justify-between gap-2">
-                  <Label htmlFor="template-body">{t({ en: 'Body', fr: 'Corps' })}</Label>
+                  <Label htmlFor="template-body">{t({ en: 'Body', es: 'Cuerpo', fr: 'Corps' })}</Label>
                   <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-muted-foreground text-xs">{t({ en: 'Insert:', fr: 'Insérer :' })}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {t({ en: 'Insert:', es: 'Insertar:', fr: 'Insérer :' })}
+                    </span>
                     {NEW_USER_VARS.map((variable) => (
                       <Button
                         className="h-6 px-2 font-mono text-xs"
@@ -1011,7 +1061,7 @@ const RouteComponent = () => {
     <div className="w-full">
       <PageHeader>
         <Heading className="text-center" variant="h2">
-          {t({ en: 'Mail Server', fr: 'Serveur de courriel' })}
+          {t({ en: 'Mail Server', es: 'Servidor de correo', fr: 'Serveur de courriel' })}
         </Heading>
       </PageHeader>
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">

--- a/apps/web/src/routes/_app/admin/settings.tsx
+++ b/apps/web/src/routes/_app/admin/settings.tsx
@@ -1,17 +1,20 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import { Button, Card, Heading, HoverCard, Select } from '@douglasneuroinformatics/libui/components';
-import { useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { Card, Checkbox, Heading, HoverCard, Select } from '@douglasneuroinformatics/libui/components';
+import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { i18n } from '@douglasneuroinformatics/libui/i18n';
+import type { Language } from '@douglasneuroinformatics/libui/i18n';
 import { createFileRoute } from '@tanstack/react-router';
 import { CircleHelpIcon } from 'lucide-react';
 
 import { PageHeader } from '@/components/PageHeader';
+import { SaveStatus } from '@/components/SaveStatus';
 import { useSetupStateQuery } from '@/hooks/useSetupStateQuery';
 import { useUpdateSetupStateMutation } from '@/hooks/useUpdateSetupStateMutation';
 import { useAppStore } from '@/store';
 import type { GroupSwitcherPosition } from '@/store/types';
+import { ALL_LANGUAGES } from '@/utils/languages';
 
-/** libui ships no Switch, so this is hand-rolled — `label` names it for assistive technology. */
 const Toggle = ({
   checked,
   label,
@@ -39,33 +42,29 @@ const RouteComponent = () => {
   const { t } = useTranslation();
   const setupStateQuery = useSetupStateQuery();
   const updateSetupStateMutation = useUpdateSetupStateMutation();
-  const addNotification = useNotificationsStore((store) => store.addNotification);
   const groupSwitcherPosition = useAppStore((store) => store.groupSwitcherPosition);
   const setGroupSwitcherPosition = useAppStore((store) => store.setGroupSwitcherPosition);
 
-  const uploaderLabel = t({ en: 'Enable Uploader', fr: 'Activer le téléversement' });
+  const [saveState, setSaveState] = React.useState<'idle' | 'saved' | 'saving'>('idle');
+  const savedTimerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // The toggle is staged locally until Save, so it holds its own state. Resync it whenever the server
-  // value changes underneath — saving invalidates the query, and the response is the authority on what
-  // was actually stored.
-  const savedUploaderEnabled = setupStateQuery.data.isExperimentalFeaturesEnabled ?? false;
-  const [uploaderEnabled, setUploaderEnabled] = useState(savedUploaderEnabled);
-  const [syncedUploaderEnabled, setSyncedUploaderEnabled] = useState(savedUploaderEnabled);
-  if (syncedUploaderEnabled !== savedUploaderEnabled) {
-    setSyncedUploaderEnabled(savedUploaderEnabled);
-    setUploaderEnabled(savedUploaderEnabled);
-  }
-
-  const handleSave = () => {
-    updateSetupStateMutation.mutate(
-      { isExperimentalFeaturesEnabled: uploaderEnabled },
-      {
-        onSuccess: () => {
-          addNotification({ type: 'success' });
+  const autosave = React.useCallback(
+    (data: Parameters<typeof updateSetupStateMutation.mutate>[0]) => {
+      setSaveState('saving');
+      updateSetupStateMutation.mutate(data, {
+        onSettled: () => {
+          setSaveState('saved');
+          clearTimeout(savedTimerRef.current);
+          savedTimerRef.current = setTimeout(() => setSaveState('idle'), 2000);
         }
-      }
-    );
-  };
+      });
+    },
+    [updateSetupStateMutation]
+  );
+
+  const uploaderLabel = t({ en: 'Enable Uploader', es: 'Activar carga de datos', fr: 'Activer le téléversement' });
+  const uploaderEnabled = setupStateQuery.data.isExperimentalFeaturesEnabled ?? false;
+  const activeLanguages = setupStateQuery.data.activeLanguages ?? ['en', 'fr'];
 
   return (
     <React.Fragment>
@@ -73,6 +72,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Application Settings',
+            es: 'Configuración de la aplicación',
             fr: "Paramètres de l'application"
           })}
         </Heading>
@@ -80,7 +80,9 @@ const RouteComponent = () => {
       <div className="mx-auto max-w-4xl">
         <Card>
           <Card.Header>
-            <Card.Title className="text-lg font-bold">{t({ en: 'Features', fr: 'Fonctionnalités' })}</Card.Title>
+            <Card.Title className="text-lg font-bold">
+              {t({ en: 'Features', es: 'Funcionalidades', fr: 'Fonctionnalités' })}
+            </Card.Title>
           </Card.Header>
           <Card.Content>
             <div className="flex items-center justify-between">
@@ -95,28 +97,29 @@ const RouteComponent = () => {
                   <HoverCard.Content className="w-72 text-sm">
                     {t({
                       en: 'When enabled, an upload menu item appears in the sidebar that allows users to upload instrument records directly from data files, bypassing the normal session workflow.',
+                      es: 'Cuando está activada, aparece un elemento de menú de carga en la barra lateral que permite a los usuarios cargar registros de instrumentos directamente desde archivos de datos, omitiendo el flujo de trabajo normal de sesión.',
                       fr: "Lorsqu'elle est activée, un élément de menu Téléversement apparaît dans le menu latéral et permet aux utilisateurs de téléverser des enregistrements d'instruments directement à partir de fichiers de données."
                     })}
                   </HoverCard.Content>
                 </HoverCard>
               </div>
-              <Toggle checked={uploaderEnabled} label={uploaderLabel} onCheckedChange={setUploaderEnabled} />
+              <Toggle
+                checked={uploaderEnabled}
+                label={uploaderLabel}
+                onCheckedChange={(checked) => autosave({ isExperimentalFeaturesEnabled: checked })}
+              />
             </div>
           </Card.Content>
-          <Card.Footer className="justify-end">
-            <Button disabled={updateSetupStateMutation.isPending} onClick={handleSave}>
-              {t({ en: 'Save', fr: 'Enregistrer' })}
-            </Button>
-          </Card.Footer>
         </Card>
-        {/* A separate card because these settings are not the instance's: they live in this browser and
-            apply instantly, so they are deliberately outside the Save button's scope above. */}
         <Card className="mt-6">
           <Card.Header>
-            <Card.Title className="text-lg font-bold">{t({ en: 'Preferences', fr: 'Préférences' })}</Card.Title>
+            <Card.Title className="text-lg font-bold">
+              {t({ en: 'Preferences', es: 'Preferencias', fr: 'Préférences' })}
+            </Card.Title>
             <Card.Description>
               {t({
                 en: 'Saved in this browser and applied immediately. They affect only you, not other users of this instance.',
+                es: 'Guardadas en este navegador y aplicadas inmediatamente. Solo le afectan a usted, no a otros usuarios de esta instancia.',
                 fr: 'Enregistrées dans ce navigateur et appliquées immédiatement. Elles ne concernent que vous, et non les autres utilisateurs de cette instance.'
               })}
             </Card.Description>
@@ -124,7 +127,11 @@ const RouteComponent = () => {
           <Card.Content>
             <div className="flex items-center justify-between gap-4">
               <p className="text-sm font-medium">
-                {t({ en: 'Group Switcher Position', fr: 'Position du sélecteur de groupe' })}
+                {t({
+                  en: 'Group Switcher Position',
+                  es: 'Posición del selector de grupo',
+                  fr: 'Position du sélecteur de groupe'
+                })}
               </p>
               <Select
                 value={groupSwitcherPosition}
@@ -135,9 +142,11 @@ const RouteComponent = () => {
                 </Select.Trigger>
                 <Select.Content>
                   <Select.Group>
-                    <Select.Item value="sidebar">{t({ en: 'Sidebar Menu', fr: 'Menu latéral' })}</Select.Item>
+                    <Select.Item value="sidebar">
+                      {t({ en: 'Sidebar Menu', es: 'Menú lateral', fr: 'Menu latéral' })}
+                    </Select.Item>
                     <Select.Item value="topbar">
-                      {t({ en: 'Top Right Corner', fr: 'Coin supérieur droit' })}
+                      {t({ en: 'Top Right Corner', es: 'Esquina superior derecha', fr: 'Coin supérieur droit' })}
                     </Select.Item>
                   </Select.Group>
                 </Select.Content>
@@ -145,7 +154,50 @@ const RouteComponent = () => {
             </div>
           </Card.Content>
         </Card>
+        <Card className="mt-6">
+          <Card.Header>
+            <Card.Title className="text-lg font-bold">
+              {t({ en: 'Languages', es: 'Idiomas', fr: 'Langues' })}
+            </Card.Title>
+            <Card.Description>
+              {t({
+                en: 'Select which languages are available across the application. At least one language must remain active.',
+                es: 'Seleccione qué idiomas están disponibles en la aplicación. Al menos un idioma debe permanecer activo.',
+                fr: "Sélectionnez les langues disponibles dans l'application. Au moins une langue doit rester active."
+              })}
+            </Card.Description>
+          </Card.Header>
+          <Card.Content>
+            <div className="flex flex-col gap-3">
+              {Object.entries(ALL_LANGUAGES).map(([code, name]) => {
+                const isActive = activeLanguages.includes(code);
+                const isLastActive = isActive && activeLanguages.length === 1;
+                return (
+                  <label className="flex items-center gap-3" key={code}>
+                    <Checkbox
+                      checked={isActive}
+                      disabled={isLastActive}
+                      onCheckedChange={(checked) => {
+                        const updated = checked
+                          ? [...activeLanguages, code]
+                          : activeLanguages.filter((l) => l !== code);
+                        if (updated.length > 0) {
+                          autosave({ activeLanguages: updated });
+                          if (!updated.includes(i18n.resolvedLanguage)) {
+                            i18n.changeLanguage(updated[0]! as Language);
+                          }
+                        }
+                      }}
+                    />
+                    <span className="text-sm font-medium">{name}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </Card.Content>
+        </Card>
       </div>
+      <SaveStatus state={saveState} />
     </React.Fragment>
   );
 };

--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -74,6 +74,7 @@ const RouteComponent = () => {
             ? t(PASSWORD_ERROR_TRANSLATION_KEYS[code])
             : t({
                 en: 'Failed to create user',
+                es: 'Error al crear el usuario',
                 fr: "Échec de la création de l'utilisateur"
               }),
           type: 'error'
@@ -82,6 +83,7 @@ const RouteComponent = () => {
         notification.addNotification({
           message: t({
             en: 'Failed to create user',
+            es: 'Error al crear el usuario',
             fr: "Échec de la création de l'utilisateur"
           }),
           type: 'error'
@@ -97,10 +99,12 @@ const RouteComponent = () => {
         notification.addNotification({
           message: t({
             en: `A welcome email was sent to ${welcomeEmail.recipient ?? ''}`,
+            es: `Se envió un correo de bienvenida a ${welcomeEmail.recipient ?? ''}`,
             fr: `Un courriel de bienvenue a été envoyé à ${welcomeEmail.recipient ?? ''}`
           }),
           title: t({
             en: 'Welcome email sent',
+            es: 'Correo de bienvenida enviado',
             fr: 'Courriel de bienvenue envoyé'
           }),
           type: 'success'
@@ -115,10 +119,12 @@ const RouteComponent = () => {
               welcomeEmail.error ??
               t({
                 en: 'The welcome email could not be sent',
+                es: 'No se pudo enviar el correo de bienvenida',
                 fr: "Le courriel de bienvenue n'a pas pu être envoyé"
               }),
             title: t({
               en: 'Welcome email failed',
+              es: 'Error en el correo de bienvenida',
               fr: 'Échec du courriel de bienvenue'
             }),
             type: 'error'
@@ -137,6 +143,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Add User',
+            es: 'Agregar usuario',
             fr: 'Ajouter un utilisateur'
           })}
         </Heading>
@@ -146,6 +153,7 @@ const RouteComponent = () => {
           <Label>
             {t({
               en: 'Welcome email language',
+              es: 'Idioma del correo de bienvenida',
               fr: 'Langue du courriel de bienvenue'
             })}
           </Label>
@@ -191,6 +199,7 @@ const RouteComponent = () => {
             },
             title: t({
               en: 'Login Credentials',
+              es: 'Credenciales de inicio de sesión',
               fr: 'Identifiants de connexion'
             })
           },
@@ -209,12 +218,14 @@ const RouteComponent = () => {
             },
             title: t({
               en: 'Contact information',
+              es: 'Información de contacto',
               fr: 'Coordonnées'
             })
           },
           {
             title: t({
               en: 'Permissions',
+              es: 'Permisos',
               fr: 'Autorisations'
             }),
             fields: {
@@ -232,10 +243,12 @@ const RouteComponent = () => {
                 kind: 'boolean',
                 description: t({
                   en: 'Use this option if the user is not intended to log in, for example, when the account is used solely to identify the author of uploaded data.',
+                  es: 'Use esta opción si el usuario no está destinado a iniciar sesión, por ejemplo, cuando la cuenta se usa únicamente para identificar al autor de los datos cargados.',
                   fr: "Utilisez cette option si l'utilisateur n'a pas vocation à se connecter, par exemple lorsque le compte sert uniquement à identifier l'auteur de données téléversées."
                 }),
                 label: t({
                   en: 'Disabled',
+                  es: 'Desactivado',
                   fr: 'Désactivé'
                 }),
                 variant: 'radio'
@@ -285,6 +298,7 @@ const RouteComponent = () => {
             },
             title: t({
               en: 'Additional Information',
+              es: 'Información adicional',
               fr: 'Informations supplémentaires'
             })
           }
@@ -336,6 +350,7 @@ const RouteComponent = () => {
                 input: ctx.value.phoneNumber,
                 message: t({
                   en: 'Invalid Phone number',
+                  es: 'Número de teléfono inválido',
                   fr: 'Numéro de téléphone invalide'
                 }),
                 path: ['phoneNumber']
@@ -355,10 +370,13 @@ const RouteComponent = () => {
       >
         <Dialog.Content className="max-w-lg">
           <Dialog.Header>
-            <Dialog.Title>{t({ en: 'Welcome message', fr: 'Message de bienvenue' })}</Dialog.Title>
+            <Dialog.Title>
+              {t({ en: 'Welcome message', es: 'Mensaje de bienvenida', fr: 'Message de bienvenue' })}
+            </Dialog.Title>
             <Dialog.Description>
               {t({
                 en: 'The welcome email could not be delivered automatically. Copy the message below and send it to the user manually.',
+                es: 'El correo de bienvenida no pudo ser entregado automáticamente. Copie el mensaje a continuación y envíelo manualmente al usuario.',
                 fr: "Le courriel de bienvenue n'a pas pu être livré automatiquement. Copiez le message ci-dessous et envoyez-le manuellement à l'utilisateur."
               })}
             </Dialog.Description>
@@ -375,7 +393,7 @@ const RouteComponent = () => {
                 void navigate({ to: '..' });
               }}
             >
-              {t({ en: 'Done', fr: 'Terminé' })}
+              {t({ en: 'Done', es: 'Listo', fr: 'Terminé' })}
             </Button>
           </Dialog.Footer>
         </Dialog.Content>

--- a/apps/web/src/routes/_app/admin/users/index.tsx
+++ b/apps/web/src/routes/_app/admin/users/index.tsx
@@ -99,6 +99,7 @@ const UpdateUserForm: React.FC<{
             input: ctx.value.confirmPassword,
             message: t({
               en: 'Standard user must be part of a group',
+              es: 'Un usuario estándar debe ser parte de un grupo',
               fr: "Un utilisateur standard doit faire partie d'un groupe"
             }),
             path: ['groupIds']
@@ -149,6 +150,7 @@ const UpdateUserForm: React.FC<{
             },
             title: t({
               en: 'Login Credentials',
+              es: 'Credenciales de inicio de sesión',
               fr: 'Identifiants de connexion'
             })
           },
@@ -167,12 +169,14 @@ const UpdateUserForm: React.FC<{
             },
             title: t({
               en: 'Update Contact Information',
+              es: 'Actualizar información de contacto',
               fr: 'Mettre à jour les coordonnées'
             })
           },
           {
             description: t({
               en: 'IMPORTANT: These permissions are not specific to any group. To manage granular permissions, please use the API.',
+              es: 'IMPORTANTE: Estos permisos no son específicos de ningún grupo. Para gestionar permisos granulares, utilice la API.',
               fr: "IMPORTANT : Ces autorisations ne sont pas spécifiques à un groupe. Pour gérer des autorisations granulaires, veuillez utiliser l'API."
             }),
             fields: {
@@ -182,27 +186,33 @@ const UpdateUserForm: React.FC<{
                     kind: 'string',
                     label: t({
                       en: 'Action',
+                      es: 'Acción',
                       fr: 'Action'
                     }),
                     options: {
                       create: t({
                         en: 'Create',
+                        es: 'Crear',
                         fr: 'Créer'
                       }),
                       delete: t({
                         en: 'Delete',
+                        es: 'Eliminar',
                         fr: 'Supprimer'
                       }),
                       manage: t({
                         en: 'Manage (All)',
+                        es: 'Gestionar (Todo)',
                         fr: 'Gérer (Tout)'
                       }),
                       read: t({
                         en: 'Read',
+                        es: 'Leer',
                         fr: 'Lire'
                       }),
                       update: t({
                         en: 'Update',
+                        es: 'Actualizar',
                         fr: 'Modifier'
                       })
                     },
@@ -212,43 +222,53 @@ const UpdateUserForm: React.FC<{
                     kind: 'string',
                     label: t({
                       en: 'Resource',
+                      es: 'Recurso',
                       fr: 'Ressource'
                     }),
                     options: {
                       all: t({
                         en: 'All',
+                        es: 'Todos',
                         fr: 'Tous'
                       }),
                       Assignment: t({
                         en: 'Assignment',
+                        es: 'Asignación',
                         fr: 'Assignation'
                       }),
                       Group: t({
                         en: 'Group',
+                        es: 'Grupo',
                         fr: 'Groupe'
                       }),
                       Instrument: t({
                         en: 'Instrument',
+                        es: 'Instrumento',
                         fr: 'Instrument'
                       }),
                       InstrumentRecord: t({
                         en: 'Instrument Record',
+                        es: 'Registro de instrumento',
                         fr: "Enregistrement de l'instrument"
                       }),
                       InstrumentRepo: t({
                         en: 'Instrument Repository',
+                        es: 'Repositorio de instrumentos',
                         fr: "Dépôt d'instruments"
                       }),
                       Session: t({
                         en: 'Session',
+                        es: 'Sesión',
                         fr: 'Session'
                       }),
                       Subject: t({
                         en: 'Subject',
+                        es: 'Sujeto',
                         fr: 'Client'
                       }),
                       User: t({
                         en: 'User',
+                        es: 'Usuario',
                         fr: 'Utilisateur'
                       })
                     },
@@ -258,17 +278,20 @@ const UpdateUserForm: React.FC<{
                 kind: 'record-array',
                 label: t({
                   en: 'Permission',
+                  es: 'Permiso',
                   fr: 'Autorisation'
                 })
               },
               disabled: {
                 description: t({
                   en: 'Use this option if the user is not intended to log in, for example, when the account is used solely to identify the author of uploaded data.',
-                  fr: 'Utilisez cette option si l’utilisateur n’a pas vocation à se connecter, par exemple lorsque le compte sert uniquement à identifier l’auteur de données téléversées.'
+                  es: 'Use esta opción si el usuario no está destinado a iniciar sesión, por ejemplo, cuando la cuenta se usa únicamente para identificar al autor de los datos cargados.',
+                  fr: "Utilisez cette option si l'utilisateur n'a pas vocation à se connecter, par exemple lorsque le compte sert uniquement à identifier l'auteur de données téléversées."
                 }),
                 kind: 'boolean',
                 label: t({
                   en: 'Disabled',
+                  es: 'Desactivado',
                   fr: 'Désactivé'
                 }),
                 variant: 'radio'
@@ -276,6 +299,7 @@ const UpdateUserForm: React.FC<{
             },
             title: t({
               en: 'Authorization',
+              es: 'Autorización',
               fr: 'Autorisation'
             })
           },
@@ -290,6 +314,7 @@ const UpdateUserForm: React.FC<{
             },
             title: t({
               en: 'Groups',
+              es: 'Grupos',
               fr: 'Groupes'
             })
           }
@@ -311,12 +336,14 @@ const UpdateUserForm: React.FC<{
           <Dialog.Title>
             {t({
               en: 'Are you absolutely sure?',
+              es: '¿Está completamente seguro?',
               fr: 'Êtes-vous absolument sûr ?'
             })}
           </Dialog.Title>
           <Dialog.Description>
             {t({
               en: 'This action will permanently delete the account and cannot be undone.',
+              es: 'Esta acción eliminará permanentemente la cuenta y no se puede deshacer.',
               fr: 'Cette action supprimera définitivement le compte et ne pourra pas être annulée.'
             })}
           </Dialog.Description>
@@ -377,6 +404,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Manage Users',
+            es: 'Administrar usuarios',
             fr: 'Gérer les utilisateurs'
           })}
         </Heading>
@@ -403,6 +431,7 @@ const RouteComponent = () => {
               if (!basePermissionLevel) {
                 return t({
                   en: 'None',
+                  es: 'Ninguno',
                   fr: 'Aucune'
                 });
               }
@@ -424,6 +453,7 @@ const RouteComponent = () => {
             <Link to="/admin/users/create">
               {t({
                 en: 'Add User',
+                es: 'Agregar usuario',
                 fr: 'Ajouter un utilisateur'
               })}
             </Link>
@@ -441,6 +471,7 @@ const RouteComponent = () => {
           <Sheet.Description>
             {t({
               en: 'Make changes to this user here. Click save when you are done.',
+              es: 'Realice cambios a este usuario aquí. Haga clic en guardar cuando haya terminado.',
               fr: 'Apportez des modifications à cet utilisateur ici. Cliquez sur « Enregistrer » lorsque vous avez terminé.'
             })}
           </Sheet.Description>

--- a/apps/web/src/routes/_app/dashboard.tsx
+++ b/apps/web/src/routes/_app/dashboard.tsx
@@ -120,16 +120,19 @@ const RouteComponent = () => {
   if (currentGroup?.type === 'CLINICAL') {
     welcome = t({
       en: 'Overview of Your Clinic',
+      es: 'Resumen de su clínica',
       fr: "Vue d'ensemble de votre clinique"
     });
   } else if (currentGroup?.type === 'RESEARCH') {
     welcome = t({
       en: 'Overview of Your Research Group',
+      es: 'Resumen de su grupo de investigación',
       fr: "Vue d'ensemble de votre groupe de recherche"
     });
   } else {
     welcome = t({
       en: 'Summary of Application State',
+      es: 'Resumen del estado de la aplicación',
       fr: "Résumé de l'état de l'application"
     });
   }
@@ -145,6 +148,7 @@ const RouteComponent = () => {
         <Heading variant="h2">
           {t({
             en: 'Dashboard',
+            es: 'Panel de control',
             fr: 'Tableau de bord'
           })}
         </Heading>
@@ -167,6 +171,7 @@ const RouteComponent = () => {
                     }
                     label={t({
                       en: 'Total Users',
+                      es: 'Total de usuarios',
                       fr: "Nombre d'utilisateurs"
                     })}
                     value={summaryQuery.data.counts.users}
@@ -177,6 +182,7 @@ const RouteComponent = () => {
                     <Dialog.Title>
                       {t({
                         en: 'Users',
+                        es: 'Usuarios',
                         fr: 'Utilisateurs'
                       })}
                     </Dialog.Title>
@@ -188,6 +194,7 @@ const RouteComponent = () => {
                       <p>
                         {t({
                           en: 'Error finding users',
+                          es: 'Error al buscar usuarios',
                           fr: "Erreur lors de la recherche d'utilisateurs"
                         })}
                       </p>
@@ -232,6 +239,7 @@ const RouteComponent = () => {
                 }
                 label={t({
                   en: 'Total Subjects',
+                  es: 'Total de sujetos',
                   fr: 'Nombre total de sujets'
                 })}
                 value={summaryQuery.data.counts.subjects}
@@ -249,6 +257,7 @@ const RouteComponent = () => {
                     }
                     label={t({
                       en: 'Total Instruments',
+                      es: 'Total de instrumentos',
                       fr: "Nombre d'instruments"
                     })}
                     value={summaryQuery.data.counts.instruments}
@@ -262,6 +271,7 @@ const RouteComponent = () => {
                     <Dialog.Title>
                       {t({
                         en: 'Available Instruments',
+                        es: 'Instrumentos disponibles',
                         fr: 'Instruments disponibles'
                       })}
                     </Dialog.Title>
@@ -271,6 +281,7 @@ const RouteComponent = () => {
                       <p>
                         {t({
                           en: 'Error finding instruments',
+                          es: 'Error al buscar instrumentos',
                           fr: 'Erreur lors de la recherche des instruments'
                         })}
                       </p>
@@ -281,10 +292,11 @@ const RouteComponent = () => {
                           <p>
                             {t({
                               en: 'Title',
+                              es: 'Título',
                               fr: 'Titre'
                             })}
                           </p>{' '}
-                          <p>{t({ en: 'Kind', fr: 'Type' })}</p>
+                          <p>{t({ en: 'Kind', es: 'Tipo', fr: 'Type' })}</p>
                         </div>
                         <hr></hr>
                         {instrumentInfo.map((instrument, i) => {
@@ -321,6 +333,7 @@ const RouteComponent = () => {
                     }
                     label={t({
                       en: 'Total Records',
+                      es: 'Total de registros',
                       fr: "Nombre d'enregistrements"
                     })}
                     value={summaryQuery.data.counts.records}
@@ -331,6 +344,7 @@ const RouteComponent = () => {
                     <Dialog.Title>
                       {t({
                         en: 'Number of Records',
+                        es: 'Número de registros',
                         fr: "Nombre d'enregistrements"
                       })}
                     </Dialog.Title>
@@ -340,6 +354,7 @@ const RouteComponent = () => {
                       <p>
                         {t({
                           en: 'Error finding records',
+                          es: 'Error al buscar registros',
                           fr: "Erreur lors de la recherche d'enregistrements"
                         })}
                       </p>
@@ -350,10 +365,11 @@ const RouteComponent = () => {
                           <p>
                             {t({
                               en: 'Title',
+                              es: 'Título',
                               fr: 'Titre'
                             })}
                           </p>{' '}
-                          <p>{t({ en: 'Number', fr: 'Nombre' })}</p>
+                          <p>{t({ en: 'Number', es: 'Número', fr: 'Nombre' })}</p>
                         </div>
                         <hr></hr>
                         {recordCounter.map((instrument, i) => {
@@ -394,12 +410,14 @@ const RouteComponent = () => {
                   <Heading className="text-slate-800 dark:text-slate-200" variant="h4">
                     {t({
                       en: 'Records & Sessions Trend',
+                      es: 'Tendencia de registros y sesiones',
                       fr: 'Tendance des enregistrements et des sessions'
                     })}
                   </Heading>
                   <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
                     {t({
                       en: 'Activity over time',
+                      es: 'Actividad a lo largo del tiempo',
                       fr: 'Activité au fil du temps'
                     })}
                   </p>
@@ -461,6 +479,7 @@ const RouteComponent = () => {
                               <p className="font-semibold text-blue-600 dark:text-blue-400">
                                 {t({
                                   en: 'Records',
+                                  es: 'Registros',
                                   fr: 'Enregistrements'
                                 })}
                                 : {payload.find((p) => p.dataKey === 'records')?.value ?? 0}
@@ -468,6 +487,7 @@ const RouteComponent = () => {
                               <p className="font-semibold text-emerald-600 dark:text-emerald-400">
                                 {t({
                                   en: 'Sessions',
+                                  es: 'Sesiones',
                                   fr: 'Sessions'
                                 })}
                                 : {payload.find((p) => p.dataKey === 'sessions')?.value ?? 0}
@@ -514,12 +534,14 @@ const RouteComponent = () => {
                   <Heading className="text-slate-800 dark:text-slate-200" variant="h4">
                     {t({
                       en: 'Subjects Growth',
+                      es: 'Crecimiento de sujetos',
                       fr: 'Croissance des sujets'
                     })}
                   </Heading>
                   <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
                     {t({
                       en: 'Growth trajectory',
+                      es: 'Trayectoria de crecimiento',
                       fr: 'Trajectoire de croissance'
                     })}
                   </p>
@@ -579,6 +601,7 @@ const RouteComponent = () => {
                             <p className="font-semibold text-amber-600 dark:text-amber-400">
                               {t({
                                 en: 'Subjects',
+                                es: 'Sujetos',
                                 fr: 'Sujets'
                               })}
                               : {payload[0]?.value}

--- a/apps/web/src/routes/_app/datahub/$subjectId/route.tsx
+++ b/apps/web/src/routes/_app/datahub/$subjectId/route.tsx
@@ -44,6 +44,7 @@ const RouteComponent = () => {
           {t(
             {
               en: 'Instrument Records for Subject {}',
+              es: 'Registros de instrumentos del sujeto {}',
               fr: "Dossiers d'instruments pour le client {}"
             },
             {

--- a/apps/web/src/routes/_app/datahub/$subjectId/table/$recordId.tsx
+++ b/apps/web/src/routes/_app/datahub/$subjectId/table/$recordId.tsx
@@ -44,6 +44,7 @@ const FileInstrumentRecordView = ({ instrument, record }: FileInstrumentRecordVi
       notifications.addNotification({
         message: t({
           en: 'An unexpected error occurred',
+          es: 'Ocurrió un error inesperado',
           fr: "Une erreur inattendue s'est produite"
         }),
         title: 'Error',
@@ -64,13 +65,16 @@ const FileInstrumentRecordView = ({ instrument, record }: FileInstrumentRecordVi
         <p className="text-muted-foreground text-sm">
           {t({
             en: `Completed on ${dateCompleted}`,
+            es: `Completado el ${dateCompleted}`,
             fr: `Remplie le ${dateCompleted}`
           })}
         </p>
       </header>
       {record.pending ? (
         <div className="rounded-md border border-dashed p-6 text-center">
-          <p className="text-muted-foreground text-sm">{t({ en: 'Upload pending', fr: 'Téléversement en attente' })}</p>
+          <p className="text-muted-foreground text-sm">
+            {t({ en: 'Upload pending', es: 'Carga pendiente', fr: 'Téléversement en attente' })}
+          </p>
         </div>
       ) : (
         <div className="space-y-6">
@@ -80,7 +84,9 @@ const FileInstrumentRecordView = ({ instrument, record }: FileInstrumentRecordVi
               <section className="space-y-2" key={fileGroup.basename}>
                 <Heading variant="h5">{fileGroup.label}</Heading>
                 {groupFiles.length === 0 ? (
-                  <p className="text-muted-foreground text-sm">{t({ en: 'No files', fr: 'Aucun fichier' })}</p>
+                  <p className="text-muted-foreground text-sm">
+                    {t({ en: 'No files', es: 'Sin archivos', fr: 'Aucun fichier' })}
+                  </p>
                 ) : (
                   <ul className="divide-y rounded-md border">
                     {groupFiles.map((file) => (
@@ -98,7 +104,7 @@ const FileInstrumentRecordView = ({ instrument, record }: FileInstrumentRecordVi
                           }}
                         >
                           <DownloadIcon className="mr-2 h-4 w-4" />
-                          {t({ en: 'Download', fr: 'Télécharger' })}
+                          {t({ en: 'Download', es: 'Descargar', fr: 'Télécharger' })}
                         </Button>
                       </li>
                     ))}

--- a/apps/web/src/routes/_app/datahub/index.tsx
+++ b/apps/web/src/routes/_app/datahub/index.tsx
@@ -162,6 +162,7 @@ const Filters: React.FC<{
           <DropdownMenu.Label>
             {t({
               en: 'Subjects with records',
+              es: 'Sujetos con registros',
               fr: 'Sujets avec enregistrements'
             })}
           </DropdownMenu.Label>
@@ -172,6 +173,7 @@ const Filters: React.FC<{
           >
             {t({
               en: 'With records only',
+              es: 'Solo con registros',
               fr: 'Avec enregistrements seulement'
             })}
           </DropdownMenu.CheckboxItem>
@@ -229,6 +231,7 @@ const Toggles: React.FC<{
     addNotification({
       message: t({
         en: 'Exporting entries, please wait...',
+        es: 'Exportando entradas, por favor espere...',
         fr: 'Téléchargement des entrées, veuillez patienter...'
       }),
       type: 'info'
@@ -247,7 +250,11 @@ const Toggles: React.FC<{
 
         if (filteredData.length < 1) {
           throw Error(
-            t({ en: 'Export failed: No entries to export', fr: "Échec de l'exportation : aucune entrée à exporter" })
+            t({
+              en: 'Export failed: No entries to export',
+              es: 'Error de exportación: no hay entradas para exportar',
+              fr: "Échec de l'exportation : aucune entrée à exporter"
+            })
           );
         }
 
@@ -267,7 +274,7 @@ const Toggles: React.FC<{
       })
       .then(() => {
         addNotification({
-          message: t({ en: 'Export successful', fr: 'Exportation réussie' }),
+          message: t({ en: 'Export successful', es: 'Exportación exitosa', fr: 'Exportation réussie' }),
           type: 'success'
         });
       })
@@ -280,7 +287,7 @@ const Toggles: React.FC<{
           });
         } else {
           addNotification({
-            message: t({ en: 'Export failed', fr: "Échec de l'exportation" }),
+            message: t({ en: 'Export failed', es: 'Error de exportación', fr: "Échec de l'exportation" }),
             type: 'error'
           });
         }
@@ -300,6 +307,7 @@ const Toggles: React.FC<{
           >
             {t({
               en: 'Subject Lookup',
+              es: 'Buscar sujeto',
               fr: 'Trouver un client'
             })}
             <UserSearchIcon style={{ strokeWidth: '2px' }} />
@@ -450,7 +458,7 @@ const MasterDataTable: React.FC<{
         }}
         rowActions={[
           {
-            label: t({ en: 'View', fr: 'Voir' }),
+            label: t({ en: 'View', es: 'Ver', fr: 'Voir' }),
             onSelect
           }
         ]}

--- a/apps/web/src/routes/_app/group/email-templates.tsx
+++ b/apps/web/src/routes/_app/group/email-templates.tsx
@@ -14,7 +14,7 @@ const RouteComponent = () => {
     <React.Fragment>
       <PageHeader>
         <Heading className="text-center" variant="h2">
-          {t({ en: 'Email Templates', fr: 'Modèles de courriel' })}
+          {t({ en: 'Email Templates', es: 'Plantillas de correo', fr: 'Modèles de courriel' })}
         </Heading>
       </PageHeader>
       <GroupEmailTemplates />

--- a/apps/web/src/routes/_app/group/manage.tsx
+++ b/apps/web/src/routes/_app/group/manage.tsx
@@ -38,7 +38,7 @@ import { useAppStore } from '@/store';
 type InstrumentSource = { kind: 'manual' } | { kind: 'repo'; name: string };
 
 /** Passed to the renderer as a localizable value; the shared component resolves it to the active language. */
-const PREVIEW_SUBMIT_LABEL = { en: 'Preview Submit', fr: 'Soumettre l’aperçu' };
+const PREVIEW_SUBMIT_LABEL = { en: 'Preview Submit', es: 'Enviar vista previa', fr: "Soumettre l'aperçu" };
 
 type InstrumentItem = {
   authors?: null | string[];
@@ -146,7 +146,11 @@ const InstrumentSection = ({
       {title && <h3 className="mb-2 text-sm font-semibold">{title}</h3>}
       {filtered.length === 0 ? (
         <p className="text-muted-foreground text-sm italic">
-          {t({ en: 'No instruments available.', fr: 'Aucun instrument disponible.' })}
+          {t({
+            en: 'No instruments available.',
+            es: 'No hay instrumentos disponibles.',
+            fr: 'Aucun instrument disponible.'
+          })}
         </p>
       ) : (
         <div className="space-y-1">
@@ -170,11 +174,17 @@ const InstrumentSection = ({
                 {item.title}
               </button>
               <Badge className="shrink-0" variant={item.source.kind === 'repo' ? 'secondary' : 'outline'}>
-                {item.source.kind === 'repo' ? item.source.name : t({ en: 'No repo', fr: 'Aucun dépôt' })}
+                {item.source.kind === 'repo'
+                  ? item.source.name
+                  : t({ en: 'No repo', es: 'Sin repositorio', fr: 'Aucun dépôt' })}
               </Badge>
               <div className="flex shrink-0 items-center gap-1">
                 <button
-                  aria-label={t({ en: 'Preview instrument', fr: "Aperçu de l'instrument" })}
+                  aria-label={t({
+                    en: 'Preview instrument',
+                    es: 'Vista previa del instrumento',
+                    fr: "Aperçu de l'instrument"
+                  })}
                   className="text-muted-foreground hover:text-foreground p-1 transition-colors"
                   type="button"
                   onClick={(e) => {
@@ -186,7 +196,11 @@ const InstrumentSection = ({
                 </button>
                 {onDelete && !readOnly && item.isDeletable && (
                   <button
-                    aria-label={t({ en: 'Delete instrument', fr: "Supprimer l'instrument" })}
+                    aria-label={t({
+                      en: 'Delete instrument',
+                      es: 'Eliminar instrumento',
+                      fr: "Supprimer l'instrument"
+                    })}
                     className="text-muted-foreground hover:text-destructive p-1 transition-colors"
                     type="button"
                     onClick={(e) => {
@@ -223,7 +237,7 @@ const InstrumentPreviewDialog = ({
   const bundleQuery = useInstrumentBundle(showForm ? item.id : null);
   const seriesItemTitles = useMemo(() => {
     return getSeriesPreviewItemTitles({
-      fallbackTitle: (index) => t({ en: `Item ${index + 1}`, fr: `Élément ${index + 1}` }),
+      fallbackTitle: (index) => t({ en: `Item ${index + 1}`, es: `Elemento ${index + 1}`, fr: `Élément ${index + 1}` }),
       items,
       seriesItems: item.seriesItems ?? []
     });
@@ -251,6 +265,7 @@ const InstrumentPreviewDialog = ({
               <p className="text-destructive py-4 text-center text-sm">
                 {t({
                   en: 'Failed to load instrument preview.',
+                  es: 'Error al cargar la vista previa del instrumento.',
                   fr: "Échec du chargement de l'aperçu de l'instrument."
                 })}
               </p>
@@ -269,18 +284,22 @@ const InstrumentPreviewDialog = ({
           <div className="flex max-h-[70vh] flex-col text-sm">
             <div className="min-h-0 space-y-3 overflow-y-auto pr-1">
               <div>
-                <span className="font-medium">{t({ en: 'Kind', fr: 'Type' })}: </span>
+                <span className="font-medium">{t({ en: 'Kind', es: 'Tipo', fr: 'Type' })}: </span>
                 <span className="text-muted-foreground">{item.kind}</span>
               </div>
               {item.kind === 'SERIES' && (
                 <div>
                   <span className="font-medium">
-                    {t({ en: 'Series order', fr: 'Ordre de la série' })}
+                    {t({ en: 'Series order', es: 'Orden de la serie', fr: 'Ordre de la série' })}
                     {seriesItemTitles.length > 0 && ` (${seriesItemTitles.length})`}:{' '}
                   </span>
                   {seriesItemTitles.length === 0 ? (
                     <span className="text-muted-foreground">
-                      {t({ en: 'No items in this series.', fr: 'Aucun élément dans cette série.' })}
+                      {t({
+                        en: 'No items in this series.',
+                        es: 'No hay elementos en esta serie.',
+                        fr: 'Aucun élément dans cette série.'
+                      })}
                     </span>
                   ) : (
                     <ol className="text-muted-foreground mt-1 max-h-48 list-decimal space-y-1 overflow-auto rounded-md border border-slate-200 py-2 pl-8 pr-3 dark:border-slate-800">
@@ -295,25 +314,31 @@ const InstrumentPreviewDialog = ({
               )}
               {item.authors && item.authors.length > 0 && (
                 <div>
-                  <span className="font-medium">{t({ en: 'Authors', fr: 'Auteurs' })}: </span>
+                  <span className="font-medium">{t({ en: 'Authors', es: 'Autores', fr: 'Auteurs' })}: </span>
                   <span className="text-muted-foreground">{item.authors.join(', ')}</span>
                 </div>
               )}
               {item.description && (
                 <div>
-                  <span className="font-medium">{t({ en: 'Description', fr: 'Description' })}: </span>
+                  <span className="font-medium">
+                    {t({ en: 'Description', es: 'Descripción', fr: 'Description' })}:{' '}
+                  </span>
                   <span className="text-muted-foreground">{item.description}</span>
                 </div>
               )}
               <div>
-                <span className="font-medium">{t({ en: 'Source', fr: 'Source' })}: </span>
+                <span className="font-medium">{t({ en: 'Source', es: 'Fuente', fr: 'Source' })}: </span>
                 <span className="text-muted-foreground">
-                  {item.source.kind === 'repo' ? item.source.name : t({ en: 'No repo', fr: 'Aucun dépôt' })}
+                  {item.source.kind === 'repo'
+                    ? item.source.name
+                    : t({ en: 'No repo', es: 'Sin repositorio', fr: 'Aucun dépôt' })}
                 </span>
               </div>
             </div>
             <div className="mt-3 flex shrink-0 justify-center border-t border-slate-200 pt-3 dark:border-slate-800">
-              <Button onClick={() => setShowForm(true)}>{t({ en: 'Preview Form', fr: 'Aperçu du formulaire' })}</Button>
+              <Button onClick={() => setShowForm(true)}>
+                {t({ en: 'Preview Form', es: 'Vista previa del formulario', fr: 'Aperçu du formulaire' })}
+              </Button>
             </div>
           </div>
         )}
@@ -379,7 +404,7 @@ const CreateSeriesInstrumentDialog = ({
     details: { title: title.trim() },
     groupId,
     items,
-    language: resolvedLanguage
+    language: resolvedLanguage === 'en' || resolvedLanguage === 'fr' ? resolvedLanguage : 'en'
   });
 
   const handleCreate = async () => {
@@ -429,22 +454,33 @@ const CreateSeriesInstrumentDialog = ({
       >
         <Dialog.Content className="sm:max-w-[600px]">
           <Dialog.Header>
-            <Dialog.Title>{t({ en: 'Create Series Instrument', fr: 'Créer un instrument en série' })}</Dialog.Title>
+            <Dialog.Title>
+              {t({
+                en: 'Create Series Instrument',
+                es: 'Crear instrumento en serie',
+                fr: 'Créer un instrument en série'
+              })}
+            </Dialog.Title>
             <Dialog.Description>
               {t({
                 en: 'Give the series a unique name, then select at least two instruments to include in order.',
-                fr: 'Donnez un nom unique à la série, puis sélectionnez au moins deux instruments à inclure dans l’ordre.'
+                es: 'Asigne un nombre único a la serie, luego seleccione al menos dos instrumentos para incluir en orden.',
+                fr: "Donnez un nom unique à la série, puis sélectionnez au moins deux instruments à inclure dans l'ordre."
               })}
             </Dialog.Description>
           </Dialog.Header>
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <label className="text-sm font-medium" htmlFor="series-name">
-                {t({ en: 'Name', fr: 'Nom' })}
+                {t({ en: 'Name', es: 'Nombre', fr: 'Nom' })}
               </label>
               <Input
                 id="series-name"
-                placeholder={t({ en: 'e.g. Baseline Battery', fr: 'p. ex. Batterie de base' })}
+                placeholder={t({
+                  en: 'e.g. Baseline Battery',
+                  es: 'p. ej. Batería de referencia',
+                  fr: 'p. ex. Batterie de base'
+                })}
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
               />
@@ -452,6 +488,7 @@ const CreateSeriesInstrumentDialog = ({
                 <p className="text-destructive text-xs">
                   {t({
                     en: 'An instrument with this name already exists.',
+                    es: 'Ya existe un instrumento con este nombre.',
                     fr: 'Un instrument portant ce nom existe déjà.'
                   })}
                 </p>
@@ -459,12 +496,13 @@ const CreateSeriesInstrumentDialog = ({
             </div>
             <div className="flex flex-col gap-1">
               <label className="text-sm font-medium" htmlFor="series-instructions">
-                {t({ en: 'Instructions', fr: 'Instructions' })}
+                {t({ en: 'Instructions', es: 'Instrucciones', fr: 'Instructions' })}
               </label>
               <TextArea
                 id="series-instructions"
                 placeholder={t({
                   en: 'Optional instructions shown before the series begins.',
+                  es: 'Instrucciones opcionales mostradas antes de que comience la serie.',
                   fr: 'Instructions facultatives affichées avant le début de la série.'
                 })}
                 rows={3}
@@ -474,22 +512,30 @@ const CreateSeriesInstrumentDialog = ({
             </div>
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium">
-                {t({ en: 'Available instruments', fr: 'Instruments disponibles' })}
+                {t({ en: 'Available instruments', es: 'Instrumentos disponibles', fr: 'Instruments disponibles' })}
                 {selectedIds.length > 0 && ` (${selectedIds.length})`}
               </span>
               <SearchBar
-                placeholder={t({ en: 'Search instruments...', fr: 'Rechercher des instruments...' })}
+                placeholder={t({
+                  en: 'Search instruments...',
+                  es: 'Buscar instrumentos...',
+                  fr: 'Rechercher des instruments...'
+                })}
                 value={search}
                 onValueChange={setSearch}
               />
               <div className="text-muted-foreground flex items-center justify-between px-2 text-xs font-medium uppercase">
-                <span>{t({ en: 'Instrument', fr: 'Instrument' })}</span>
-                <span>{t({ en: 'Series order', fr: 'Ordre de la série' })}</span>
+                <span>{t({ en: 'Instrument', es: 'Instrumento', fr: 'Instrument' })}</span>
+                <span>{t({ en: 'Series order', es: 'Orden de la serie', fr: 'Ordre de la série' })}</span>
               </div>
               <div className="max-h-[40vh] space-y-1 overflow-auto">
                 {filteredForms.length === 0 ? (
                   <p className="text-muted-foreground text-sm italic">
-                    {t({ en: 'No instruments available.', fr: 'Aucun instrument disponible.' })}
+                    {t({
+                      en: 'No instruments available.',
+                      es: 'No hay instrumentos disponibles.',
+                      fr: 'Aucun instrument disponible.'
+                    })}
                   </p>
                 ) : (
                   filteredForms.map((form) => {
@@ -513,10 +559,10 @@ const CreateSeriesInstrumentDialog = ({
           </div>
           <Dialog.Footer>
             <Button type="button" variant="outline" onClick={onClose}>
-              {t({ en: 'Cancel', fr: 'Annuler' })}
+              {t({ en: 'Cancel', es: 'Cancelar', fr: 'Annuler' })}
             </Button>
             <Button disabled={!canCreate} type="button" onClick={() => void handleCreate()}>
-              {t({ en: 'Create', fr: 'Créer' })}
+              {t({ en: 'Create', es: 'Crear', fr: 'Créer' })}
             </Button>
           </Dialog.Footer>
         </Dialog.Content>
@@ -530,20 +576,23 @@ const CreateSeriesInstrumentDialog = ({
         >
           <Dialog.Content className="sm:max-w-[450px]">
             <Dialog.Header>
-              <Dialog.Title>{t({ en: 'Series Already Exists', fr: 'La série existe déjà' })}</Dialog.Title>
+              <Dialog.Title>
+                {t({ en: 'Series Already Exists', es: 'La serie ya existe', fr: 'La série existe déjà' })}
+              </Dialog.Title>
               <Dialog.Description>
                 {t({
                   en: `A series named "${duplicateOf}" already contains the same forms — you can use it instead. Do you still want to create "${title.trim()}"?`,
-                  fr: `Une série nommée « ${duplicateOf} » contient déjà les mêmes formulaires — vous pouvez l’utiliser à la place. Voulez-vous quand même créer « ${title.trim()} » ?`
+                  es: `Una serie llamada "${duplicateOf}" ya contiene los mismos formularios — puede usarla en su lugar. ¿Desea crear "${title.trim()}" de todos modos?`,
+                  fr: `Une série nommée « ${duplicateOf} » contient déjà les mêmes formulaires — vous pouvez l'utiliser à la place. Voulez-vous quand même créer « ${title.trim()} » ?`
                 })}
               </Dialog.Description>
             </Dialog.Header>
             <Dialog.Footer>
               <Button type="button" variant="outline" onClick={() => setDuplicateOf(null)}>
-                {t({ en: 'No', fr: 'Non' })}
+                {t({ en: 'No', es: 'No', fr: 'Non' })}
               </Button>
               <Button disabled={createMutation.isPending} type="button" onClick={() => void handleConfirmDuplicate()}>
-                {t({ en: 'Yes, create anyway', fr: 'Oui, créer quand même' })}
+                {t({ en: 'Yes, create anyway', es: 'Sí, crear de todos modos', fr: 'Oui, créer quand même' })}
               </Button>
             </Dialog.Footer>
           </Dialog.Content>
@@ -579,20 +628,27 @@ const DeleteInstrumentDialog = ({
     >
       <Dialog.Content className="sm:max-w-[450px]">
         <Dialog.Header>
-          <Dialog.Title>{t({ en: 'Delete Series Instrument', fr: 'Supprimer l’instrument en série' })}</Dialog.Title>
+          <Dialog.Title>
+            {t({
+              en: 'Delete Series Instrument',
+              es: 'Eliminar instrumento en serie',
+              fr: "Supprimer l'instrument en série"
+            })}
+          </Dialog.Title>
           <Dialog.Description>
             {t({
               en: `Are you sure you want to delete "${item.title}"? This cannot be undone.`,
+              es: `¿Está seguro de que desea eliminar "${item.title}"? Esta acción no se puede deshacer.`,
               fr: `Êtes-vous sûr de vouloir supprimer « ${item.title} » ? Cette action est irréversible.`
             })}
           </Dialog.Description>
         </Dialog.Header>
         <Dialog.Footer>
           <Button type="button" variant="outline" onClick={onClose}>
-            {t({ en: 'No', fr: 'Non' })}
+            {t({ en: 'No', es: 'No', fr: 'Non' })}
           </Button>
           <Button disabled={deleteMutation.isPending} type="button" variant="danger" onClick={handleDelete}>
-            {t({ en: 'Yes, delete', fr: 'Oui, supprimer' })}
+            {t({ en: 'Yes, delete', es: 'Sí, eliminar', fr: 'Oui, supprimer' })}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>
@@ -671,7 +727,11 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
       <p className="text-muted-foreground mb-3 mt-1 text-sm">{description}</p>
       <div className="mb-4">
         <SearchBar
-          placeholder={t({ en: 'Search instruments...', fr: 'Rechercher des instruments...' })}
+          placeholder={t({
+            en: 'Search instruments...',
+            es: 'Buscar instrumentos...',
+            fr: 'Rechercher des instruments...'
+          })}
           value={search}
           onValueChange={setSearch}
         />
@@ -698,7 +758,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
         <h3 className="text-sm font-semibold">{t('group.manage.series')}</h3>
         {!readOnly && (
           <Button size="sm" type="button" variant="primary" onClick={() => setShowCreateSeries(true)}>
-            {t({ en: 'Create series', fr: 'Créer une série' })}
+            {t({ en: 'Create series', es: 'Crear serie', fr: 'Créer une série' })}
           </Button>
         )}
       </div>
@@ -720,6 +780,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                 kind: 'number',
                 label: t({
                   en: 'Preferred Subject ID Display Length',
+                  es: 'Longitud de visualización preferida del ID del sujeto',
                   fr: "La longueur d'affichage préférée de l'ID"
                 }),
                 variant: 'input'
@@ -727,6 +788,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
             },
             title: t({
               en: 'Display Settings',
+              es: 'Configuración de visualización',
               fr: "Paramètres d'affichage"
             })
           },
@@ -736,6 +798,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                 kind: 'boolean',
                 label: t({
                   en: 'Apply Minimum Age For Subjects',
+                  es: 'Aplicar edad mínima para sujetos',
                   fr: 'Appliquer un âge minimum aux sujets'
                 }),
                 variant: 'radio'
@@ -750,6 +813,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                       kind: 'number',
                       label: t({
                         en: 'Minimum Age',
+                        es: 'Edad mínima',
                         fr: 'Âge minimum'
                       }),
                       variant: 'input'
@@ -761,6 +825,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
             },
             title: t({
               en: 'Age Limit Settings',
+              es: 'Configuración de límite de edad',
               fr: "Paramètres de limite d'âge"
             })
           },
@@ -778,11 +843,13 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
               idValidationRegex: {
                 description: t({
                   en: 'Define a custom regular expression to validate subject IDs (see https://regexr.com for help designing your regular expression).',
+                  es: 'Defina una expresión regular personalizada para validar los IDs de sujetos (consulte https://regexr.com para ayuda en el diseño de su expresión regular).',
                   fr: "Définir une expression régulière pour valider les identifiants des sujets (voir https://regexr.com pour obtenir de l'aide dans la conception de votre expression régulière)."
                 }),
                 kind: 'string',
                 label: t({
                   en: 'ID Validation Pattern',
+                  es: 'Patrón de validación de ID',
                   fr: "Modèle de validation d'identifiant"
                 }),
                 variant: 'input'
@@ -798,6 +865,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                     kind: 'string',
                     label: t({
                       en: 'Custom ID Validation Message (English)',
+                      es: 'Mensaje de validación de ID personalizado (inglés)',
                       fr: 'Message de validation spécifique (en anglais)'
                     }),
                     variant: 'input'
@@ -815,6 +883,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                     kind: 'string',
                     label: t({
                       en: 'Custom ID Validation Message (French)',
+                      es: 'Mensaje de validación de ID personalizado (francés)',
                       fr: 'Message de validation spécifique (en français)'
                     }),
                     variant: 'input'
@@ -845,6 +914,7 @@ const ManageGroupForm = ({ data, onSubmit, readOnly }: ManageGroupFormProps) => 
                 input: ctx.value.minimumAge,
                 message: t({
                   en: 'Please enter an age',
+                  es: 'Por favor ingrese una edad',
                   fr: 'Veuillez entrer un âge'
                 }),
                 path: ['minimumAge']
@@ -917,7 +987,12 @@ const RouteComponent = () => {
       // name but is still repo-sourced (and so must not get the "manual" delete affordance). We fall back
       // to a placeholder label only for display.
       const source: InstrumentSource = repoId
-        ? { kind: 'repo', name: instrument.sourceRepo?.name ?? t({ en: 'Unknown repository', fr: 'Dépôt inconnu' }) }
+        ? {
+            kind: 'repo',
+            name:
+              instrument.sourceRepo?.name ??
+              t({ en: 'Unknown repository', es: 'Repositorio desconocido', fr: 'Dépôt inconnu' })
+          }
         : { kind: 'manual' };
       const item: InstrumentItem = {
         authors: instrument.details.authors,

--- a/apps/web/src/routes/_app/session/remote-assignment.tsx
+++ b/apps/web/src/routes/_app/session/remote-assignment.tsx
@@ -33,6 +33,7 @@ const CreateAssignmentForm: React.FC<{
       setError(
         t({
           en: 'Expiry date must be a valid date in the future',
+          es: 'La fecha de expiración debe ser una fecha válida en el futuro',
           fr: "La date d'expiration doit être une date valide dans le futur"
         })
       );
@@ -45,7 +46,9 @@ const CreateAssignmentForm: React.FC<{
   return (
     <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="expires-at">{t({ en: 'Expires At', fr: "Date d'expiration" })}</Label>
+        <Label htmlFor="expires-at">
+          {t({ en: 'Expires At', es: 'Fecha de expiración', fr: "Date d'expiration" })}
+        </Label>
         <Input
           id="expires-at"
           placeholder="YYYY-MM-DD"
@@ -59,7 +62,9 @@ const CreateAssignmentForm: React.FC<{
         {error && <p className="text-destructive text-xs font-medium">{error}</p>}
       </div>
       <Button className="w-full" disabled={isPending} type="submit" variant="primary">
-        {isPending ? t({ en: 'Creating…', fr: 'Création…' }) : t({ en: 'Submit', fr: 'Soumettre' })}
+        {isPending
+          ? t({ en: 'Creating…', es: 'Creando…', fr: 'Création…' })
+          : t({ en: 'Submit', es: 'Enviar', fr: 'Soumettre' })}
       </Button>
     </form>
   );
@@ -84,6 +89,7 @@ const AssignmentResultSlider: React.FC<{
           <Sheet.Description>
             {t({
               en: 'Share this link with the subject to complete the assignment remotely. If the link is lost, it can be found by navigating to View Current Subject, selecting the Assignments tab, and clicking on the assignment.',
+              es: 'Comparta este enlace con el sujeto para completar la tarea de forma remota. Si el enlace se pierde, puede encontrarlo navegando a Ver sujeto actual, seleccionando la pestaña Tareas y haciendo clic en la tarea.',
               fr: "Partagez ce lien avec le client pour compléter la tâche à distance. Si le lien est perdu, il peut être retrouvé en naviguant vers Voir le client actuel, en sélectionnant l'onglet Tâches, puis en cliquant sur la tâche."
             })}
           </Sheet.Description>
@@ -94,6 +100,7 @@ const AssignmentResultSlider: React.FC<{
               <a className="hover:underline" href={url} rel="noreferrer" target="_blank">
                 {t({
                   en: 'Assignment Link',
+                  es: 'Enlace de la tarea',
                   fr: 'Lien de la tâche'
                 })}
               </a>
@@ -161,6 +168,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Remote Assignment',
+            es: 'Tarea remota',
             fr: 'Tâche à distance'
           })}
         </Heading>
@@ -185,6 +193,7 @@ const RouteComponent = () => {
             <Dialog.Title>
               {t({
                 en: 'Create Remote Assignment',
+                es: 'Crear tarea remota',
                 fr: 'Créer une tâche à distance'
               })}
             </Dialog.Title>
@@ -192,6 +201,7 @@ const RouteComponent = () => {
               {t(
                 {
                   en: 'Assign "{}" to the current subject for remote completion.',
+                  es: 'Asignar "{}" al sujeto actual para completar de forma remota.',
                   fr: 'Assigner « {} » au client actuel pour complétion à distance.'
                 },
                 { args: [selectedInstrument?.details.title ?? ''] }

--- a/apps/web/src/routes/_app/session/start-session.tsx
+++ b/apps/web/src/routes/_app/session/start-session.tsx
@@ -92,11 +92,16 @@ const RouteComponent = () => {
                   />
                 </svg>
                 <h5 className="font-semibold text-green-900 dark:text-green-500">
-                  {t({ en: 'Session Successfully Started', fr: 'Session démarrée avec succès' })}
+                  {t({
+                    en: 'Session Successfully Started',
+                    es: 'Sesión iniciada exitosamente',
+                    fr: 'Session démarrée avec succès'
+                  })}
                 </h5>
                 <p className="text-sm text-green-700 dark:text-green-300">
                   {t({
                     en: 'Please note that you must end the current session before completing this form again.',
+                    es: 'Tenga en cuenta que debe finalizar la sesión actual antes de completar este formulario nuevamente.',
                     fr: 'Veuillez noter que vous devez mettre fin à la session en cours avant de remplir à nouveau ce formulaire.'
                   })}
                 </p>

--- a/apps/web/src/routes/_app/upload/$instrumentId.tsx
+++ b/apps/web/src/routes/_app/upload/$instrumentId.tsx
@@ -51,6 +51,7 @@ const RouteComponent = () => {
             description: error instanceof UploadError ? error.description : undefined,
             title: {
               en: `Error Occurred Downloading Sample Template`,
+              es: `Ocurrió un error al descargar la plantilla de muestra`,
               fr: `Une erreur s'est produite lors du téléchargement du modèle`
             }
           }
@@ -74,6 +75,7 @@ const RouteComponent = () => {
         addNotification({
           message: t({
             en: 'Lots of entries loading, please wait...',
+            es: 'Cargando muchas entradas, por favor espere...',
             fr: 'Beaucoup de données, veuillez patienter...'
           }),
           type: 'info'
@@ -89,6 +91,7 @@ const RouteComponent = () => {
             description: error instanceof UploadError ? error.description : undefined,
             title: {
               en: `An error has happened within the request`,
+              es: `Ocurrió un error en la solicitud`,
               fr: `Une erreur s'est produite lors du téléversement`
             }
           }
@@ -117,6 +120,7 @@ const RouteComponent = () => {
           >
             {t({
               en: 'Error Report',
+              es: 'Informe de error',
               fr: "Rapport d'erreur"
             })}
           </Button>
@@ -129,6 +133,7 @@ const RouteComponent = () => {
           >
             {t({
               en: 'Try Again',
+              es: 'Intentar de nuevo',
               fr: 'Réessayer'
             })}
           </Button>
@@ -147,6 +152,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: `Upload Data For ${instrument.details.title}`,
+            es: `Subir datos para ${instrument.details.title}`,
             fr: `Téléverser les données pour l'instrument : ${instrument.details.title}`
           })}
         </Heading>
@@ -166,7 +172,11 @@ const RouteComponent = () => {
               {(currentUser?.groups.length ?? 0) > 0 && (
                 <div className="flex w-full shrink-0 flex-col gap-1 sm:w-48">
                   <p className="text-muted-foreground text-xs">
-                    {t({ en: 'Filter users by group.', fr: 'Filtrer les utilisateurs par groupe.' })}
+                    {t({
+                      en: 'Filter users by group.',
+                      es: 'Filtrar usuarios por grupo.',
+                      fr: 'Filtrer les utilisateurs par groupe.'
+                    })}
                   </p>
                   <Select
                     value={selectedGroupId}
@@ -176,7 +186,9 @@ const RouteComponent = () => {
                     }}
                   >
                     <Select.Trigger>
-                      <Select.Value placeholder={t({ en: 'Select group', fr: 'Sélectionner un groupe' })} />
+                      <Select.Value
+                        placeholder={t({ en: 'Select group', es: 'Seleccionar grupo', fr: 'Sélectionner un groupe' })}
+                      />
                     </Select.Trigger>
                     <Select.Content>
                       <Select.Group>
@@ -194,6 +206,7 @@ const RouteComponent = () => {
                 <p className="text-muted-foreground text-xs">
                   {t({
                     en: 'Select the username to associate with these records for audit and traceability.',
+                    es: 'Seleccione el nombre de usuario a asociar con estos registros para auditoría y trazabilidad.',
                     fr: "Sélectionnez le nom d'utilisateur à associer à ces entrées pour l'audit et la traçabilité."
                   })}
                 </p>
@@ -224,7 +237,7 @@ const RouteComponent = () => {
             <div className="flex gap-2">
               <Button className="gap-2" size="sm" variant="outline" onClick={handleTemplateDownload}>
                 <DownloadIcon size={16} />
-                {t({ en: 'Template', fr: 'Modèle' })}
+                {t({ en: 'Template', es: 'Plantilla', fr: 'Modèle' })}
               </Button>
               <Button
                 className="gap-2"
@@ -233,7 +246,7 @@ const RouteComponent = () => {
                 onClick={() => window.open('https://opendatacapture.org/en/docs/guides/how-to-upload-data/')}
               >
                 <BadgeHelpIcon size={16} />
-                {t({ en: 'Help', fr: 'Aide' })}
+                {t({ en: 'Help', es: 'Ayuda', fr: 'Aide' })}
               </Button>
             </div>
           </div>
@@ -244,6 +257,7 @@ const RouteComponent = () => {
           <Heading className="mt-4 text-center" variant="h3">
             {t({
               en: 'Data currently uploading...',
+              es: 'Datos cargándose actualmente...',
               fr: 'Données en cours de téléversement...'
             })}
           </Heading>
@@ -261,12 +275,14 @@ export const Route = createFileRoute('/_app/upload/$instrumentId')({
         description: z
           .object({
             en: z.string(),
+            es: z.string(),
             fr: z.string()
           })
           .partial()
           .optional(),
         title: z.object({
           en: z.string(),
+          es: z.string().optional(),
           fr: z.string()
         })
       })

--- a/apps/web/src/routes/_app/upload/index.tsx
+++ b/apps/web/src/routes/_app/upload/index.tsx
@@ -21,6 +21,7 @@ const UploadSelectTable: React.FC<{
           field: (instrument) => instrument.details.title,
           label: t({
             en: 'Title',
+            es: 'Título',
             fr: 'Titre'
           })
         },
@@ -28,6 +29,7 @@ const UploadSelectTable: React.FC<{
           field: (instrument) => instrument.kind,
           label: t({
             en: 'Kind',
+            es: 'Tipo',
             fr: 'Type'
           })
         }
@@ -58,6 +60,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'Select Instrument (Experimental Feature)',
+            es: 'Seleccionar instrumento (Función experimental)',
             fr: 'Sélectionnez un instrument (Fonctionnalité expérimentale)'
           })}
         </Heading>
@@ -66,6 +69,7 @@ const RouteComponent = () => {
         className="mb-3"
         placeholder={t({
           en: 'Search by Instrument Title',
+          es: 'Buscar por título del instrumento',
           fr: "Rechercher par titre de l'instrument"
         })}
         value={searchTerm}

--- a/apps/web/src/routes/_app/user.tsx
+++ b/apps/web/src/routes/_app/user.tsx
@@ -36,14 +36,17 @@ const RouteComponent = () => {
   const userType: { [key: string]: string } = {
     ADMIN: t({
       en: 'Admin',
+      es: 'Administrador',
       fr: 'Admin'
     }),
     GROUP_MANAGER: t({
       en: 'Group Manager',
+      es: 'Administrador de grupo',
       fr: 'Responsable de groupe'
     }),
     STANDARD: t({
       en: 'Standard User',
+      es: 'Usuario estándar',
       fr: 'Utilisateur standard'
     })
   };
@@ -103,6 +106,7 @@ const RouteComponent = () => {
         <Heading className="text-center" variant="h2">
           {t({
             en: 'User Info',
+            es: 'Información del usuario',
             fr: 'Informations utilisateur'
           })}
         </Heading>
@@ -126,6 +130,7 @@ const RouteComponent = () => {
                 kind: 'string',
                 label: t({
                   en: 'Email',
+                  es: 'Correo electrónico',
                   fr: 'Courriel'
                 }),
                 variant: 'input'
@@ -147,6 +152,7 @@ const RouteComponent = () => {
                 kind: 'string',
                 label: t({
                   en: 'Phone Number',
+                  es: 'Número de teléfono',
                   fr: 'Numéro de téléphone'
                 }),
                 variant: 'input'
@@ -154,6 +160,7 @@ const RouteComponent = () => {
             },
             title: t({
               en: 'Login Credentials',
+              es: 'Credenciales de inicio de sesión',
               fr: 'Identifiants de connexion'
             })
           },
@@ -185,6 +192,7 @@ const RouteComponent = () => {
             },
             title: t({
               en: 'Personal Information',
+              es: 'Información personal',
               fr: 'Informations personnelles'
             })
           }

--- a/apps/web/src/routes/auth/login.tsx
+++ b/apps/web/src/routes/auth/login.tsx
@@ -1,5 +1,9 @@
+import { useEffect } from 'react';
+
 import { Card, Heading, LanguageToggle, ThemeToggle } from '@douglasneuroinformatics/libui/components';
 import { useNotificationsStore, useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { i18n } from '@douglasneuroinformatics/libui/i18n';
+import type { Language } from '@douglasneuroinformatics/libui/i18n';
 import { Logo } from '@opendatacapture/react-core';
 import type { $LoginCredentials, AuthPayload } from '@opendatacapture/schemas/auth';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
@@ -12,6 +16,7 @@ import { config } from '@/config';
 import { setupStateQueryOptions, useSetupStateQuery } from '@/hooks/useSetupStateQuery';
 import { useAppStore } from '@/store';
 import { getRightPanelGradient } from '@/utils/branding';
+import { ALL_LANGUAGES } from '@/utils/languages';
 
 const loginRequest = async (
   credentials: $LoginCredentials
@@ -33,10 +38,21 @@ const RouteComponent = () => {
   const { resolvedLanguage, t } = useTranslation('auth');
   const navigate = useNavigate();
 
+  const activeLanguages = setupStateQuery.data.activeLanguages ?? ['en', 'fr'];
+  const languageOptions = Object.fromEntries(
+    Object.entries(ALL_LANGUAGES).filter(([key]) => activeLanguages.includes(key))
+  );
+
+  useEffect(() => {
+    if (!activeLanguages.includes(resolvedLanguage)) {
+      i18n.changeLanguage(activeLanguages[0]! as Language);
+    }
+  }, [activeLanguages, resolvedLanguage]);
+
   const branding = setupStateQuery.data.branding;
   const enableBranding = branding?.enableBranding === true;
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const instanceName = branding?.instanceName?.[resolvedLanguage]?.trim() || 'Open Data Capture';
+  const instanceName = branding?.instanceName?.[resolvedLanguage as 'en' | 'fr']?.trim() || 'Open Data Capture';
 
   const handleLogin = async (credentials: $LoginCredentials) => {
     const result = await loginRequest(credentials);
@@ -69,15 +85,7 @@ const RouteComponent = () => {
               <LoginForm onSubmit={(credentials) => void handleLogin(credentials)} />
             </Card.Content>
             <Card.Footer className="text-muted-foreground flex justify-between" data-testid="login-footer-toggles">
-              <LanguageToggle
-                align="start"
-                options={{
-                  en: 'English',
-                  fr: 'Français'
-                }}
-                triggerClassName="border p-2"
-                variant="ghost"
-              />
+              <LanguageToggle align="start" options={languageOptions} triggerClassName="border p-2" variant="ghost" />
               <ThemeToggle className="border p-2" variant="ghost" />
             </Card.Footer>
           </Card>
@@ -110,15 +118,7 @@ const RouteComponent = () => {
               <LoginForm onSubmit={(credentials) => void handleLogin(credentials)} />
             </Card.Content>
             <Card.Footer className="text-muted-foreground flex justify-between" data-testid="login-footer-toggles">
-              <LanguageToggle
-                align="start"
-                options={{
-                  en: 'English',
-                  fr: 'Français'
-                }}
-                triggerClassName="border p-2"
-                variant="ghost"
-              />
+              <LanguageToggle align="start" options={languageOptions} triggerClassName="border p-2" variant="ghost" />
               <ThemeToggle className="border p-2" variant="ghost" />
             </Card.Footer>
           </Card>

--- a/apps/web/src/services/axios.ts
+++ b/apps/web/src/services/axios.ts
@@ -116,6 +116,7 @@ axios.interceptors.request.use((config) => {
     config.timeout = 10000; // abort request after 10 seconds
     config.timeoutErrorMessage = i18n.t({
       en: 'Network Error',
+      es: 'Error de red',
       fr: 'Erreur de réseau'
     });
   }
@@ -174,6 +175,7 @@ axios.interceptors.response.use(
       notifications.addNotification({
         message: i18n.t({
           en: 'Unknown Error',
+          es: 'Error desconocido',
           fr: 'Erreur inconnue'
         }),
         type: 'error'
@@ -187,10 +189,12 @@ axios.interceptors.response.use(
       notifications.addNotification({
         message: i18n.t({
           en: 'Unable to reach the server. Please check your connection and try again.',
+          es: 'No se pudo conectar con el servidor. Por favor, verifique su conexión e intente de nuevo.',
           fr: 'Impossible de joindre le serveur. Veuillez vérifier votre connexion et réessayer.'
         }),
         title: i18n.t({
           en: 'Connection Problem',
+          es: 'Problema de conexión',
           fr: 'Problème de connexion'
         }),
         type: 'warning'
@@ -200,6 +204,7 @@ axios.interceptors.response.use(
     notifications.addNotification({
       message: i18n.t({
         en: 'HTTP Request Failed',
+        es: 'Error en la solicitud HTTP',
         fr: 'Échec de la requête HTTP'
       }),
       title: error.response?.status.toString(),

--- a/apps/web/src/services/i18n.ts
+++ b/apps/web/src/services/i18n.ts
@@ -19,6 +19,7 @@ declare module '@douglasneuroinformatics/libui/i18n' {
   export namespace UserConfig {
     export interface LanguageOptions {
       en: true;
+      es: true;
       fr: true;
     }
     export interface Translations {

--- a/apps/web/src/translations/auth.json
+++ b/apps/web/src/translations/auth.json
@@ -2,65 +2,80 @@
   "demo": {
     "availableUsers": {
       "en": "Available Users",
+      "es": "Usuarios disponibles",
       "fr": "Utilisateurs disponibles"
     },
     "groups": {
       "en": "Group(s)",
+      "es": "Grupo(s)",
       "fr": "Groupe(s)"
     },
     "info": {
       "en": "Demo Information",
+      "es": "Información de la demostración",
       "fr": "Informations sur la démonstration"
     },
     "learnMore": {
       "en": "How to Use?",
+      "es": "¿Cómo usarlo?",
       "fr": "Comment l'utiliser ?"
     },
     "password": {
       "en": "Password: {{value}}",
+      "es": "Contraseña: {{value}}",
       "fr": "Mot de passe : {{value}}"
     },
     "role": {
       "en": "Role",
+      "es": "Rol",
       "fr": "Rôle"
     },
     "summary": {
       "en": "This demo includes a number of publicly-available instruments along with several months of simulated data. To access the platform, please select a user from the options below.",
+      "es": "Esta demostración incluye una serie de instrumentos disponibles públicamente junto con varios meses de datos simulados. Para acceder a la plataforma, seleccione un usuario de las opciones a continuación.",
       "fr": "Cette démonstration comprend un certain nombre d'instruments disponibles publiquement ainsi que plusieurs mois de données simulées. Pour accéder à la plateforme, veuillez sélectionner un utilisateur parmi les options ci-dessous."
     },
     "useCredentials": {
       "en": "Use these credentials",
+      "es": "Usar estas credenciales",
       "fr": "Utilisez ces informations d'identification"
     },
     "username": {
       "en": "Username",
+      "es": "Nombre de usuario",
       "fr": "Nom d'utilisateur"
     },
     "welcome": {
       "en": "Welcome to the Demo Version of Open Data Capture",
+      "es": "Bienvenido a la versión de demostración de Open Data Capture",
       "fr": "Bienvenue sur la version de démonstration de la plateforme Open Data Capture"
     }
   },
   "login": {
     "en": "Login",
+    "es": "Iniciar sesión",
     "fr": "Se connecter"
   },
   "password": {
     "en": "Password",
+    "es": "Contraseña",
     "fr": "Mot de passe"
   },
   "unauthorizedError": {
     "message": {
       "en": "Invalid login credentials",
+      "es": "Credenciales de inicio de sesión no válidas",
       "fr": "Informations d'identification invalides"
     },
     "title": {
       "en": "Unauthorized",
+      "es": "No autorizado",
       "fr": "Non autorisé"
     }
   },
   "username": {
     "en": "Username",
+    "es": "Nombre de usuario",
     "fr": "Nom d'utilisateur"
   }
 }

--- a/apps/web/src/translations/common.json
+++ b/apps/web/src/translations/common.json
@@ -1,258 +1,320 @@
 {
   "action": {
     "en": "Action",
+    "es": "Acción",
     "fr": "Action"
   },
   "activeGroup": {
     "en": "Active Group",
+    "es": "Grupo activo",
     "fr": "Groupe actif"
   },
   "admin": {
     "en": "Admin",
+    "es": "Administrador",
     "fr": "Administrateur"
   },
   "assignment": {
     "en": "Assignment",
+    "es": "Asignación",
     "fr": "Assignation"
   },
   "auditLogs": {
     "en": "Audit Logs",
+    "es": "Registros de auditoría",
     "fr": "Journaux d'audit"
   },
   "basePermissionLevel": {
     "en": "Base Permission Level",
+    "es": "Nivel de permiso base",
     "fr": "Niveau de permission de base"
   },
   "clinical": {
     "en": "Clinical",
+    "es": "Clínico",
     "fr": "Clinique"
   },
   "confirmPassword": {
     "en": "Confirm Password",
+    "es": "Confirmar contraseña",
     "fr": "Confirmer le mot de passe"
   },
   "create": {
     "en": "Create",
+    "es": "Crear",
     "fr": "Créer"
   },
   "currentSession": {
     "en": "Current Session",
+    "es": "Sesión actual",
     "fr": "Session en cours"
   },
   "customIdentifier": {
     "en": "Custom Identifier",
+    "es": "Identificador personalizado",
     "fr": "Identifiant unique"
   },
   "dateFormat": {
     "en": "Date Format",
+    "es": "Formato de fecha",
     "fr": "Format de date"
   },
   "delete": {
     "en": "Delete",
+    "es": "Eliminar",
     "fr": "Supprimer"
   },
   "email": {
     "en": "Email",
+    "es": "Correo electrónico",
     "fr": "Adresse courriel"
   },
   "entity": {
     "en": "Entity",
+    "es": "Entidad",
     "fr": "Entité"
   },
   "errors": {
     "failedToChangeLanguage": {
       "en": "Failed to change languages",
+      "es": "No se pudo cambiar el idioma",
       "fr": "Le changement de langue n'a pas été effectué"
     },
     "noDataToExport": {
       "en": "No Data to Export",
+      "es": "No hay datos para exportar",
       "fr": "Pas de données à exporter"
     },
     "noInstrumentSelected": {
       "en": "No Instrument Selected",
+      "es": "Ningún instrumento seleccionado",
       "fr": "Aucun instrument sélectionné"
     }
   },
   "filters": {
     "en": "Filters",
+    "es": "Filtros",
     "fr": "Filtres"
   },
   "graph": {
     "en": "Graph",
+    "es": "Gráfico",
     "fr": "Graphique"
   },
   "group": {
     "en": "Group",
+    "es": "Grupo",
     "fr": "Groupe"
   },
   "groupManager": {
     "en": "Group Manager",
+    "es": "Responsable de grupo",
     "fr": "Responsable de groupe"
   },
   "groupName": {
     "en": "Group Name",
+    "es": "Nombre del grupo",
     "fr": "Nom du groupe"
   },
   "groupTrend": {
     "en": "Group Trend",
+    "es": "Tendencia del grupo",
     "fr": "Tendance du groupe"
   },
   "groupType": {
     "en": "Group Type",
+    "es": "Tipo de grupo",
     "fr": "Type de groupe"
   },
   "groups": {
     "en": "Groups",
+    "es": "Grupos",
     "fr": "Groupes"
   },
   "identificationMethod": {
     "en": "Identification Method",
+    "es": "Método de identificación",
     "fr": "Méthode d'identification"
   },
   "identificationMethodDesc": {
     "en": "Please select the method by which a subject will be identified for this session.",
+    "es": "Seleccione el método por el cual se identificará al sujeto para esta sesión.",
     "fr": "Veuillez sélectionner la méthode par laquelle un sujet sera identifié pour cette session."
   },
   "identifier": {
     "en": "Identifier",
+    "es": "Identificador",
     "fr": "Identifiant"
   },
   "instrument": {
     "en": "Instrument",
+    "es": "Instrumento",
     "fr": "Instrument"
   },
   "instrumentRecord": {
     "en": "Instrument Record",
+    "es": "Registro del instrumento",
     "fr": "Enregistrement"
   },
   "insufficientPasswordStrength": {
     "en": "Insufficient password strength",
+    "es": "Contraseña demasiado débil",
     "fr": "Mot de passe trop faible"
   },
   "localFormat": {
     "en": "Local",
+    "es": "Local",
     "fr": "Local"
   },
   "login": {
     "en": "Login",
+    "es": "Iniciar sesión",
     "fr": "Se connecter"
   },
   "manage": {
     "en": "Manage",
+    "es": "Gestionar",
     "fr": "Gérer"
   },
   "method": {
     "en": "Method",
+    "es": "Método",
     "fr": "Méthode"
   },
   "password": {
     "en": "Password",
+    "es": "Contraseña",
     "fr": "Mot de passe"
   },
   "passwordInDataBreach": {
     "en": "This password has appeared in a known data breach and cannot be used",
+    "es": "Esta contraseña ha aparecido en una filtración de datos conocida y no se puede utilizar",
     "fr": "Ce mot de passe est apparu dans une fuite de données connue et ne peut pas être utilisé"
   },
   "passwordMatchesUsername": {
     "en": "Password must not be the same as the username",
+    "es": "La contraseña no debe ser igual al nombre de usuario",
     "fr": "Le mot de passe ne doit pas être identique au nom d'utilisateur"
   },
   "passwordsMustMatch": {
     "en": "Passwords Must Match",
+    "es": "Las contraseñas deben coincidir",
     "fr": "Les mots de passe doivent correspondre"
   },
   "personalInfo": {
     "en": "Personal Information",
+    "es": "Información personal",
     "fr": "Renseignements personnels"
   },
   "phoneNumber": {
     "en": "Phone Number",
+    "es": "Número de teléfono",
     "fr": "Numéro de téléphone"
   },
   "research": {
     "en": "Research",
+    "es": "Investigación",
     "fr": "Recherche"
   },
   "session": {
     "en": "Session",
+    "es": "Sesión",
     "fr": "Session"
   },
   "sessionInProgress": {
     "en": "Session in Progress",
+    "es": "Sesión en curso",
     "fr": "Session en cours"
   },
   "standard": {
     "en": "Standard",
+    "es": "Estándar",
     "fr": "Standard"
   },
   "subject": {
     "en": "Subject",
+    "es": "Sujeto",
     "fr": "Client"
   },
   "subjectIdentification": {
     "description": {
       "en": "The following items are used to compute a unique identifier that enables consistent cross-session identification.",
+      "es": "Los siguientes elementos se utilizan para calcular un identificador único que permite una identificación coherente entre sesiones.",
       "fr": "Les éléments suivants sont utilisés pour calculer un identifiant unique qui permet une identification cohérente entre les sessions."
     },
     "firstName": {
       "description": {
         "en": "The subject's first name, as provided by their birth certificate. For the purpose of identification, white space, special characters, and accents are removed, with accented characters treated as a fixed ASCII transliteration.",
+        "es": "El nombre del sujeto, según su certificado de nacimiento. A efectos de identificación, se eliminan los espacios en blanco, los caracteres especiales y los acentos, y los caracteres acentuados se tratan como una transliteración ASCII fija.",
         "fr": "Le prénom du sujet, tel qu'il figure dans son acte de naissance. Pour les besoins de l'identification, les espaces blancs, les caractères spéciaux et les accents sont supprimés, les caractères accentués étant traités comme une translittération ASCII fixe."
       },
       "label": {
         "en": "First Name",
+        "es": "Nombre",
         "fr": "Prénom"
       }
     },
     "lastName": {
       "description": {
         "en": "The subject's last name, as provided by their birth certificate. For the purpose of identification, white space, special characters, and accents are removed, with accented characters treated as their ASCII equivalents.",
+        "es": "El apellido del sujeto, según su certificado de nacimiento. A efectos de identificación, se eliminan los espacios en blanco, los caracteres especiales y los acentos, y los caracteres acentuados se tratan como sus equivalentes ASCII.",
         "fr": "Le nom de famille du sujet, tel qu'il figure dans son acte de naissance. Aux fins d'identification, les espaces blancs, les caractères spéciaux et les accents sont supprimés, les caractères accentués étant traités comme leurs équivalents ASCII."
       },
       "label": {
         "en": "Last Name",
+        "es": "Apellido",
         "fr": "Nom de famille"
       }
     },
     "title": {
       "en": "Subject Identification",
+      "es": "Identificación del sujeto",
       "fr": "Identification du client"
     }
   },
   "tags": {
     "en": "Tags",
+    "es": "Etiquetas",
     "fr": "Tags"
   },
   "time": {
     "en": "Time",
+    "es": "Hora",
     "fr": "Heure"
   },
   "timeCollected": {
     "en": "Time Collected",
+    "es": "Hora de recopilación",
     "fr": "Horodatage"
   },
   "update": {
     "en": "Update",
+    "es": "Actualizar",
     "fr": "Mise à jour"
   },
   "uploadSuccessful": {
     "en": "Upload Successful",
+    "es": "Carga exitosa",
     "fr": "Téléversement réussi"
   },
   "user": {
     "en": "User",
+    "es": "Usuario",
     "fr": "Utilisateur"
   },
   "username": {
     "en": "Username",
+    "es": "Nombre de usuario",
     "fr": "Nom d'utilisateur"
   },
   "usernameExists": {
     "en": "Username already exists",
+    "es": "El nombre de usuario ya existe",
     "fr": "Le nom d'utilisateur existe déjà"
   },
   "view": {
     "en": "View",
+    "es": "Ver",
     "fr": "Voir"
   }
 }

--- a/apps/web/src/translations/contact.json
+++ b/apps/web/src/translations/contact.json
@@ -1,31 +1,38 @@
 {
   "message": {
     "en": "Message",
+    "es": "Mensaje",
     "fr": "Message"
   },
   "pageTitle": {
     "en": "Contact Us",
+    "es": "Contáctenos",
     "fr": "Nous contacter"
   },
   "reason": {
     "en": "Reason",
+    "es": "Razón",
     "fr": "Raison"
   },
   "reasons": {
     "bug": {
       "en": "Bug Report",
+      "es": "Informe de error",
       "fr": "Rapport de bug"
     },
     "feedback": {
       "en": "Feedback",
+      "es": "Comentarios",
       "fr": "Retour d'information"
     },
     "other": {
       "en": "Other",
+      "es": "Otro",
       "fr": "Autre"
     },
     "request": {
       "en": "Request",
+      "es": "Solicitud",
       "fr": "Demande"
     }
   }

--- a/apps/web/src/translations/core.json
+++ b/apps/web/src/translations/core.json
@@ -1,332 +1,408 @@
 {
   "anonymous": {
     "en": "Anonymous",
+    "es": "Anónimo",
     "fr": "Anonyme"
   },
   "authors": {
     "en": "Authors",
+    "es": "Autores",
     "fr": "Auteurs"
   },
   "begin": {
     "en": "Begin",
+    "es": "Comenzar",
     "fr": "Commencer"
   },
   "bilingual": {
     "en": "Bilingual",
+    "es": "Bilingüe",
     "fr": "Bilingue"
   },
   "cancel": {
     "en": "Cancel",
+    "es": "Cancelar",
     "fr": "Annuler"
   },
   "changeTheme": {
     "en": "Change Theme",
+    "es": "Cambiar tema",
     "fr": "Changer de thème"
   },
   "close": {
     "en": "Close",
+    "es": "Cerrar",
     "fr": "Fermer"
   },
   "data": {
     "en": "Data",
+    "es": "Datos",
     "fr": "Données"
   },
   "delete": {
     "en": "Delete",
+    "es": "Eliminar",
     "fr": "Supprimer"
   },
   "description": {
     "en": "Description",
+    "es": "Descripción",
     "fr": "Description"
   },
   "details": {
     "en": "Details",
+    "es": "Detalles",
     "fr": "Détails"
   },
   "download": {
     "en": "Download",
+    "es": "Descargar",
     "fr": "Télécharger"
   },
   "edition": {
     "en": "Edition",
+    "es": "Edición",
     "fr": "Édition"
   },
   "editor": {
     "keyboardShortcuts": {
       "format": {
         "en": "Format Document: {{keybinding}}",
+        "es": "Formatear documento: {{keybinding}}",
         "fr": "Appliquer le formatage du code : {{keybinding}}"
       }
     },
     "noFileSelected": {
       "en": "No File Selected",
+      "es": "Ningún archivo seleccionado",
       "fr": "Aucun fichier sélectionné"
     },
     "pleaseSelectFile": {
       "en": "Please Select a File to Begin",
+      "es": "Seleccione un archivo para comenzar",
       "fr": "Veuillez sélectionner un fichier pour commencer"
     }
   },
   "error": {
     "en": "Error",
+    "es": "Error",
     "fr": "Erreur"
   },
   "estimatedDuration": {
     "en": "Estimated Duration",
+    "es": "Duración estimada",
     "fr": "Durée estimée"
   },
   "failedToLoadInstrument": {
     "en": "Failed to Load Instrument",
+    "es": "Error al cargar el instrumento",
     "fr": "Échec du chargement de l'instrument"
   },
   "failedToLoadInstrumentDesc": {
     "en": "An unexpected error occurred while loading this instrument. Please contact the platform administrator for further assistance.",
+    "es": "Se produjo un error inesperado al cargar este instrumento. Comuníquese con el administrador de la plataforma para obtener ayuda.",
     "fr": "Une erreur inattendue s'est produite lors du chargement de cet instrument. Veuillez contacter l'administrateur de la plateforme pour obtenir de l'aide."
   },
   "form": {
     "requiredField": {
       "en": "This field is required",
+      "es": "Este campo es obligatorio",
       "fr": "Ce champ est obligatoire"
     }
   },
   "fullName": {
     "en": "Full Name",
+    "es": "Nombre completo",
     "fr": "Nom et prénom"
   },
   "genericApology": {
     "en": "We apologize for the inconvenience. Please contact us for further assistance.",
+    "es": "Nos disculpamos por las molestias. Comuníquese con nosotros para obtener ayuda.",
     "fr": "Nous nous excusons pour ce désagrément. N'hésitez pas à nous contacter pour obtenir de l'aide."
   },
   "help": {
     "en": "Help",
+    "es": "Ayuda",
     "fr": "Aide"
   },
   "httpRequestFailed": {
     "en": "HTTP Request Failed",
+    "es": "Error en la solicitud HTTP",
     "fr": "Échec de la requête HTTP"
   },
   "identificationData": {
     "dateOfBirth": {
       "label": {
         "en": "Date of Birth",
+        "es": "Fecha de nacimiento",
         "fr": "Date de naissance"
       }
     },
     "firstName": {
       "description": {
         "en": "The subject's first name, as provided by their birth certificate.",
+        "es": "El nombre del sujeto, tal como figura en su acta de nacimiento.",
         "fr": "Le prénom du sujet, tel qu'il figure dans son acte de naissance."
       },
       "label": {
         "en": "First Name",
+        "es": "Nombre",
         "fr": "Prénom"
       }
     },
     "lastName": {
       "description": {
         "en": "The subject's last name, as provided by their birth certificate.",
+        "es": "El apellido del sujeto, tal como figura en su acta de nacimiento.",
         "fr": "Le nom de famille du sujet, tel qu'il figure dans son acte de naissance."
       },
       "label": {
         "en": "Last Name",
+        "es": "Apellido",
         "fr": "Nom de famille"
       }
     },
     "sex": {
       "description": {
         "en": "The subject's biological sex, as assigned at birth.",
+        "es": "El sexo biológico del sujeto, tal como fue asignado al nacer.",
         "fr": "Le sexe biologique du sujet, tel qu'il a été assigné à la naissance."
       },
       "female": {
         "en": "Female",
+        "es": "Femenino",
         "fr": "Féminin"
       },
       "label": {
         "en": "Sex at Birth",
+        "es": "Sexo al nacer",
         "fr": "Sexe à la naissance"
       },
       "male": {
         "en": "Male",
+        "es": "Masculino",
         "fr": "Masculin"
       }
     }
   },
   "instructions": {
     "en": "Instructions",
+    "es": "Instrucciones",
     "fr": "Instructions"
   },
   "instrument": {
     "en": "Instrument",
+    "es": "Instrumento",
     "fr": "Instrument"
   },
   "instrumentComplete": {
     "en": "Instrument Complete",
+    "es": "Instrumento completado",
     "fr": "Instrument complet"
   },
   "instrumentName": {
     "en": "Instrument Name",
+    "es": "Nombre del instrumento",
     "fr": "Nom de l'instrument"
   },
   "language": {
     "en": "Language",
+    "es": "Idioma",
     "fr": "Langue"
   },
   "languages": {
     "english": {
       "en": "English",
+      "es": "Inglés",
       "fr": "Anglais"
     },
     "french": {
       "en": "French",
+      "es": "Francés",
       "fr": "Français"
     }
   },
   "license": {
     "en": "License",
+    "es": "Licencia",
     "fr": "Licence"
   },
   "minutes": {
     "en": "{{minutes}} minute(s)",
+    "es": "{{minutes}} minuto(s)",
     "fr": "{{minutes}} minute(s)"
   },
   "mobileBlocker": {
     "subtitle": {
       "en": "Please try again on a device with a larger screen",
+      "es": "Inténtelo de nuevo en un dispositivo con una pantalla más grande",
       "fr": "Veuillez réessayer sur un appareil doté d'un écran plus grand"
     },
     "title": {
       "en": "Sorry, this feature is not available on mobile",
+      "es": "Lo sentimos, esta función no está disponible en dispositivos móviles",
       "fr": "Désolé, cette fonctionnalité n'est pas disponible sur mobile"
     }
   },
   "name": {
     "en": "Name",
+    "es": "Nombre",
     "fr": "Nom"
   },
   "networkError": {
     "en": "Network Error",
+    "es": "Error de red",
     "fr": "Erreur de réseau"
   },
   "nextInstrument": {
     "en": "Next Instrument: {{title}}",
+    "es": "Siguiente instrumento: {{title}}",
     "fr": "Next Instrument: {{title}}"
   },
   "no": {
     "en": "No",
+    "es": "No",
     "fr": "Non"
   },
   "notFound": {
     "en": "Not Found",
+    "es": "No encontrado",
     "fr": "Pas trouvé"
   },
   "openSourceLicense": {
     "en": "This is a free and open-source license",
+    "es": "Esta es una licencia libre y de código abierto",
     "fr": "Il s'agit d'une licence libre"
   },
   "print": {
     "en": "Print",
+    "es": "Imprimir",
     "fr": "Imprimer"
   },
   "proprietaryLicense": {
     "en": "This is not a free and open source license",
+    "es": "Esta no es una licencia libre y de código abierto",
     "fr": "Il ne s'agit pas d'une licence libre"
   },
   "referenceLink": {
     "en": "Reference Link",
+    "es": "Enlace de referencia",
     "fr": "Lien vers la référence"
   },
   "responses": {
     "en": "Responses",
+    "es": "Respuestas",
     "fr": "Réponses"
   },
   "results": {
     "en": "Results",
+    "es": "Resultados",
     "fr": "Résultats"
   },
   "save": {
     "en": "Save",
+    "es": "Guardar",
     "fr": "Enregistrer"
   },
   "seriesInstrumentContent": {
     "inProgress": {
       "en": "Series Instrument in Process",
+      "es": "Serie de instrumentos en proceso",
       "fr": "Série d'instruments en cours"
     },
     "instrumentsCompleted": {
       "en": "Instruments Completed: {{completed}}/{{total}}",
+      "es": "Instrumentos completados: {{completed}}/{{total}}",
       "fr": "Nombre d'instruments complétés : {{completed}}/{{total}}"
     }
   },
   "somethingWentWrong": {
     "en": "Something Went Wrong",
+    "es": "Algo salió mal",
     "fr": "Quelque chose n'a pas fonctionné"
   },
   "sourceLink": {
     "en": "Source Link",
+    "es": "Enlace al código fuente",
     "fr": "Lien vers le code source"
   },
   "steps": {
     "overview": {
       "en": "Overview",
+      "es": "Descripción general",
       "fr": "Aperçu"
     },
     "questions": {
       "en": "Content",
+      "es": "Contenido",
       "fr": "Contenu"
     },
     "summary": {
       "en": "Summary",
+      "es": "Resumen",
       "fr": "Résumé"
     }
   },
   "subject": {
     "en": "Subject",
+    "es": "Sujeto",
     "fr": "Client"
   },
   "submit": {
     "en": "Submit",
+    "es": "Enviar",
     "fr": "Soumettre"
   },
   "summary": {
     "subtitle": {
       "en": "Completed on {{ dateCompleted }}",
+      "es": "Completado el {{ dateCompleted }}",
       "fr": "Remplie le {{ dateCompleted }}"
     },
     "title": {
       "en": "Summary of Results for the {{title}}",
+      "es": "Resumen de resultados para el {{title}}",
       "fr": "{{title}} : résumé des résultats"
     },
     "titleFallback": {
       "en": "Summary of Results",
+      "es": "Resumen de resultados",
       "fr": "Résumé des résultats"
     }
   },
   "table": {
     "en": "Table",
+    "es": "Tabla",
     "fr": "Tableau"
   },
   "tag": {
     "en": "Tag",
+    "es": "Etiqueta",
     "fr": "Tag"
   },
   "tags": {
     "en": "Tags",
+    "es": "Etiquetas",
     "fr": "Tags"
   },
   "title": {
     "en": "Title",
+    "es": "Título",
     "fr": "Titre"
   },
   "unknownError": {
     "en": "Unknown Error",
+    "es": "Error desconocido",
     "fr": "Erreur inconnue"
   },
   "version": {
     "en": "Version",
+    "es": "Versión",
     "fr": "Version"
   },
   "yes": {
     "en": "Yes",
+    "es": "Sí",
     "fr": "Oui"
   }
 }

--- a/apps/web/src/translations/datahub.json
+++ b/apps/web/src/translations/datahub.json
@@ -2,74 +2,91 @@
   "assignments": {
     "assignedAt": {
       "en": "Assigned",
+      "es": "Asignado",
       "fr": "Attribué"
     },
     "assignedInstruments": {
       "en": "Assigned Instruments",
+      "es": "Instrumentos asignados",
       "fr": "Instruments assignés"
     },
     "assignmentSliderDesc": {
       "en": "View additional details related to this assignment here. This includes the link to the assignment, which you can send to the client.",
+      "es": "Consulte aquí los detalles adicionales relacionados con esta asignación. Esto incluye el enlace a la asignación, que puede enviar al cliente.",
       "fr": "Consultez ici les détails supplémentaires relatifs à cette assignation. Il s'agit notamment du lien vers l'assignation, que vous pouvez envoyer au client."
     },
     "expiresAt": {
       "en": "Expires",
+      "es": "Vencimiento",
       "fr": "Expiration"
     },
     "link": {
       "en": "Link to Assignment",
+      "es": "Enlace a la asignación",
       "fr": "Lien vers l'assignation"
     },
     "resendNotification": {
       "en": "Resend Notification",
+      "es": "Reenviar notificación",
       "fr": "Renvoyer la notification"
     },
     "status": {
       "en": "Status",
+      "es": "Estado",
       "fr": "État"
     },
     "statusOptions": {
       "canceled": {
         "en": "Canceled",
+        "es": "Cancelado",
         "fr": "Annulé"
       },
       "complete": {
         "en": "Complete",
+        "es": "Completado",
         "fr": "Terminé"
       },
       "expired": {
         "en": "Expired",
+        "es": "Expirado",
         "fr": "Expiré"
       },
       "outstanding": {
         "en": "Outstanding",
+        "es": "Pendiente",
         "fr": "À compléter"
       }
     },
     "title": {
       "en": "Title",
+      "es": "Título",
       "fr": "Titre"
     }
   },
   "downloadInfo": {
     "allTime": {
       "en": "Timeframe: All time",
+      "es": "Periodo: Todo el tiempo",
       "fr": "Période : Toujours"
     },
     "download": {
       "en": "Download",
+      "es": "Descargar",
       "fr": "Télécharger"
     },
     "measurement": {
       "en": "Measures: ",
+      "es": "Medidas: ",
       "fr": "Mesures : "
     },
     "subjectText": {
       "en": "{} of Subject: {}",
+      "es": "{} del sujeto: {}",
       "fr": "{} du client : {}"
     },
     "time": {
       "en": "Timeframe: ",
+      "es": "Periodo: ",
       "fr": "Période : "
     }
   },
@@ -77,47 +94,57 @@
     "lookup": {
       "title": {
         "en": "Subject Lookup",
+        "es": "Buscar sujeto",
         "fr": "Trouver un client"
       }
     },
     "table": {
       "export": {
         "en": "Export",
+        "es": "Exportar",
         "fr": "Exporter"
       },
       "exportHelpText": {
         "en": "This data is provided in an ultra-long format. Each row corresponds to the value for a single measure. Rows corresponding to the same record will have matching subject identifiers and timestamps.",
+        "es": "Estos datos se proporcionan en un formato ultralargo. Cada fila corresponde al valor de una sola medida. Las filas correspondientes al mismo registro tendrán identificadores de sujeto y marcas de tiempo coincidentes.",
         "fr": "Ces données sont fournies dans un format ultra-long. Chaque ligne correspond à la valeur d'une seule mesure. Les lignes correspondant à un même enregistrement auront des identifiants de sujet et des horodatages correspondants."
       },
       "filters": {
         "en": "Filters",
+        "es": "Filtros",
         "fr": "Filtres"
       },
       "subject": {
         "en": "Subject",
+        "es": "Sujeto",
         "fr": "Client"
       }
     },
     "title": {
       "en": "Data Hub",
+      "es": "Centro de datos",
       "fr": "Centre de données"
     }
   },
   "files": {
     "dateCollected": {
       "en": "Date Collected",
+      "es": "Fecha de recopilación",
       "fr": "Date de collecte"
     },
     "download": {
       "en": "Download",
+      "es": "Descargar",
       "fr": "Télécharger"
     },
     "empty": {
       "en": "No files have been uploaded for this subject.",
+      "es": "No se han cargado archivos para este sujeto.",
       "fr": "Aucun fichier n'a été téléversé pour ce client."
     },
     "instrument": {
       "en": "Instrument",
+      "es": "Instrumento",
       "fr": "Instrument"
     }
   },
@@ -125,71 +152,87 @@
     "tabs": {
       "assignments": {
         "en": "Assignments",
+        "es": "Asignaciones",
         "fr": "Assignations"
       },
       "files": {
         "en": "Files",
+        "es": "Archivos",
         "fr": "Fichiers"
       },
       "graph": {
         "en": "Graph",
+        "es": "Gráfico",
         "fr": "Graphique"
       },
       "table": {
         "en": "Table",
+        "es": "Tabla",
         "fr": "Tableau"
       }
     },
     "title": {
       "en": "Instrument Records for Subject {{id}}",
+      "es": "Registros de instrumentos del sujeto {{id}}",
       "fr": "Dossiers d'instruments pour le client {{id}}"
     }
   },
   "visualization": {
     "instrument": {
       "en": "Instrument",
+      "es": "Instrumento",
       "fr": "Instrument"
     },
     "measures": {
       "en": "Measures",
+      "es": "Medidas",
       "fr": "Mesures"
     },
     "selectEdition": {
       "en": "Select an edition",
+      "es": "Seleccione una edición",
       "fr": "Sélectionnez une édition"
     },
     "selectInstrument": {
       "en": "Select an instrument",
+      "es": "Seleccione un instrumento",
       "fr": "Sélectionnez un instrument"
     },
     "selectMeasures": {
       "en": "Please select one or more measures",
+      "es": "Por favor, seleccione una o más medidas",
       "fr": "Veuillez sélectionner au moins une mesure"
     },
     "timeframe": {
       "en": "Timeframe",
+      "es": "Periodo",
       "fr": "Période"
     },
     "timeframeOptions": {
       "all": {
         "en": "All-Time",
+        "es": "Todo el tiempo",
         "fr": "Toujours"
       },
       "month": {
         "en": "Past Month",
+        "es": "Último mes",
         "fr": "Mois écoulé"
       },
       "year": {
         "en": "Past Year",
+        "es": "Último año",
         "fr": "Année écoulée"
       }
     },
     "xLabel": {
       "en": "Date Collected",
+      "es": "Fecha de recopilación",
       "fr": "Date d'enregistrement"
     },
     "yLabel": {
       "en": "Value",
+      "es": "Valor",
       "fr": "Valeur"
     }
   }

--- a/apps/web/src/translations/group.json
+++ b/apps/web/src/translations/group.json
@@ -2,38 +2,47 @@
   "manage": {
     "accessibleInstrumentDemoNote": {
       "en": "Please note that this feature is disabled in demo mode to avoid disrupting other users.",
+      "es": "Tenga en cuenta que esta funcionalidad está desactivada en modo de demostración para evitar interrumpir a otros usuarios.",
       "fr": "Veuillez noter que cette fonctionnalité est désactivée en mode démo, afin d'éviter de perturber les autres utilisateurs."
     },
     "accessibleInstruments": {
       "en": "Accessible Instruments",
+      "es": "Instrumentos accesibles",
       "fr": "Instruments accessibles"
     },
     "accessibleInstrumentsDesc": {
       "en": "Select the instruments that are shown to you and other members of your group. This can be changed by a group manager at any time.",
+      "es": "Seleccione los instrumentos que se muestran a usted y a los demás miembros de su grupo. Esto puede ser modificado por un administrador de grupo en cualquier momento.",
       "fr": "Sélectionnez les instruments qui vous sont présentés ainsi qu'aux autres membres de votre groupe. Cette sélection peut être modifiée à tout moment par un responsable de groupe."
     },
     "defaultSubjectIdMethod": {
       "en": "Subject Identification Method (Default)",
+      "es": "Método de identificación del sujeto (predeterminado)",
       "fr": "Méthode d'identification du sujet par défaut"
     },
     "forms": {
       "en": "Forms",
+      "es": "Formularios",
       "fr": "Formulaires"
     },
     "groupSettings": {
       "en": "Group Settings",
+      "es": "Configuración del grupo",
       "fr": "Paramètres du groupe"
     },
     "interactive": {
       "en": "Interactive Tasks",
+      "es": "Tareas interactivas",
       "fr": "Tâches interactives"
     },
     "series": {
       "en": "Series",
+      "es": "Series",
       "fr": "Séries"
     },
     "pageTitle": {
       "en": "Manage Group",
+      "es": "Gestionar grupo",
       "fr": "Gérer le groupe"
     }
   }

--- a/apps/web/src/translations/instruments.json
+++ b/apps/web/src/translations/instruments.json
@@ -2,66 +2,80 @@
   "accessible": {
     "title": {
       "en": "Administer Instrument",
+      "es": "Administrar instrumento",
       "fr": "Administrer un instrument"
     }
   },
   "manage": {
     "title": {
       "en": "Manage Instruments",
+      "es": "Gestionar instrumentos",
       "fr": "Gérer les instruments"
     }
   },
   "overview": {
     "estimatedDuration": {
       "en": "{{minutes}} minutes",
+      "es": "{{minutes}} minutos",
       "fr": "{{minutes}} minutes"
     }
   },
   "props": {
     "description": {
       "en": "Description",
+      "es": "Descripción",
       "fr": "Description"
     },
     "details": {
       "en": "Details",
+      "es": "Detalles",
       "fr": "Détails"
     },
     "estimatedDuration": {
       "en": "Estimated Duration",
+      "es": "Duración estimada",
       "fr": "Durée estimée"
     },
     "instructions": {
       "en": "Instructions",
+      "es": "Instrucciones",
       "fr": "Instructions"
     },
     "name": {
       "en": "Instrument Name",
+      "es": "Nombre del instrumento",
       "fr": "Nom de l'instrument"
     },
     "tag": {
       "en": "Tag",
+      "es": "Etiqueta",
       "fr": "Tag"
     },
     "tags": {
       "en": "Tags",
+      "es": "Etiquetas",
       "fr": "Tags"
     },
     "title": {
       "en": "Title",
+      "es": "Título",
       "fr": "Titre"
     },
     "version": {
       "en": "Version",
+      "es": "Versión",
       "fr": "Version"
     }
   },
   "summary": {
     "subtitle": {
       "en": "Completed on {{ dateCompleted }}",
+      "es": "Completado el {{ dateCompleted }}",
       "fr": "Complété le {{ dateCompleted }}"
     },
     "title": {
       "en": "Summary of Results for the {{title}}",
+      "es": "Resumen de resultados del {{title}}",
       "fr": "{{title}} : Résumé des résultats"
     }
   },
@@ -69,15 +83,18 @@
     "filters": {
       "language": {
         "en": "Language",
+        "es": "Idioma",
         "fr": "Langue"
       },
       "tags": {
         "en": "Tags",
+        "es": "Etiquetas",
         "fr": "Tags"
       }
     },
     "title": {
       "en": "Instruments",
+      "es": "Instrumentos",
       "fr": "Instruments"
     }
   }

--- a/apps/web/src/translations/layout.json
+++ b/apps/web/src/translations/layout.json
@@ -2,82 +2,100 @@
   "branding": {
     "title": {
       "en": "Open Data Capture",
+      "es": "Open Data Capture",
       "fr": "Open Data Capture"
     }
   },
   "endSessionModal": {
     "message": {
       "en": "Are you sure you want to end the current session? If you choose to proceed, you'll be taken back to the begin session page.",
+      "es": "Está seguro de que desea finalizar la sesión actual? Si decide continuar, será redirigido a la página para comenzar una nueva sesión.",
       "fr": "Êtes-vous sûr de vouloir mettre fin à la session en cours ? Si vous décidez de continuer, vous serez ramené à la page de démarrage de session."
     },
     "title": {
       "en": "End Session",
+      "es": "Finalizar sesión",
       "fr": "Terminer la session en cours"
     }
   },
   "footer": {
     "contact": {
       "en": "Contact Us",
+      "es": "Contáctenos",
       "fr": "Contactez-nous"
     },
     "documentation": {
       "en": "Documentation",
+      "es": "Documentación",
       "fr": "Documentation"
     },
     "license": {
       "en": "License",
+      "es": "Licencia",
       "fr": "Licence"
     },
     "sourceCode": {
       "en": "Source Code",
+      "es": "Código fuente",
       "fr": "Code source"
     }
   },
   "navLinks": {
     "accessibleInstruments": {
       "en": "Administer Instrument",
+      "es": "Administrar instrumento",
       "fr": "Administrer un instrument"
     },
     "createInstrument": {
       "en": "Add Instrument",
+      "es": "Agregar instrumento",
       "fr": "Ajouter un instrument"
     },
     "dashboard": {
       "en": "Dashboard",
+      "es": "Panel de control",
       "fr": "Tableau de bord"
     },
     "datahub": {
       "en": "Data Hub",
+      "es": "Centro de datos",
       "fr": "Centre de données"
     },
     "endSession": {
       "en": "End Current Session",
+      "es": "Finalizar la sesión actual",
       "fr": "Terminer la session en cours"
     },
     "manageGroup": {
       "en": "Manage Group",
+      "es": "Gestionar grupo",
       "fr": "Gérer le groupe"
     },
     "remoteAssignment": {
       "en": "Remote Assignment",
+      "es": "Tarea remota",
       "fr": "Tâche à distance"
     },
     "startSession": {
       "en": "Start Session",
+      "es": "Iniciar una sesión",
       "fr": "Démarrer une session"
     },
     "upload": {
       "en": "Upload Data",
+      "es": "Cargar datos",
       "fr": "Téléverser les données"
     },
     "viewCurrentSubject": {
       "en": "View Current Subject",
+      "es": "Ver el sujeto actual",
       "fr": "Voir le client actuel"
     }
   },
   "organization": {
     "name": {
       "en": "Douglas Neuroinformatics Platform",
+      "es": "Douglas Neuroinformatics Platform",
       "fr": "Douglas Neuroinformatics Platform"
     }
   }

--- a/apps/web/src/translations/session.json
+++ b/apps/web/src/translations/session.json
@@ -2,44 +2,53 @@
   "additionalData": {
     "title": {
       "en": "Additional Data",
+      "es": "Datos adicionales",
       "fr": "Données supplémentaires"
     }
   },
   "dateAssessed": {
     "description": {
       "en": "If the session took place on a date other than today, you can change it here.",
+      "es": "Si la sesión tuvo lugar en una fecha distinta a hoy, puede modificarla aquí.",
       "fr": "Si la session a eu lieu à une autre date qu'aujourd'hui, vous pouvez la modifier ici."
     },
     "label": {
       "en": "Date Assessed",
+      "es": "Fecha de evaluación",
       "fr": "Date d'évaluation"
     }
   },
   "errors": {
     "assessmentMustBeInPast": {
       "en": "The assessment must be in the past",
+      "es": "La evaluación debe estar en el pasado",
       "fr": "L'évaluation doit être dans le passé"
     },
     "mustBeAdult": {
       "en": "The subject must be at least 18 years old",
+      "es": "El sujeto debe tener al menos 18 años de edad",
       "fr": "Le client doit avoir au moins 18 ans"
     }
   },
   "startSession": {
     "en": "Start Session",
+    "es": "Iniciar sesión",
     "fr": "Démarrer une session"
   },
   "type": {
     "in-person": {
       "en": "In-Person",
+      "es": "En persona",
       "fr": "En personne"
     },
     "label": {
       "en": "Type of Assessment",
+      "es": "Tipo de evaluación",
       "fr": "Type d'évaluation"
     },
     "retrospective": {
       "en": "Retrospective",
+      "es": "Retrospectiva",
       "fr": "Rétrospective"
     }
   }

--- a/apps/web/src/translations/setup.json
+++ b/apps/web/src/translations/setup.json
@@ -2,53 +2,65 @@
   "admin": {
     "description": {
       "en": "To use the application, there must be at least one platform administrator. Ensure you remember these credentials, as failure to do so may result in data loss.",
+      "es": "Para utilizar la aplicación, debe haber al menos un administrador de la plataforma. Asegúrese de recordar estas credenciales, ya que no hacerlo puede resultar en la pérdida de datos.",
       "fr": "Pour utiliser l'application, il faut qu'il y ait au moins un administrateur. Assurez-vous de vous souvenir de ces informations d'identification, faute de quoi vous risquez de perdre des données."
     },
     "password": {
       "en": "Password",
+      "es": "Contraseña",
       "fr": "Mot de passe"
     },
     "title": {
       "en": "Admin",
+      "es": "Administrador",
       "fr": "Administrateur"
     },
     "username": {
       "en": "Username",
+      "es": "Nombre de usuario",
       "fr": "Nom d'utilisateur"
     }
   },
   "demo": {
     "description": {
       "en": "If you're testing the platform, you have the option to populate the database with sample data.",
+      "es": "Si está probando la plataforma, tiene la opción de poblar la base de datos con datos de muestra.",
       "fr": "Si vous testez la plateforme, vous avez la possibilité d'alimenter la base de données avec des échantillons de données."
     },
     "dummySubjectCount": {
       "en": "Number of Dummy Subjects",
+      "es": "Número de sujetos ficticios",
       "fr": "Nombre de clients fictifs"
     },
     "init": {
       "en": "Initialize Demo",
+      "es": "Inicializar demostración",
       "fr": "Initialiser la démonstration"
     },
     "recordsPerSubject": {
       "en": "Records Per Subject",
+      "es": "Registros por sujeto",
       "fr": "Enregistrements par sujet"
     },
     "title": {
       "en": "Demo",
+      "es": "Demostración",
       "fr": "Démonstration"
     }
   },
   "loadingSubtitle": {
     "en": "Please be patient, this may take a while...",
+    "es": "Por favor, tenga paciencia, esto puede tardar un momento...",
     "fr": "Veuillez patienter, cela peut prendre un certain temps..."
   },
   "loadingTitle": {
     "en": "Initializing Application",
+    "es": "Inicializando la aplicación",
     "fr": "Initialisation de l'application"
   },
   "pageTitle": {
     "en": "Setup",
+    "es": "Configuración",
     "fr": "Mise en service"
   }
 }

--- a/apps/web/src/translations/upload.json
+++ b/apps/web/src/translations/upload.json
@@ -1,6 +1,7 @@
 {
   "title": {
     "en": "Instrument Title",
+    "es": "Título del instrumento",
     "fr": "Titre de l'instrument"
   }
 }

--- a/packages/react-core/src/components/InteractiveContent/InteractiveContent.tsx
+++ b/packages/react-core/src/components/InteractiveContent/InteractiveContent.tsx
@@ -63,7 +63,7 @@ export const _InteractiveContent = React.memo<InteractiveContentProps>(function 
   const isLocked = Boolean(enableLanguageLock) && hasSelectedLanguage;
 
   const handleChangeLanguageEvent = useCallback(
-    (event: CustomEvent<Language>) => {
+    (event: CustomEvent<string>) => {
       if (event.detail !== 'en' && event.detail !== 'fr') {
         console.error(`Cannot change language: invalid language '${event.detail}', expected 'en' or 'fr'`);
         return;
@@ -179,7 +179,11 @@ export const _InteractiveContent = React.memo<InteractiveContentProps>(function 
                         changeLanguage(language);
                       }}
                     >
-                      {ALL_LANGUAGES[language][resolvedLanguage]}
+                      {
+                        ALL_LANGUAGES[language][
+                          resolvedLanguage === 'en' || resolvedLanguage === 'fr' ? resolvedLanguage : 'en'
+                        ]
+                      }
                     </DropdownMenu.Item>
                   ))}
                 </DropdownMenu.Content>

--- a/packages/react-core/src/hooks/useInterpretedInstrument.ts
+++ b/packages/react-core/src/hooks/useInterpretedInstrument.ts
@@ -45,7 +45,10 @@ export function useInterpretedInstrument<TInstrument extends AnyUnilingualInstru
     if (instrument) {
       setState({
         instrument: {
-          ...(translateInstrument(instrument, resolvedLanguage) as TInstrument),
+          ...(translateInstrument(
+            instrument,
+            resolvedLanguage === 'en' || resolvedLanguage === 'fr' ? resolvedLanguage : 'en'
+          ) as TInstrument),
           supportedLanguages: Array.isArray(instrument.language) ? instrument.language : [instrument.language]
         },
         status: 'DONE'

--- a/packages/schemas/src/setup/setup.ts
+++ b/packages/schemas/src/setup/setup.ts
@@ -194,6 +194,7 @@ const $SetupState = z.object({
 });
 
 const $UpdateSetupStateData = z.object({
+  activeLanguages: z.array(z.string()).optional(),
   branding: $BrandingConfig.nullish(),
   isExperimentalFeaturesEnabled: z.boolean().nullish()
 });


### PR DESCRIPTION
Splits #1434 into three PRs. **This is PR 3 of 3 and merges last**, per @gdevenyi's request.

## Merge order

| Order | PR | Branch | Base |
|---|---|---|---|
| 1st | #1440 — UX fixes | `split/ux` | `main` |
| 2nd | #1439 — mailer | `split/mailer` | `main` |
| **3rd** | this PR — Spanish + active languages | `split/language` | `split/mailer` |

> **Base is `split/mailer`, not `main`.** GitHub will retarget it to `main` automatically once #1439 merges. The diff shown here is language-only.

## Why this one is stacked rather than independent

Declaring `es` in `LanguageOptions` makes `es` a **required** key in every `t({ ... })` call in `apps/web` — that's why this PR touches 82 files. Whichever PR lands *after* that declaration exists must supply Spanish for its own strings.

Since this goes last, it carries the Spanish for the mailer's strings too: **117 of the lines here translate the mail admin page, group email templates, and assignment email form** introduced in #1439. That's only possible if those files exist on this branch, hence the stack. The upside of this ordering is that #1439 needs no follow-up patch, and the `activeLanguages` / `ALL_LANGUAGES` plumbing is no longer duplicated across two branches — it lives in #1439 and is simply inherited here.

## What's here

- `es` declared in `LanguageOptions`, and Spanish added to every `t({ ... })` call in the app, plus the `es` keys in `apps/web/src/translations/*.json`. No new translation keys — the JSON changes are purely `es` additions.
- An admin **Languages** card so an instance chooses which languages it offers. The sidebar, navbar, and login language toggles render only active languages and disappear entirely when one language is active.
- The gateway resolves a `?lang` query param, which is what makes the assignment links emailed by #1439 open in the participant's language.
- Widening `Language` with `es` makes it broader than the instrument runtime's `en | fr`, so the instrument translation call sites narrow explicitly.

## Note on `admin/settings.tsx`

The autosave refactor + `SaveStatus` component landed here rather than in the UX PR, because the new Languages card is built on `autosave` — separating them would have meant inventing a Save-button variant of the card that exists nowhere in #1434.

## Verification

`tsc` and `eslint` clean for `schemas`, `react-core`, `web`, `gateway`, `api`; `pnpm test` 382 passed / 1 skipped. Merging all three PRs in the order above was rehearsed end to end: **zero conflicts**, and the assembled tree typechecks, lints, and passes 382 tests. Two redundant type assertions (`Navbar`, `Sidebar`) were removed to satisfy `no-unnecessary-type-assertion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
