### PR TITLE
feat(i18n): add Spanish translations

### DIFF
--- a/apps/web/src/translations/auth.json
+++ b/apps/web/src/translations/auth.json
@@ -2,65 +2,80 @@
   "demo": {
     "availableUsers": {
       "en": "Available Users",
+      "es": "Usuarios disponibles",
       "fr": "Utilisateurs disponibles"
     },
     "groups": {
       "en": "Group(s)",
+      "es": "Grupo(s)",
       "fr": "Groupe(s)"
     },
     "info": {
       "en": "Demo Information",
+      "es": "Información de la demostración",
       "fr": "Informations sur la démonstration"
     },
     "learnMore": {
       "en": "How to Use?",
+      "es": "¿Cómo usarlo?",
       "fr": "Comment l'utiliser ?"
     },
     "password": {
       "en": "Password: {{value}}",
+      "es": "Contraseña: {{value}}",
       "fr": "Mot de passe : {{value}}"
     },
     "role": {
       "en": "Role",
+      "es": "Rol",
       "fr": "Rôle"
     },
     "summary": {
       "en": "This demo includes a number of publicly-available instruments along with several months of simulated data. To access the platform, please select a user from the options below.",
+      "es": "Esta demostración incluye una serie de instrumentos disponibles públicamente junto con varios meses de datos simulados. Para acceder a la plataforma, seleccione un usuario de las opciones a continuación.",
       "fr": "Cette démonstration comprend un certain nombre d'instruments disponibles publiquement ainsi que plusieurs mois de données simulées. Pour accéder à la plateforme, veuillez sélectionner un utilisateur parmi les options ci-dessous."
     },
     "useCredentials": {
       "en": "Use these credentials",
+      "es": "Usar estas credenciales",
       "fr": "Utilisez ces informations d'identification"
     },
     "username": {
       "en": "Username",
+      "es": "Nombre de usuario",
       "fr": "Nom d'utilisateur"
     },
     "welcome": {
       "en": "Welcome to the Demo Version of Open Data Capture",
+      "es": "Bienvenido a la versión de demostración de Open Data Capture",
       "fr": "Bienvenue sur la version de démonstration de la plateforme Open Data Capture"
     }
   },
   "login": {
     "en": "Login",
+    "es": "Iniciar sesión",
     "fr": "Se connecter"
   },
   "password": {
     "en": "Password",
+    "es": "Contraseña",
     "fr": "Mot de passe"
   },
   "unauthorizedError": {
     "message": {
       "en": "Invalid login credentials",
+      "es": "Credenciales de inicio de sesión no válidas",
       "fr": "Informations d'identification invalides"
     },
     "title": {
       "en": "Unauthorized",
+      "es": "No autorizado",
       "fr": "Non autorisé"
     }
   },
   "username": {
     "en": "Username",
+    "es": "Nombre de usuario",
     "fr": "Nom d'utilisateur"
   }
 }

