### PR TITLE
fix(web): keyboard navigation and layout fixes in the instrument list and sidebar

### DIFF
--- a/apps/web/src/components/InstrumentCard/InstrumentCard.tsx
+++ b/apps/web/src/components/InstrumentCard/InstrumentCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Card, Heading, Tooltip } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
+import { cn } from '@douglasneuroinformatics/libui/utils';
 import { licenses } from '@opendatacapture/licenses';
 import { InstrumentIcon } from '@opendatacapture/react-core';
 import type { TranslatedInstrumentInfo } from '@opendatacapture/schemas/instrument';
@@ -16,11 +17,12 @@ type TextCardItem = BaseCardItem & { kind: 'text'; text?: string };
 type CardItem = LinkCardItem | TextCardItem;
 
 type InstrumentCardProps = {
+  highlighted?: boolean;
   instrument: TranslatedInstrumentInfo;
   onClick: () => void;
 };
 
-export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => {
+export const InstrumentCard = ({ highlighted, instrument, onClick }: InstrumentCardProps) => {
   const { t } = useTranslation();
 
   const license = licenses.get(instrument.details.license);
@@ -124,12 +126,14 @@ export const InstrumentCard = ({ instrument, onClick }: InstrumentCardProps) => 
 
   return (
     <Card
-      className="group flex gap-8 p-6 transition-transform duration-300 ease-in-out hover:scale-[1.03] hover:cursor-pointer sm:p-8"
+      className={cn(
+        'group flex gap-8 p-6 transition-transform duration-300 ease-in-out hover:scale-[1.03] hover:cursor-pointer sm:p-8',
+        highlighted && 'bg-sky-100/60 ring-2 ring-sky-500/60 dark:bg-sky-900/30'
+      )}
       data-testid={`instrument-card-${instrument.id}`}
       role="button"
-      tabIndex={0}
+      tabIndex={-1}
       onClick={onClick}
-      onKeyDown={onClick}
     >
       <div className="hidden shrink-0 items-center justify-center sm:flex md:min-w-24 lg:min-w-32">
         <div className="flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100 text-indigo-500">

--- a/apps/web/src/components/InstrumentShowcase/InstrumentShowcase.tsx
+++ b/apps/web/src/components/InstrumentShowcase/InstrumentShowcase.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ListboxDropdown, SearchBar } from '@douglasneuroinformatics/libui/components';
 import type { ListboxDropdownOption } from '@douglasneuroinformatics/libui/components';
@@ -26,6 +26,8 @@ export const InstrumentShowcase: React.FC<{
   const [selectedLanguages, setSelectedLanguages] = useState<InstrumentShowcaseLanguageOption[]>([]);
   const [selectedTags, setSelectedTags] = useState<ListboxDropdownOption[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     const updatedFilteredInstruments = availableInstruments.filter(({ details, kind, supportedLanguages, tags }) => {
@@ -45,6 +47,7 @@ export const InstrumentShowcase: React.FC<{
       return a.details.title.localeCompare(b.details.title);
     });
     setFilteredInstruments(updatedFilteredInstruments);
+    setHighlightedIndex(0);
   }, [availableInstruments, selectedKinds, selectedLanguages, selectedTags, searchTerm]);
 
   useEffect(() => {
@@ -58,8 +61,40 @@ export const InstrumentShowcase: React.FC<{
     );
   }, [availableInstruments]);
 
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll<HTMLElement>('[data-instrument-index]');
+    items[highlightedIndex]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (filteredInstruments.length === 0) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setHighlightedIndex((prev) => Math.min(prev + 1, filteredInstruments.length - 1));
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const instrument = filteredInstruments[highlightedIndex];
+        if (instrument) {
+          onSelect(instrument);
+        }
+      }
+    },
+    [filteredInstruments, highlightedIndex, onSelect]
+  );
+
   return (
-    <div className="flex flex-col gap-5" data-testid="instrument-showcase">
+    <div
+      className="flex flex-col gap-5"
+      data-testid="instrument-showcase"
+      role="toolbar"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
       <div className="flex items-center gap-2.5">
         <SearchBar
           className="grow"
@@ -85,19 +120,24 @@ export const InstrumentShowcase: React.FC<{
           </div>
         </div>
       </div>
-      <ul className="flex flex-col gap-5">
+      <ul className="flex flex-col gap-5" ref={listRef}>
         <AnimatePresence mode="popLayout">
           {filteredInstruments.map((instrument, i) => {
             return (
               <motion.li
                 layout
                 animate={{ opacity: 1, y: 0 }}
+                data-instrument-index={i}
                 exit={{ opacity: 0, y: 80 }}
                 initial={{ opacity: 0, y: 80 }}
                 key={instrument.id}
                 transition={{ bounce: 0.2, delay: 0.15 * i, duration: 1.5, type: 'spring' }}
               >
-                <InstrumentCard instrument={instrument} onClick={() => onSelect(instrument)} />
+                <InstrumentCard
+                  highlighted={i === highlightedIndex}
+                  instrument={instrument}
+                  onClick={() => onSelect(instrument)}
+                />
               </motion.li>
             );
           })}

--- a/apps/web/src/components/NavGroup/NavGroup.tsx
+++ b/apps/web/src/components/NavGroup/NavGroup.tsx
@@ -31,14 +31,13 @@ export const NavGroup = ({
   const containsActive = items.some((item) => item.url === location.pathname);
   const [isOpen, setIsOpen] = React.useState(containsActive);
 
-  // Navigating into the group from anywhere else (a link, a redirect, a restored URL) must reveal the
-  // active child rather than leaving it hidden inside a collapsed group. Only expanding here — never
-  // collapsing — keeps a group the user opened deliberately open as they navigate away from it.
   React.useEffect(() => {
     if (containsActive) {
       setIsOpen(true);
+    } else {
+      setIsOpen(false);
     }
-  }, [containsActive]);
+  }, [location.pathname]);
 
   return (
     <div className="flex flex-col">

--- a/apps/web/src/components/QRCode.tsx
+++ b/apps/web/src/components/QRCode.tsx
@@ -18,7 +18,7 @@ export const QRCode = ({ url }: { url: string }) => {
           light: '#0000'
         },
         margin: 2,
-        scale: 6
+        scale: 4
       },
       (error) => {
         if (error) {

--- a/apps/web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar/Sidebar.tsx
@@ -45,7 +45,7 @@ export const Sidebar = () => {
           <hr className="mt-2 h-[1px] border-none bg-slate-700" />
         </div>
       )}
-      <nav className="flex w-full flex-col divide-y divide-slate-700">
+      <nav className="scrollbar-none flex min-h-0 flex-1 flex-col divide-y divide-slate-700 overflow-y-auto">
         {navItems.map((items, i) => (
           <div className="flex flex-col py-1 first:pt-0 last:pb-0" key={i}>
             {items.map(({ disabled, url, ...props }) =>
@@ -104,7 +104,6 @@ export const Sidebar = () => {
           </div>
         ))}
       </nav>
-      <hr className="invisible mt-auto" />
       <AnimatePresence>
         {currentSession && (
           <motion.div

--- a/apps/web/src/hooks/useNavItems.ts
+++ b/apps/web/src/hooks/useNavItems.ts
@@ -23,10 +23,12 @@ import { useAppStore } from '@/store';
 import { useSetupStateQuery } from './useSetupStateQuery';
 
 export type NavItem = {
+  /** When present, this item renders as a collapsible group rather than a link. */
   children?: NavItem[];
   disabled?: boolean;
   icon: React.ComponentType<Omit<React.SVGProps<SVGSVGElement>, 'ref'>>;
   label: string;
+  /** The route to navigate to. Omitted for collapsible group headers. */
   url?: string;
 };
 
@@ -117,17 +119,17 @@ export function useNavItems() {
             url: '/admin/settings'
           },
           {
+            icon: LogsIcon,
+            label: t('common.auditLogs'),
+            url: '/admin/audit/logs'
+          },
+          {
             icon: PaletteIcon,
             label: t({
               en: 'Branding',
               fr: 'Image de marque'
             }),
             url: '/admin/branding'
-          },
-          {
-            icon: LogsIcon,
-            label: t('common.auditLogs'),
-            url: '/admin/audit/logs'
           },
           {
             icon: PackageIcon,

--- a/apps/web/src/routes/_app/instruments/accessible-instruments.tsx
+++ b/apps/web/src/routes/_app/instruments/accessible-instruments.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Heading } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
@@ -15,6 +15,11 @@ const RouteComponent = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const instrumentInfoQuery = useInstrumentInfoQuery();
+
+  useEffect(() => {
+    const input = document.querySelector<HTMLInputElement>('[data-testid="instrument-search-bar"] input');
+    input?.focus();
+  }, []);
 
   return (
     <div data-testid="accessible-instruments-page">


### PR DESCRIPTION
Splits #1434 into three PRs. **This is PR 1 of 3 and merges first.**

## Merge order

| Order | PR | Branch | Base |
|---|---|---|---|
| **1st** | this PR — UX fixes | `split/ux` | `main` |
| 2nd | #1439 — mailer | `split/mailer` | `main` |
| 3rd | #1438 — Spanish + active languages | `split/language` | `split/mailer` |

This PR is fully independent of the other two: it adds **zero** new `t()` calls, so nothing in it changes when Spanish lands. It goes first because it's the smallest and carries no cross-PR constraints. Verified: merging all three in this order produces **zero conflicts**.

## What's here

- **Instrument showcase is keyboard navigable** — arrow keys move a highlight through the filtered results, Enter selects, and the highlighted card scrolls into view. Focus moves to the search input on entering the accessible instruments page. Individual cards lose their own tab stop so the list is traversed as one control rather than one stop per card.
- **Sidebar nav scrolls independently** once it outgrows the viewport, instead of pushing the session card and footer off screen.
- **Nav groups collapse when navigation leaves them**, so at most one group is open at a time. Note this reverses a deliberate behaviour documented in the code on `main` (a group the user opened stayed open as they navigated away) — worth a second look if that was intentional.
- Audit Logs moves above Branding in the admin nav; QR codes render at a smaller scale.

## Dropped from #1434

The whitespace realignment of the `InstrumentRepo` model in `schema.prisma` is not carried over. It is incidental editor churn, and `prisma format` on current `main` produces a different, larger realignment (it also touches `InstrumentRecord`), so replaying it would have added unrelated noise rather than a formatting fix.

## Verification

`tsc`, `eslint`, and `prettier --check` clean for `web`; `pnpm test` 307 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