--- a/apps/web/src/translations/common.json
+++ b/apps/web/src/translations/common.json
@@ -1,258 +1,320 @@
 {
   "action": {
     "en": "Action",
+    "es": "Acción",
     "fr": "Action"
   },
   "activeGroup": {
     "en": "Active Group",
+    "es": "Grupo activo",
     "fr": "Groupe actif"
   },
   "admin": {
     "en": "Admin",
+    "es": "Administrador",
     "fr": "Administrateur"
   },
   "assignment": {
     "en": "Assignment",
+    "es": "Asignación",
     "fr": "Assignation"
   },
   "auditLogs": {
     "en": "Audit Logs",
+    "es": "Registros de auditoría",
     "fr": "Journaux d'audit"
   },
   "basePermissionLevel": {
     "en": "Base Permission Level",
+    "es": "Nivel de permiso base",
     "fr": "Niveau de permission de base"
   },
   "clinical": {
     "en": "Clinical",
+    "es": "Clínico",
     "fr": "Clinique"
   },
   "confirmPassword": {
     "en": "Confirm Password",
+    "es": "Confirmar contraseña",
     "fr": "Confirmer le mot de passe"
   },
   "create": {
     "en": "Create",
+    "es": "Crear",
     "fr": "Créer"
   },
   "currentSession": {
     "en": "Current Session",
+    "es": "Sesión actual",
     "fr": "Session en cours"
   },
   "customIdentifier": {
     "en": "Custom Identifier",
+    "es": "Identificador personalizado",
     "fr": "Identifiant unique"
   },
   "dateFormat": {
     "en": "Date Format",
+    "es": "Formato de fecha",
     "fr": "Format de date"
   },
   "delete": {
     "en": "Delete",
+    "es": "Eliminar",
     "fr": "Supprimer"
   },
   "email": {
     "en": "Email",
+    "es": "Correo electrónico",
     "fr": "Adresse courriel"
   },
   "entity": {
     "en": "Entity",
+    "es": "Entidad",
     "fr": "Entité"
   },
   "errors": {
     "failedToChangeLanguage": {
       "en": "Failed to change languages",
+      "es": "No se pudo cambiar el idioma",
       "fr": "Le changement de langue n'a pas été effectué"
     },
     "noDataToExport": {
       "en": "No Data to Export",
+      "es": "No hay datos para exportar",
       "fr": "Pas de données à exporter"
     },
     "noInstrumentSelected": {
       "en": "No Instrument Selected",
+      "es": "Ningún instrumento seleccionado",
       "fr": "Aucun instrument sélectionné"
     }
   },
   "filters": {
     "en": "Filters",
+    "es": "Filtros",
     "fr": "Filtres"
   },
   "graph": {
     "en": "Graph",
+    "es": "Gráfico",
     "fr": "Graphique"
   },
   "group": {
     "en": "Group",
+    "es": "Grupo",
     "fr": "Groupe"
   },
   "groupManager": {
     "en": "Group Manager",
+    "es": "Responsable de grupo",
     "fr": "Responsable de groupe"
   },
   "groupName": {
     "en": "Group Name",
+    "es": "Nombre del grupo",
     "fr": "Nom du groupe"
   },
   "groupTrend": {
     "en": "Group Trend",
+    "es": "Tendencia del grupo",
     "fr": "Tendance du groupe"
   },
   "groupType": {
     "en": "Group Type",
+    "es": "Tipo de grupo",
     "fr": "Type de groupe"
   },
   "groups": {
     "en": "Groups",
+    "es": "Grupos",
     "fr": "Groupes"
   },
   "identificationMethod": {
     "en": "Identification Method",
+    "es": "Método de identificación",
     "fr": "Méthode d'identification"
   },
   "identificationMethodDesc": {
     "en": "Please select the method by which a subject will be identified for this session.",
+    "es": "Seleccione el método por el cual se identificará al sujeto para esta sesión.",
     "fr": "Veuillez sélectionner la méthode par laquelle un sujet sera identifié pour cette session."
   },
   "identifier": {
     "en": "Identifier",
+    "es": "Identificador",
     "fr": "Identifiant"
   },
   "instrument": {
     "en": "Instrument",
+    "es": "Instrumento",
     "fr": "Instrument"
   },
   "instrumentRecord": {
     "en": "Instrument Record",
+    "es": "Registro del instrumento",
     "fr": "Enregistrement"
   },
   "insufficientPasswordStrength": {
     "en": "Insufficient password strength",
+    "es": "Contraseña demasiado débil",
     "fr": "Mot de passe trop faible"
   },
   "localFormat": {
     "en": "Local",
+    "es": "Local",
     "fr": "Local"
   },
   "login": {
     "en": "Login",
+    "es": "Iniciar sesión",
     "fr": "Se connecter"
   },
   "manage": {
     "en": "Manage",
+    "es": "Gestionar",
     "fr": "Gérer"
   },
   "method": {
     "en": "Method",
+    "es": "Método",
     "fr": "Méthode"
   },
   "password": {
     "en": "Password",
+    "es": "Contraseña",
     "fr": "Mot de passe"
   },
   "passwordInDataBreach": {
     "en": "This password has appeared in a known data breach and cannot be used",
+    "es": "Esta contraseña ha aparecido en una filtración de datos conocida y no se puede utilizar",
     "fr": "Ce mot de passe est apparu dans une fuite de données connue et ne peut pas être utilisé"
   },
   "passwordMatchesUsername": {
     "en": "Password must not be the same as the username",
+    "es": "La contraseña no debe ser igual al nombre de usuario",
     "fr": "Le mot de passe ne doit pas être identique au nom d'utilisateur"
   },
   "passwordsMustMatch": {
     "en": "Passwords Must Match",
+    "es": "Las contraseñas deben coincidir",
     "fr": "Les mots de passe doivent correspondre"
   },
   "personalInfo": {
     "en": "Personal Information",
+    "es": "Información personal",
     "fr": "Renseignements personnels"
   },
   "phoneNumber": {
     "en": "Phone Number",
+    "es": "Número de teléfono",
     "fr": "Numéro de téléphone"
   },
   "research": {
     "en": "Research",
+    "es": "Investigación",
     "fr": "Recherche"
   },
   "session": {
     "en": "Session",
+    "es": "Sesión",
     "fr": "Session"
   },
   "sessionInProgress": {
     "en": "Session in Progress",
+    "es": "Sesión en curso",
     "fr": "Session en cours"
   },
   "standard": {
     "en": "Standard",
+    "es": "Estándar",
     "fr": "Standard"
   },
   "subject": {
     "en": "Subject",
+    "es": "Sujeto",
     "fr": "Client"
   },
   "subjectIdentification": {
     "description": {
       "en": "The following items are used to compute a unique identifier that enables consistent cross-session identification.",
+      "es": "Los siguientes elementos se utilizan para calcular un identificador único que permite una identificación coherente entre sesiones.",
       "fr": "Les éléments suivants sont utilisés pour calculer un identifiant unique qui permet une identification cohérente entre les sessions."
     },
     "firstName": {
       "description": {
         "en": "The subject's first name, as provided by their birth certificate. For the purpose of identification, white space, special characters, and accents are removed, with accented characters treated as a fixed ASCII transliteration.",
+        "es": "El nombre del sujeto, según su certificado de nacimiento. A efectos de identificación, se eliminan los espacios en blanco, los caracteres especiales y los acentos, y los caracteres acentuados se tratan como una transliteración ASCII fija.",
         "fr": "Le prénom du sujet, tel qu'il figure dans son acte de naissance. Pour les besoins de l'identification, les espaces blancs, les caractères spéciaux et les accents sont supprimés, les caractères accentués étant traités comme une translittération ASCII fixe."
       },
       "label": {
         "en": "First Name",
+        "es": "Nombre",
         "fr": "Prénom"
       }
     },
     "lastName": {
       "description": {
         "en": "The subject's last name, as provided by their birth certificate. For the purpose of identification, white space, special characters, and accents are removed, with accented characters treated as their ASCII equivalents.",
+        "es": "El apellido del sujeto, según su certificado de nacimiento. A efectos de identificación, se eliminan los espacios en blanco, los caracteres especiales y los acentos, y los caracteres acentuados se tratan como sus equivalentes ASCII.",
         "fr": "Le nom de famille du sujet, tel qu'il figure dans son acte de naissance. Aux fins d'identification, les espaces blancs, les caractères spéciaux et les accents sont supprimés, les caractères accentués étant traités comme leurs équivalents ASCII."
       },
       "label": {
         "en": "Last Name",
+        "es": "Apellido",
         "fr": "Nom de famille"
       }
     },
     "title": {
       "en": "Subject Identification",
+      "es": "Identificación del sujeto",
       "fr": "Identification du client"
     }
   },
   "tags": {
     "en": "Tags",
+    "es": "Etiquetas",
     "fr": "Tags"
   },
   "time": {
     "en": "Time",
+    "es": "Hora",
     "fr": "Heure"
   },
   "timeCollected": {
     "en": "Time Collected",
+    "es": "Hora de recopilación",
     "fr": "Horodatage"
   },
   "update": {
     "en": "Update",
+    "es": "Actualizar",
     "fr": "Mise à jour"
   },
   "uploadSuccessful": {
     "en": "Upload Successful",
+    "es": "Carga exitosa",
     "fr": "Téléversement réussi"
   },
   "user": {
     "en": "User",
+    "es": "Usuario",
     "fr": "Utilisateur"
   },
   "username": {
     "en": "Username",
+    "es": "Nombre de usuario",
     "fr": "Nom d'utilisateur"
   },
   "usernameExists": {
     "en": "Username already exists",
+    "es": "El nombre de usuario ya existe",
     "fr": "Le nom d'utilisateur existe déjà"
   },
   "view": {
     "en": "View",
+    "es": "Ver",
     "fr": "Voir"
   }
 }

--- a/apps/web/src/translations/contact.json
+++ b/apps/web/src/translations/contact.json
@@ -1,31 +1,38 @@
 {
   "message": {
     "en": "Message",
+    "es": "Mensaje",
     "fr": "Message"
   },
   "pageTitle": {
     "en": "Contact Us",
+    "es": "Contáctenos",
     "fr": "Nous contacter"
   },
   "reason": {
     "en": "Reason",
+    "es": "Razón",
     "fr": "Raison"
   },
   "reasons": {
     "bug": {
       "en": "Bug Report",
+      "es": "Informe de error",
       "fr": "Rapport de bug"
     },
     "feedback": {
       "en": "Feedback",
+      "es": "Comentarios",
       "fr": "Retour d'information"
     },
     "other": {
       "en": "Other",
+      "es": "Otro",
       "fr": "Autre"
     },
     "request": {
       "en": "Request",
+      "es": "Solicitud",
       "fr": "Demande"
     }
   }

--- a/apps/web/src/translations/core.json
+++ b/apps/web/src/translations/core.json
@@ -1,332 +1,408 @@
 {
   "anonymous": {
     "en": "Anonymous",
+    "es": "Anónimo",
     "fr": "Anonyme"
   },
   "authors": {
     "en": "Authors",
+    "es": "Autores",
     "fr": "Auteurs"
   },
   "begin": {
     "en": "Begin",
+    "es": "Comenzar",
     "fr": "Commencer"
   },
   "bilingual": {
     "en": "Bilingual",
+    "es": "Bilingüe",
     "fr": "Bilingue"
   },
   "cancel": {
     "en": "Cancel",
+    "es": "Cancelar",
     "fr": "Annuler"
   },
   "changeTheme": {
     "en": "Change Theme",
+    "es": "Cambiar tema",
     "fr": "Changer de thème"
   },
   "close": {
     "en": "Close",
+    "es": "Cerrar",
     "fr": "Fermer"
   },
   "data": {
     "en": "Data",
+    "es": "Datos",
     "fr": "Données"
   },
   "delete": {
     "en": "Delete",
+    "es": "Eliminar",
     "fr": "Supprimer"
   },
   "description": {
     "en": "Description",
+    "es": "Descripción",
     "fr": "Description"
   },
   "details": {
     "en": "Details",
+    "es": "Detalles",
     "fr": "Détails"
   },
   "download": {
     "en": "Download",
+    "es": "Descargar",
     "fr": "Télécharger"
   },
   "edition": {
     "en": "Edition",
+    "es": "Edición",
     "fr": "Édition"
   },
   "editor": {
     "keyboardShortcuts": {
       "format": {
         "en": "Format Document: {{keybinding}}",
+        "es": "Formatear documento: {{keybinding}}",
         "fr": "Appliquer le formatage du code : {{keybinding}}"
       }
     },
     "noFileSelected": {
       "en": "No File Selected",
+      "es": "Ningún archivo seleccionado",
       "fr": "Aucun fichier sélectionné"
     },
     "pleaseSelectFile": {
       "en": "Please Select a File to Begin",
+      "es": "Seleccione un archivo para comenzar",
       "fr": "Veuillez sélectionner un fichier pour commencer"
     }
   },
   "error": {
     "en": "Error",
+    "es": "Error",
     "fr": "Erreur"
   },
   "estimatedDuration": {
     "en": "Estimated Duration",
+    "es": "Duración estimada",
     "fr": "Durée estimée"
   },
   "failedToLoadInstrument": {
     "en": "Failed to Load Instrument",
+    "es": "Error al cargar el instrumento",
     "fr": "Échec du chargement de l'instrument"
   },
   "failedToLoadInstrumentDesc": {
     "en": "An unexpected error occurred while loading this instrument. Please contact the platform administrator for further assistance.",
+    "es": "Se produjo un error inesperado al cargar este instrumento. Comuníquese con el administrador de la plataforma para obtener ayuda.",
     "fr": "Une erreur inattendue s'est produite lors du chargement de cet instrument. Veuillez contacter l'administrateur de la plateforme pour obtenir de l'aide."
   },
   "form": {
     "requiredField": {
       "en": "This field is required",
+      "es": "Este campo es obligatorio",
       "fr": "Ce champ est obligatoire"
     }
   },
   "fullName": {
     "en": "Full Name",
+    "es": "Nombre completo",
     "fr": "Nom et prénom"
   },
   "genericApology": {
     "en": "We apologize for the inconvenience. Please contact us for further assistance.",
+    "es": "Nos disculpamos por las molestias. Comuníquese con nosotros para obtener ayuda.",
     "fr": "Nous nous excusons pour ce désagrément. N'hésitez pas à nous contacter pour obtenir de l'aide."
   },
   "help": {
     "en": "Help",
+    "es": "Ayuda",
     "fr": "Aide"
   },
   "httpRequestFailed": {
     "en": "HTTP Request Failed",
+    "es": "Error en la solicitud HTTP",
     "fr": "Échec de la requête HTTP"
   },
   "identificationData": {
     "dateOfBirth": {
       "label": {
         "en": "Date of Birth",
+        "es": "Fecha de nacimiento",
         "fr": "Date de naissance"
       }
     },
     "firstName": {
       "description": {
         "en": "The subject's first name, as provided by their birth certificate.",
+        "es": "El nombre del sujeto, tal como figura en su acta de nacimiento.",
         "fr": "Le prénom du sujet, tel qu'il figure dans son acte de naissance."
       },
       "label": {
         "en": "First Name",
+        "es": "Nombre",
         "fr": "Prénom"
       }
     },
     "lastName": {
       "description": {
         "en": "The subject's last name, as provided by their birth certificate.",
+        "es": "El apellido del sujeto, tal como figura en su acta de nacimiento.",
         "fr": "Le nom de famille du sujet, tel qu'il figure dans son acte de naissance."
       },
       "label": {
         "en": "Last Name",
+        "es": "Apellido",
         "fr": "Nom de famille"
       }
     },
     "sex": {
       "description": {
         "en": "The subject's biological sex, as assigned at birth.",
+        "es": "El sexo biológico del sujeto, tal como fue asignado al nacer.",
         "fr": "Le sexe biologique du sujet, tel qu'il a été assigné à la naissance."
       },
       "female": {
         "en": "Female",
+        "es": "Femenino",
         "fr": "Féminin"
       },
       "label": {
         "en": "Sex at Birth",
+        "es": "Sexo al nacer",
         "fr": "Sexe à la naissance"
       },
       "male": {
         "en": "Male",
+        "es": "Masculino",
         "fr": "Masculin"
       }
     }
   },
   "instructions": {
     "en": "Instructions",
+    "es": "Instrucciones",
     "fr": "Instructions"
   },
   "instrument": {
     "en": "Instrument",
+    "es": "Instrumento",
     "fr": "Instrument"
   },
   "instrumentComplete": {
     "en": "Instrument Complete",
+    "es": "Instrumento completado",
     "fr": "Instrument complet"
   },
   "instrumentName": {
     "en": "Instrument Name",
+    "es": "Nombre del instrumento",
     "fr": "Nom de l'instrument"
   },
   "language": {
     "en": "Language",
+    "es": "Idioma",
     "fr": "Langue"
   },
   "languages": {
     "english": {
       "en": "English",
+      "es": "Inglés",
       "fr": "Anglais"
     },
     "french": {
       "en": "French",
+      "es": "Francés",
       "fr": "Français"
     }
   },
   "license": {
     "en": "License",
+    "es": "Licencia",
     "fr": "Licence"
   },
   "minutes": {
     "en": "{{minutes}} minute(s)",
+    "es": "{{minutes}} minuto(s)",
     "fr": "{{minutes}} minute(s)"
   },
   "mobileBlocker": {
     "subtitle": {
       "en": "Please try again on a device with a larger screen",
+      "es": "Inténtelo de nuevo en un dispositivo con una pantalla más grande",
       "fr": "Veuillez réessayer sur un appareil doté d'un écran plus grand"
     },
     "title": {
       "en": "Sorry, this feature is not available on mobile",
+      "es": "Lo sentimos, esta función no está disponible en dispositivos móviles",
       "fr": "Désolé, cette fonctionnalité n'est pas disponible sur mobile"
     }
   },
   "name": {
     "en": "Name",
+    "es": "Nombre",
     "fr": "Nom"
   },
   "networkError": {
     "en": "Network Error",
+    "es": "Error de red",
     "fr": "Erreur de réseau"
   },
   "nextInstrument": {
     "en": "Next Instrument: {{title}}",
+    "es": "Siguiente instrumento: {{title}}",
     "fr": "Next Instrument: {{title}}"
   },
   "no": {
     "en": "No",
+    "es": "No",
     "fr": "Non"
   },
   "notFound": {
     "en": "Not Found",
+    "es": "No encontrado",
     "fr": "Pas trouvé"
   },
   "openSourceLicense": {
     "en": "This is a free and open-source license",
+    "es": "Esta es una licencia libre y de código abierto",
     "fr": "Il s'agit d'une licence libre"
   },
   "print": {
     "en": "Print",
+    "es": "Imprimir",
     "fr": "Imprimer"
   },
   "proprietaryLicense": {
     "en": "This is not a free and open source license",
+    "es": "Esta no es una licencia libre y de código abierto",
     "fr": "Il ne s'agit pas d'une licence libre"
   },
   "referenceLink": {
     "en": "Reference Link",
+    "es": "Enlace de referencia",
     "fr": "Lien vers la référence"
   },
   "responses": {
     "en": "Responses",
+    "es": "Respuestas",
     "fr": "Réponses"
   },
   "results": {
     "en": "Results",
+    "es": "Resultados",
     "fr": "Résultats"
   },
   "save": {
     "en": "Save",
+    "es": "Guardar",
     "fr": "Enregistrer"
   },
   "seriesInstrumentContent": {
     "inProgress": {
       "en": "Series Instrument in Process",
+      "es": "Serie de instrumentos en proceso",
       "fr": "Série d'instruments en cours"
     },
     "instrumentsCompleted": {
       "en": "Instruments Completed: {{completed}}/{{total}}",
+      "es": "Instrumentos completados: {{completed}}/{{total}}",
       "fr": "Nombre d'instruments complétés : {{completed}}/{{total}}"
     }
   },
   "somethingWentWrong": {
     "en": "Something Went Wrong",
+    "es": "Algo salió mal",
     "fr": "Quelque chose n'a pas fonctionné"
   },
   "sourceLink": {
     "en": "Source Link",
+    "es": "Enlace al código fuente",
     "fr": "Lien vers le code source"
   },
   "steps": {
     "overview": {
       "en": "Overview",
+      "es": "Descripción general",
       "fr": "Aperçu"
     },
     "questions": {
       "en": "Content",
+      "es": "Contenido",
       "fr": "Contenu"
     },
     "summary": {
       "en": "Summary",
+      "es": "Resumen",
       "fr": "Résumé"
     }
   },
   "subject": {
     "en": "Subject",
+    "es": "Sujeto",
     "fr": "Client"
   },
   "submit": {
     "en": "Submit",
+    "es": "Enviar",
     "fr": "Soumettre"
   },
   "summary": {
     "subtitle": {
       "en": "Completed on {{ dateCompleted }}",
+      "es": "Completado el {{ dateCompleted }}",
       "fr": "Remplie le {{ dateCompleted }}"
     },
     "title": {
       "en": "Summary of Results for the {{title}}",
+      "es": "Resumen de resultados para el {{title}}",
       "fr": "{{title}} : résumé des résultats"
     },
     "titleFallback": {
       "en": "Summary of Results",
+      "es": "Resumen de resultados",
       "fr": "Résumé des résultats"
     }
   },
   "table": {
     "en": "Table",
+    "es": "Tabla",
     "fr": "Tableau"
   },
   "tag": {
     "en": "Tag",
+    "es": "Etiqueta",
     "fr": "Tag"
   },
   "tags": {
     "en": "Tags",
+    "es": "Etiquetas",
     "fr": "Tags"
   },
   "title": {
     "en": "Title",
+    "es": "Título",
     "fr": "Titre"
   },
   "unknownError": {
     "en": "Unknown Error",
+    "es": "Error desconocido",
     "fr": "Erreur inconnue"
   },
   "version": {
     "en": "Version",
+    "es": "Versión",
     "fr": "Version"
   },
   "yes": {
     "en": "Yes",
+    "es": "Sí",
     "fr": "Oui"
   }
 }

--- a/apps/web/src/translations/datahub.json
+++ b/apps/web/src/translations/datahub.json
@@ -2,74 +2,91 @@
   "assignments": {
     "assignedAt": {
       "en": "Assigned",
+      "es": "Asignado",
       "fr": "Attribué"
     },
     "assignedInstruments": {
       "en": "Assigned Instruments",
+      "es": "Instrumentos asignados",
       "fr": "Instruments assignés"
     },
     "assignmentSliderDesc": {
       "en": "View additional details related to this assignment here. This includes the link to the assignment, which you can send to the client.",
+      "es": "Consulte aquí los detalles adicionales relacionados con esta asignación. Esto incluye el enlace a la asignación, que puede enviar al cliente.",
       "fr": "Consultez ici les détails supplémentaires relatifs à cette assignation. Il s'agit notamment du lien vers l'assignation, que vous pouvez envoyer au client."
     },
     "expiresAt": {
       "en": "Expires",
+      "es": "Vencimiento",
       "fr": "Expiration"
     },
     "link": {
       "en": "Link to Assignment",
+      "es": "Enlace a la asignación",
       "fr": "Lien vers l'assignation"
     },
     "resendNotification": {
       "en": "Resend Notification",
+      "es": "Reenviar notificación",
       "fr": "Renvoyer la notification"
     },
     "status": {
       "en": "Status",
+      "es": "Estado",
       "fr": "État"
     },
     "statusOptions": {
       "canceled": {
         "en": "Canceled",
+        "es": "Cancelado",
         "fr": "Annulé"
       },
       "complete": {
         "en": "Complete",
+        "es": "Completado",
         "fr": "Terminé"
       },
       "expired": {
         "en": "Expired",
+        "es": "Expirado",
         "fr": "Expiré"
       },
       "outstanding": {
         "en": "Outstanding",
+        "es": "Pendiente",
         "fr": "À compléter"
       }
     },
     "title": {
       "en": "Title",
+      "es": "Título",
       "fr": "Titre"
     }
   },
   "downloadInfo": {
     "allTime": {
       "en": "Timeframe: All time",
+      "es": "Periodo: Todo el tiempo",
       "fr": "Période : Toujours"
     },
     "download": {
       "en": "Download",
+      "es": "Descargar",
       "fr": "Télécharger"
     },
     "measurement": {
       "en": "Measures: ",
+      "es": "Medidas: ",
       "fr": "Mesures : "
     },
     "subjectText": {
       "en": "{} of Subject: {}",
+      "es": "{} del sujeto: {}",
       "fr": "{} du client : {}"
     },
     "time": {
       "en": "Timeframe: ",
+      "es": "Periodo: ",
       "fr": "Période : "
     }
   },
@@ -77,47 +94,57 @@
     "lookup": {
       "title": {
         "en": "Subject Lookup",
+        "es": "Buscar sujeto",
         "fr": "Trouver un client"
       }
     },
     "table": {
       "export": {
         "en": "Export",
+        "es": "Exportar",
         "fr": "Exporter"
       },
       "exportHelpText": {
         "en": "This data is provided in an ultra-long format. Each row corresponds to the value for a single measure. Rows corresponding to the same record will have matching subject identifiers and timestamps.",
+        "es": "Estos datos se proporcionan en un formato ultralargo. Cada fila corresponde al valor de una sola medida. Las filas correspondientes al mismo registro tendrán identificadores de sujeto y marcas de tiempo coincidentes.",
         "fr": "Ces données sont fournies dans un format ultra-long. Chaque ligne correspond à la valeur d'une seule mesure. Les lignes correspondant à un même enregistrement auront des identifiants de sujet et des horodatages correspondants."
       },
       "filters": {
         "en": "Filters",
+        "es": "Filtros",
         "fr": "Filtres"
       },
       "subject": {
         "en": "Subject",
+        "es": "Sujeto",
         "fr": "Client"
       }
     },
     "title": {
       "en": "Data Hub",
+      "es": "Centro de datos",
       "fr": "Centre de données"
     }
   },
   "files": {
     "dateCollected": {
       "en": "Date Collected",
+      "es": "Fecha de recopilación",
       "fr": "Date de collecte"
     },
     "download": {
       "en": "Download",
+      "es": "Descargar",
       "fr": "Télécharger"
     },
     "empty": {
       "en": "No files have been uploaded for this subject.",
+      "es": "No se han cargado archivos para este sujeto.",
       "fr": "Aucun fichier n'a été téléversé pour ce client."
     },
     "instrument": {
       "en": "Instrument",
+      "es": "Instrumento",
       "fr": "Instrument"
     }
   },
@@ -125,71 +152,87 @@
     "tabs": {
       "assignments": {
         "en": "Assignments",
+        "es": "Asignaciones",
         "fr": "Assignations"
       },
       "files": {
         "en": "Files",
+        "es": "Archivos",
         "fr": "Fichiers"
       },
       "graph": {
         "en": "Graph",
+        "es": "Gráfico",
         "fr": "Graphique"
       },
       "table": {
         "en": "Table",
+        "es": "Tabla",
         "fr": "Tableau"
       }
     },
     "title": {
       "en": "Instrument Records for Subject {{id}}",
+      "es": "Registros de instrumentos del sujeto {{id}}",
       "fr": "Dossiers d'instruments pour le client {{id}}"
     }
   },
   "visualization": {
     "instrument": {
       "en": "Instrument",
+      "es": "Instrumento",
       "fr": "Instrument"
     },
     "measures": {
       "en": "Measures",
+      "es": "Medidas",
       "fr": "Mesures"
     },
     "selectEdition": {
       "en": "Select an edition",
+      "es": "Seleccione una edición",
       "fr": "Sélectionnez une édition"
     },
     "selectInstrument": {
       "en": "Select an instrument",
+      "es": "Seleccione un instrumento",
       "fr": "Sélectionnez un instrument"
     },
     "selectMeasures": {
       "en": "Please select one or more measures",
+      "es": "Por favor, seleccione una o más medidas",
       "fr": "Veuillez sélectionner au moins une mesure"
     },
     "timeframe": {
       "en": "Timeframe",
+      "es": "Periodo",
       "fr": "Période"
     },
     "timeframeOptions": {
       "all": {
         "en": "All-Time",
+        "es": "Todo el tiempo",
         "fr": "Toujours"
       },
       "month": {
         "en": "Past Month",
+        "es": "Último mes",
         "fr": "Mois écoulé"
       },
       "year": {
         "en": "Past Year",
+        "es": "Último año",
         "fr": "Année écoulée"
       }
     },
     "xLabel": {
       "en": "Date Collected",
+      "es": "Fecha de recopilación",
       "fr": "Date d'enregistrement"
     },
     "yLabel": {
       "en": "Value",
+      "es": "Valor",
       "fr": "Valeur"
     }
   }

--- a/apps/web/src/translations/group.json
+++ b/apps/web/src/translations/group.json
@@ -2,38 +2,47 @@
   "manage": {
     "accessibleInstrumentDemoNote": {
       "en": "Please note that this feature is disabled in demo mode to avoid disrupting other users.",
+      "es": "Tenga en cuenta que esta funcionalidad está desactivada en modo de demostración para evitar interrumpir a otros usuarios.",
       "fr": "Veuillez noter que cette fonctionnalité est désactivée en mode démo, afin d'éviter de perturber les autres utilisateurs."
     },
     "accessibleInstruments": {
       "en": "Accessible Instruments",
+      "es": "Instrumentos accesibles",
       "fr": "Instruments accessibles"
     },
     "accessibleInstrumentsDesc": {
       "en": "Select the instruments that are shown to you and other members of your group. This can be changed by a group manager at any time.",
+      "es": "Seleccione los instrumentos que se muestran a usted y a los demás miembros de su grupo. Esto puede ser modificado por un administrador de grupo en cualquier momento.",
       "fr": "Sélectionnez les instruments qui vous sont présentés ainsi qu'aux autres membres de votre groupe. Cette sélection peut être modifiée à tout moment par un responsable de groupe."
     },
     "defaultSubjectIdMethod": {
       "en": "Subject Identification Method (Default)",
+      "es": "Método de identificación del sujeto (predeterminado)",
       "fr": "Méthode d'identification du sujet par défaut"
     },
     "forms": {
       "en": "Forms",
+      "es": "Formularios",
       "fr": "Formulaires"
     },
     "groupSettings": {
       "en": "Group Settings",
+      "es": "Configuración del grupo",
       "fr": "Paramètres du groupe"
     },
     "interactive": {
       "en": "Interactive Tasks",
+      "es": "Tareas interactivas",
       "fr": "Tâches interactives"
     },
     "series": {
       "en": "Series",
+      "es": "Series",
       "fr": "Séries"
     },
     "pageTitle": {
       "en": "Manage Group",
+      "es": "Gestionar grupo",
       "fr": "Gérer le groupe"
     }
   }

--- a/apps/web/src/translations/instruments.json
+++ b/apps/web/src/translations/instruments.json
@@ -2,66 +2,80 @@
   "accessible": {
     "title": {
       "en": "Administer Instrument",
+      "es": "Administrar instrumento",
       "fr": "Administrer un instrument"
     }
   },
   "manage": {
     "title": {
       "en": "Manage Instruments",
+      "es": "Gestionar instrumentos",
       "fr": "Gérer les instruments"
     }
   },
   "overview": {
     "estimatedDuration": {
       "en": "{{minutes}} minutes",
+      "es": "{{minutes}} minutos",
       "fr": "{{minutes}} minutes"
     }
   },
   "props": {
     "description": {
       "en": "Description",
+      "es": "Descripción",
       "fr": "Description"
     },
     "details": {
       "en": "Details",
+      "es": "Detalles",
       "fr": "Détails"
     },
     "estimatedDuration": {
       "en": "Estimated Duration",
+      "es": "Duración estimada",
       "fr": "Durée estimée"
     },
     "instructions": {
       "en": "Instructions",
+      "es": "Instrucciones",
       "fr": "Instructions"
     },
     "name": {
       "en": "Instrument Name",
+      "es": "Nombre del instrumento",
       "fr": "Nom de l'instrument"
     },
     "tag": {
       "en": "Tag",
+      "es": "Etiqueta",
       "fr": "Tag"
     },
     "tags": {
       "en": "Tags",
+      "es": "Etiquetas",
       "fr": "Tags"
     },
     "title": {
       "en": "Title",
+      "es": "Título",
       "fr": "Titre"
     },
     "version": {
       "en": "Version",
+      "es": "Versión",
       "fr": "Version"
     }
   },
   "summary": {
     "subtitle": {
       "en": "Completed on {{ dateCompleted }}",
+      "es": "Completado el {{ dateCompleted }}",
       "fr": "Complété le {{ dateCompleted }}"
     },
     "title": {
       "en": "Summary of Results for the {{title}}",
+      "es": "Resumen de resultados del {{title}}",
       "fr": "{{title}} : Résumé des résultats"
     }
   },
@@ -69,15 +83,18 @@
     "filters": {
       "language": {
         "en": "Language",
+        "es": "Idioma",
         "fr": "Langue"
       },
       "tags": {
         "en": "Tags",
+        "es": "Etiquetas",
         "fr": "Tags"
       }
     },
     "title": {
       "en": "Instruments",
+      "es": "Instrumentos",
       "fr": "Instruments"
     }
   }

--- a/apps/web/src/translations/layout.json
+++ b/apps/web/src/translations/layout.json
@@ -2,82 +2,100 @@
   "branding": {
     "title": {
       "en": "Open Data Capture",
+      "es": "Open Data Capture",
       "fr": "Open Data Capture"
     }
   },
   "endSessionModal": {
     "message": {
       "en": "Are you sure you want to end the current session? If you choose to proceed, you'll be taken back to the begin session page.",
+      "es": "Está seguro de que desea finalizar la sesión actual? Si decide continuar, será redirigido a la página para comenzar una nueva sesión.",
       "fr": "Êtes-vous sûr de vouloir mettre fin à la session en cours ? Si vous décidez de continuer, vous serez ramené à la page de démarrage de session."
     },
     "title": {
       "en": "End Session",
+      "es": "Finalizar sesión",
       "fr": "Terminer la session en cours"
     }
   },
   "footer": {
     "contact": {
       "en": "Contact Us",
+      "es": "Contáctenos",
       "fr": "Contactez-nous"
     },
     "documentation": {
       "en": "Documentation",
+      "es": "Documentación",
       "fr": "Documentation"
     },
     "license": {
       "en": "License",
+      "es": "Licencia",
       "fr": "Licence"
     },
     "sourceCode": {
       "en": "Source Code",
+      "es": "Código fuente",
       "fr": "Code source"
     }
   },
   "navLinks": {
     "accessibleInstruments": {
       "en": "Administer Instrument",
+      "es": "Administrar instrumento",
       "fr": "Administrer un instrument"
     },
     "createInstrument": {
       "en": "Add Instrument",
+      "es": "Agregar instrumento",
       "fr": "Ajouter un instrument"
     },
     "dashboard": {
       "en": "Dashboard",
+      "es": "Panel de control",
       "fr": "Tableau de bord"
     },
     "datahub": {
       "en": "Data Hub",
+      "es": "Centro de datos",
       "fr": "Centre de données"
     },
     "endSession": {
       "en": "End Current Session",
+      "es": "Finalizar la sesión actual",
       "fr": "Terminer la session en cours"
     },
     "manageGroup": {
       "en": "Manage Group",
+      "es": "Gestionar grupo",
       "fr": "Gérer le groupe"
     },
     "remoteAssignment": {
       "en": "Remote Assignment",
+      "es": "Tarea remota",
       "fr": "Tâche à distance"
     },
     "startSession": {
       "en": "Start Session",
+      "es": "Iniciar una sesión",
       "fr": "Démarrer une session"
     },
     "upload": {
       "en": "Upload Data",
+      "es": "Cargar datos",
       "fr": "Téléverser les données"
     },
     "viewCurrentSubject": {
       "en": "View Current Subject",
+      "es": "Ver el sujeto actual",
       "fr": "Voir le client actuel"
     }
   },
   "organization": {
     "name": {
       "en": "Douglas Neuroinformatics Platform",
+      "es": "Douglas Neuroinformatics Platform",
       "fr": "Douglas Neuroinformatics Platform"
     }
   }

--- a/apps/web/src/translations/session.json
+++ b/apps/web/src/translations/session.json
@@ -2,44 +2,53 @@
   "additionalData": {
     "title": {
       "en": "Additional Data",
+      "es": "Datos adicionales",
       "fr": "Données supplémentaires"
     }
   },
   "dateAssessed": {
     "description": {
       "en": "If the session took place on a date other than today, you can change it here.",
+      "es": "Si la sesión tuvo lugar en una fecha distinta a hoy, puede modificarla aquí.",
       "fr": "Si la session a eu lieu à une autre date qu'aujourd'hui, vous pouvez la modifier ici."
     },
     "label": {
       "en": "Date Assessed",
+      "es": "Fecha de evaluación",
       "fr": "Date d'évaluation"
     }
   },
   "errors": {
     "assessmentMustBeInPast": {
       "en": "The assessment must be in the past",
+      "es": "La evaluación debe estar en el pasado",
       "fr": "L'évaluation doit être dans le passé"
     },
     "mustBeAdult": {
       "en": "The subject must be at least 18 years old",
+      "es": "El sujeto debe tener al menos 18 años de edad",
       "fr": "Le client doit avoir au moins 18 ans"
     }
   },
   "startSession": {
     "en": "Start Session",
+    "es": "Iniciar sesión",
     "fr": "Démarrer une session"
   },
   "type": {
     "in-person": {
       "en": "In-Person",
+      "es": "En persona",
       "fr": "En personne"
     },
     "label": {
       "en": "Type of Assessment",
+      "es": "Tipo de evaluación",
       "fr": "Type d'évaluation"
     },
     "retrospective": {
       "en": "Retrospective",
+      "es": "Retrospectiva",
       "fr": "Rétrospective"
     }
   }

--- a/apps/web/src/translations/setup.json
+++ b/apps/web/src/translations/setup.json
@@ -2,53 +2,65 @@
   "admin": {
     "description": {
       "en": "To use the application, there must be at least one platform administrator. Ensure you remember these credentials, as failure to do so may result in data loss.",
+      "es": "Para utilizar la aplicación, debe haber al menos un administrador de la plataforma. Asegúrese de recordar estas credenciales, ya que no hacerlo puede resultar en la pérdida de datos.",
       "fr": "Pour utiliser l'application, il faut qu'il y ait au moins un administrateur. Assurez-vous de vous souvenir de ces informations d'identification, faute de quoi vous risquez de perdre des données."
     },
     "password": {
       "en": "Password",
+      "es": "Contraseña",
       "fr": "Mot de passe"
     },
     "title": {
       "en": "Admin",
+      "es": "Administrador",
       "fr": "Administrateur"
     },
     "username": {
       "en": "Username",
+      "es": "Nombre de usuario",
       "fr": "Nom d'utilisateur"
     }
   },
   "demo": {
     "description": {
       "en": "If you're testing the platform, you have the option to populate the database with sample data.",
+      "es": "Si está probando la plataforma, tiene la opción de poblar la base de datos con datos de muestra.",
       "fr": "Si vous testez la plateforme, vous avez la possibilité d'alimenter la base de données avec des échantillons de données."
     },
     "dummySubjectCount": {
       "en": "Number of Dummy Subjects",
+      "es": "Número de sujetos ficticios",
       "fr": "Nombre de clients fictifs"
     },
     "init": {
       "en": "Initialize Demo",
+      "es": "Inicializar demostración",
       "fr": "Initialiser la démonstration"
     },
     "recordsPerSubject": {
       "en": "Records Per Subject",
+      "es": "Registros por sujeto",
       "fr": "Enregistrements par sujet"
     },
     "title": {
       "en": "Demo",
+      "es": "Demostración",
       "fr": "Démonstration"
     }
   },
   "loadingSubtitle": {
     "en": "Please be patient, this may take a while...",
+    "es": "Por favor, tenga paciencia, esto puede tardar un momento...",
     "fr": "Veuillez patienter, cela peut prendre un certain temps..."
   },
   "loadingTitle": {
     "en": "Initializing Application",
+    "es": "Inicializando la aplicación",
     "fr": "Initialisation de l'application"
   },
   "pageTitle": {
     "en": "Setup",
+    "es": "Configuración",
     "fr": "Mise en service"
   }
 }

--- a/apps/web/src/translations/upload.json
+++ b/apps/web/src/translations/upload.json
@@ -1,6 +1,7 @@
 {
   "title": {
     "en": "Instrument Title",
+    "es": "Título del instrumento",
     "fr": "Titre de l'instrument"
   }
 }


### PR DESCRIPTION
## Summary

- Add `es` entries to all 11 web app translation JSON files (269 lines added, 0 removed)

This is a pure translation PR — no code changes. Stacked on #1442.

## Test plan

- [x] Only translation JSON files changed
- [ ] Visual spot-check in-app

🤖 Generated with [Claude Code](https://claude.com/claude-code)