### PR TITLE
fix duplicate react instances in runtime bundle

### DIFF
--- a/packages/runtime-bundler/src/__tests__/resolver.test.ts
+++ b/packages/runtime-bundler/src/__tests__/resolver.test.ts
@@ -208,7 +208,7 @@ describe('Resolver', () => {
       vi.resetAllMocks();
     });
 
-    it('should return the exports for a valid, single source string export', async () => {
+    it('should return an asset export for a valid, single source string export', async () => {
       const relpath = './src/main.js';
       const abspath = path.join(packageRoot, relpath);
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -219,7 +219,7 @@ describe('Resolver', () => {
       await expect(resolver.resolve(PACKAGE_STUB.name)).resolves.toMatchObject({
         exports: {
           '.': {
-            import: abspath
+            copy: abspath
           }
         }
       });

--- a/packages/runtime-bundler/src/bundler.ts
+++ b/packages/runtime-bundler/src/bundler.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import esbuild from 'esbuild';
 
-import { dtsPlugin, htmlPlugin } from './plugin.js';
+import { assetPlugin, dtsPlugin } from './plugin.js';
 import { Resolver } from './resolver.js';
 
 import type { BundlerOptions, EntryPoint, ExportCondition, ResolvedPackage } from './types.js';
@@ -26,13 +26,15 @@ export class Bundler {
   async bundle(): Promise<void> {
     const packages = await this.findPackages();
     this.logger.verbose(`Found packages: ${JSON.stringify(packages, null, 2)}`);
-    const entryPoints = this.getEntryPoints(packages);
-    this.logger.verbose(`Found entry points: ${JSON.stringify(entryPoints, null, 2)}`);
+    const { assetEntryPoints, moduleEntryPoints } = this.getEntryPoints(packages);
+    this.logger.verbose(`Found entry points: ${JSON.stringify({ assetEntryPoints, moduleEntryPoints }, null, 2)}`);
 
     await fs.rm(this.options.outdir, { force: true, recursive: true });
     await esbuild.build({
       bundle: true,
-      entryPoints: entryPoints,
+      // an underscore prefix cannot collide with a served package: npm forbids it in package names
+      chunkNames: '_chunks/[hash]',
+      entryPoints: [...moduleEntryPoints, ...assetEntryPoints],
       format: 'esm',
       keepNames: true,
       minify: this.options.mode === 'production',
@@ -41,15 +43,15 @@ export class Bundler {
       plugins: [
         dtsPlugin({
           configFilepath: this.options.configFilepath,
-          entryPoints,
+          entryPoints: moduleEntryPoints,
           outdir: this.options.outdir,
           packages
         }),
-        htmlPlugin()
+        assetPlugin(new Set(assetEntryPoints.map((entryPoint) => entryPoint.in)))
       ],
       sourcemap: 'linked',
       sourcesContent: true,
-      splitting: false,
+      splitting: true,
       target: 'es2022'
     });
   }
@@ -63,34 +65,45 @@ export class Bundler {
     return packages;
   }
 
-  private getEntryPoints(packages: ResolvedPackage[]): EntryPoint[] {
-    const entryPoints: EntryPoint[] = [];
+  private getEntryPoints(packages: ResolvedPackage[]): {
+    assetEntryPoints: EntryPoint[];
+    moduleEntryPoints: EntryPoint[];
+  } {
+    const assetEntryPoints: EntryPoint[] = [];
+    const moduleEntryPoints: EntryPoint[] = [];
     for (const pkg of packages) {
       for (const key in pkg.exports) {
         if (key === './package.json') {
           continue;
         }
-        const conditions = pkg.exports[key]!;
+        const packageExport = pkg.exports[key]!;
         const runtimePackageName = pkg.name.split('__').join('@');
         const parsedOutPath = path.parse(key === '.' ? 'index' : key);
         const out = path.join(runtimePackageName, parsedOutPath.dir, parsedOutPath.name);
+        if ('copy' in packageExport) {
+          assetEntryPoints.push({
+            in: packageExport.copy,
+            out
+          });
+          continue;
+        }
         for (const condition of ['import', 'default'] satisfies ExportCondition[]) {
-          if (conditions[condition]) {
-            entryPoints.push({
-              in: conditions[condition],
+          if (packageExport[condition]) {
+            moduleEntryPoints.push({
+              in: packageExport[condition],
               out
             });
             break;
           }
         }
-        if (conditions.types) {
-          entryPoints.push({
-            in: conditions.types,
+        if (packageExport.types) {
+          moduleEntryPoints.push({
+            in: packageExport.types,
             out: out + '.d'
           });
         }
       }
     }
-    return entryPoints;
+    return { assetEntryPoints, moduleEntryPoints };
   }
 }

--- a/packages/runtime-bundler/src/plugin.ts
+++ b/packages/runtime-bundler/src/plugin.ts
@@ -50,6 +50,9 @@ export function dtsPlugin(options: DtsPluginOptions): Plugin {
       }
       const packageExport = pkg.exports[exportKey];
       if (packageExport) {
+        if ('copy' in packageExport) {
+          throw new Error(`Found dependency '${importPath}' but export '${exportKey}' is a static asset`);
+        }
         const types = packageExport.types;
         if (types) {
           const outfile = options.entryPoints.find((item) => item.in === types)?.out;
@@ -127,12 +130,15 @@ export function dtsPlugin(options: DtsPluginOptions): Plugin {
   };
 }
 
-export function htmlPlugin(): Plugin {
+export function assetPlugin(assetFilepaths: Set<string>): Plugin {
   return {
-    name: 'html-plugin',
+    name: 'asset-plugin',
     setup(build) {
-      const namespace = 'html';
-      build.onResolve({ filter: /.+\.html$/ }, (args) => {
+      const namespace = 'asset';
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (!assetFilepaths.has(args.path)) {
+          return undefined;
+        }
         return {
           namespace,
           path: args.path
@@ -140,7 +146,7 @@ export function htmlPlugin(): Plugin {
       });
       build.onLoad({ filter: /.*/, namespace }, async (args) => {
         return {
-          contents: await fs.readFile(args.path, 'utf-8'),
+          contents: await fs.readFile(args.path),
           loader: 'copy'
         };
       });

--- a/packages/runtime-bundler/src/resolver.ts
+++ b/packages/runtime-bundler/src/resolver.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { isPlainObject } from '@douglasneuroinformatics/libjs';
 
-import type { ExportCondition, PackageExport, ResolvedPackage } from './types.js';
+import type { ExportCondition, ModuleExport, PackageExport, ResolvedPackage } from './types.js';
 
 class ResolverError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -104,9 +104,9 @@ export class Resolver {
 
   private parseExport(exp: unknown, packageRoot: string): PackageExport {
     if (typeof exp === 'string') {
-      return { import: this.resolveSourceExport(exp, packageRoot) };
+      return { copy: this.resolveSourceExport(exp, packageRoot) };
     } else if (isPlainObject(exp)) {
-      const exports: PackageExport = {};
+      const exports: ModuleExport = {};
       const conditions: ExportCondition[] = ['default', 'import', 'types'];
       for (const condition of conditions) {
         const val = exp[condition];

--- a/packages/runtime-bundler/src/types.ts
+++ b/packages/runtime-bundler/src/types.ts
@@ -2,9 +2,20 @@ import type { Config } from './schemas.js';
 
 type ExportCondition = 'default' | 'import' | 'types';
 
-type PackageExport = {
+/** An export declared with conditions: an ES module bundled into the shared module graph. */
+type ModuleExport = {
   [K in ExportCondition]?: string;
 };
+
+/**
+ * An export declared as a bare path: a static asset (classic script, stylesheet, html)
+ * emitted byte-for-byte, never bundled — classic scripts cannot carry chunk imports.
+ */
+type AssetExport = {
+  copy: string;
+};
+
+type PackageExport = AssetExport | ModuleExport;
 
 type ResolvedPackage = {
   exports: {
@@ -22,4 +33,4 @@ type EntryPoint = {
 
 export type BundlerOptions = Config & { configFilepath: string };
 
-export type { EntryPoint, ExportCondition, PackageExport, ResolvedPackage };
+export type { AssetExport, EntryPoint, ExportCondition, ModuleExport, PackageExport, ResolvedPackage };

--- a/packages/runtime-bundler/test/e2e.test.ts
+++ b/packages/runtime-bundler/test/e2e.test.ts
@@ -25,7 +25,7 @@ describe('bundle (e2e)', () => {
     await fs.writeFile(path.join(workdir, 'package.json'), '{}');
     await new Bundler({
       configFilepath: path.join(workdir, 'package.json'),
-      include: ['shared-state', 'state-writer'],
+      include: ['classic-script', 'shared-state', 'state-writer'],
       mode: 'production',
       outdir: distdir
     }).bundle();
@@ -44,5 +44,29 @@ describe('bundle (e2e)', () => {
     };
     setValue('shared');
     expect(getValue()).toBe('shared');
+  });
+
+  it('emits bare-path exports byte-for-byte, with no module syntax a classic script would reject', async () => {
+    const emitted = await fs.readFile(path.join(distdir, 'classic-script/bootstrap.js'), 'utf-8');
+    const source = await fs.readFile(path.join(fixtures, 'classic-script/bootstrap.js'), 'utf-8');
+    expect(emitted).toBe(source);
+  });
+
+  it('emits every shared chunk under _chunks, never at a path that parses as a package', async () => {
+    const jsFiles: string[] = [];
+    await (async function walk(dir: string) {
+      for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+        const abspath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(abspath);
+        } else if (entry.name.endsWith('.js')) {
+          jsFiles.push(path.relative(distdir, abspath));
+        }
+      }
+    })(distdir);
+    const packageDirs = ['classic-script/', 'shared-state/', 'state-writer/', '_chunks/'];
+    for (const file of jsFiles) {
+      expect(packageDirs.some((dir) => file.startsWith(dir))).toBe(true);
+    }
   });
 });

--- a/packages/runtime-bundler/test/e2e.test.ts
+++ b/packages/runtime-bundler/test/e2e.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Bundler } from '../src/bundler.js';
+
+/**
+ * End-to-end guard for cross-package module sharing. `state-writer` mutates a value owned by
+ * `shared-state`; both are bundled as separate entry points. If the bundler inlines its own copy of
+ * `shared-state` into `state-writer`, the write lands on a different instance than the one read back,
+ * so the value stays `initial`. The two entry points must resolve to a single runtime instance.
+ */
+describe('bundle (e2e)', () => {
+  const fixtures = path.resolve(import.meta.dirname, 'fixtures');
+  let workdir: string;
+  let distdir: string;
+
+  beforeAll(async () => {
+    workdir = await fs.mkdtemp(path.join(os.tmpdir(), 'runtime-bundler-e2e-'));
+    distdir = path.join(workdir, 'dist');
+    await fs.cp(fixtures, path.join(workdir, 'node_modules'), { recursive: true });
+    await fs.writeFile(path.join(workdir, 'package.json'), '{}');
+    await new Bundler({
+      configFilepath: path.join(workdir, 'package.json'),
+      include: ['shared-state', 'state-writer'],
+      mode: 'production',
+      outdir: distdir
+    }).bundle();
+  }, 60_000);
+
+  afterAll(async () => {
+    await fs.rm(workdir, { force: true, recursive: true });
+  });
+
+  it('shares one module instance across entry points that depend on it', async () => {
+    const { getValue } = (await import(pathToFileURL(path.join(distdir, 'shared-state/index.js')).href)) as {
+      getValue: () => string;
+    };
+    const { setValue } = (await import(pathToFileURL(path.join(distdir, 'state-writer/index.js')).href)) as {
+      setValue: (value: string) => void;
+    };
+    setValue('shared');
+    expect(getValue()).toBe('shared');
+  });
+});

--- a/packages/runtime-bundler/test/fixtures/classic-script/bootstrap.js
+++ b/packages/runtime-bundler/test/fixtures/classic-script/bootstrap.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function greet(name) {
+  return 'hello ' + name;
+}
+
+globalThis.greeting = greet('world');

--- a/packages/runtime-bundler/test/fixtures/classic-script/index.js
+++ b/packages/runtime-bundler/test/fixtures/classic-script/index.js
@@ -1,0 +1,5 @@
+import { getValue } from 'shared-state';
+
+export function report() {
+  return `value is ${getValue()}`;
+}

--- a/packages/runtime-bundler/test/fixtures/classic-script/package.json
+++ b/packages/runtime-bundler/test/fixtures/classic-script/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "classic-script",
+  "type": "module",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    },
+    "./bootstrap.js": "./bootstrap.js",
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/runtime-bundler/test/fixtures/shared-state/index.js
+++ b/packages/runtime-bundler/test/fixtures/shared-state/index.js
@@ -1,0 +1,5 @@
+export const state = { value: 'initial' };
+
+export function getValue() {
+  return state.value;
+}

--- a/packages/runtime-bundler/test/fixtures/shared-state/package.json
+++ b/packages/runtime-bundler/test/fixtures/shared-state/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "shared-state",
+  "type": "module",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/runtime-bundler/test/fixtures/state-writer/index.js
+++ b/packages/runtime-bundler/test/fixtures/state-writer/index.js
@@ -1,0 +1,5 @@
+import { state } from 'shared-state';
+
+export function setValue(value) {
+  state.value = value;
+}

--- a/packages/runtime-bundler/test/fixtures/state-writer/package.json
+++ b/packages/runtime-bundler/test/fixtures/state-writer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "state-writer",
+  "type": "module",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/runtime-bundler/tsconfig.json
+++ b/packages/runtime-bundler/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"]
   },
-  "include": ["src/**/*", "vitest.config.ts"]
+  "include": ["src/**/*", "test/**/*.ts", "vitest.config.ts"]
 }

--- a/packages/runtime-meta/package.json
+++ b/packages/runtime-meta/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "format": "prettier --write src",
-    "lint": "tsc && eslint --fix src"
+    "lint": "tsc && eslint --fix src",
+    "test": "vitest"
   }
 }

--- a/packages/runtime-meta/src/index.d.ts
+++ b/packages/runtime-meta/src/index.d.ts
@@ -71,6 +71,16 @@ export declare const MANIFEST_FILENAME: string;
 export declare function generateManifest(baseDir: string): Promise<RuntimeManifest>;
 
 /**
+ * Group the files in a runtime manifest into the packages they belong to. Files whose first
+ * path segment begins with an underscore (bundler-internal output such as shared chunks)
+ * belong to no package and are omitted.
+ */
+export declare function parsePackages(
+  runtimeVersion: string,
+  manifest: Pick<RuntimeManifest, 'html' | 'sources' | 'styles'>
+): RuntimePackageMetadata[];
+
+/**
  * Generate metadata for all available runtime versions.
  * @returns A Map keyed by version name, with corresponding metadata.
  */

--- a/packages/runtime-meta/src/index.js
+++ b/packages/runtime-meta/src/index.js
@@ -37,6 +37,39 @@ export async function generateManifest(baseDir) {
   return results;
 }
 
+/** @type {import('.').parsePackages} */
+export function parsePackages(runtimeVersion, manifest) {
+  const importPathPattern = /^(@?[^@/]+(?:\/[^@/]+)?)(?:@([^/]+))?/;
+
+  /** @type {Map<string, import('.').RuntimePackageMetadata>} */
+  const packages = new Map();
+
+  /** @param {string} filename @param {'css' | 'html' | 'js'} kind */
+  const addToPackage = (filename, kind) => {
+    // npm forbids a leading underscore in package names, so it marks bundler-internal
+    // output (e.g. _chunks/) that is served from the manifest but belongs to no package
+    if (filename.startsWith('_')) {
+      return;
+    }
+    const match = filename.match(importPathPattern);
+    if (!match) {
+      throw new Error(`Unexpected import path pattern: ${filename}`);
+    }
+    const [name, version] = /** @type {[string, string]} */ (match.slice(1, 3));
+    const key = name + '$' + version;
+    if (!packages.has(key)) {
+      packages.set(key, { exports: { css: [], html: [], js: [] }, name, version });
+    }
+    packages.get(key)?.exports[kind].push(`/runtime/${runtimeVersion}/${filename}`);
+  };
+
+  manifest.sources.forEach((source) => addToPackage(source, 'js'));
+  manifest.html.forEach((file) => addToPackage(file, 'html'));
+  manifest.styles.forEach((style) => addToPackage(style, 'css'));
+
+  return [...packages.values()];
+}
+
 /** @type {import('.').generateMetadata} */
 export async function generateMetadata(options) {
   const require = module.createRequire(options.rootDir);
@@ -47,40 +80,12 @@ export async function generateMetadata(options) {
   for (const v of RUNTIME_VERSIONS) {
     const packageDir = path.dirname(require.resolve(`@opendatacapture/runtime-${v}/package.json`));
     const baseDir = path.resolve(packageDir, RUNTIME_DIST_DIRNAME);
-    const { declarations, html, sources, styles } = await generateManifest(baseDir);
-
-    const importPathPattern = /^(@?[^@/]+(?:\/[^@/]+)?)(?:@([^/]+))?/;
-
-    /** @type {Map<string, import('.').RuntimePackageMetadata>} */
-    const packages = new Map();
-
-    /** @param {string} filename @param {'css' | 'html' | 'js'} kind */
-    const addToPackage = (filename, kind) => {
-      const match = filename.match(importPathPattern);
-      if (!match) {
-        throw new Error(`Unexpected import path pattern: ${filename}`);
-      }
-      const [name, version] = /** @type {[string, string]} */ (match.slice(1, 3));
-      const key = name + '$' + version;
-      if (!packages.has(key)) {
-        packages.set(key, { exports: { css: [], html: [], js: [] }, name, version });
-      }
-      packages.get(key)?.exports[kind].push(`/runtime/${v}/${filename}`);
-    };
-
-    sources.forEach((source) => addToPackage(source, 'js'));
-    html.forEach((file) => addToPackage(file, 'html'));
-    styles.forEach((style) => addToPackage(style, 'css'));
+    const manifest = await generateManifest(baseDir);
 
     metadata.set(v, {
       baseDir,
-      manifest: {
-        declarations,
-        html,
-        sources,
-        styles
-      },
-      packages: [...packages.values()]
+      manifest,
+      packages: parsePackages(v, manifest)
     });
   }
   return metadata;

--- a/packages/runtime-meta/test/parse-packages.test.ts
+++ b/packages/runtime-meta/test/parse-packages.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { parsePackages } from '../src/index.js';
+
+describe('parsePackages', () => {
+  it('groups files under the package parsed from their path', () => {
+    const packages = parsePackages('v1', {
+      html: [],
+      sources: ['react@19.x/index.js', 'react@19.x/jsx-runtime.js'],
+      styles: ['normalize.css@8.x/normalize.css']
+    });
+    expect(packages).toStrictEqual([
+      {
+        exports: {
+          css: [],
+          html: [],
+          js: ['/runtime/v1/react@19.x/index.js', '/runtime/v1/react@19.x/jsx-runtime.js']
+        },
+        name: 'react',
+        version: '19.x'
+      },
+      {
+        exports: { css: ['/runtime/v1/normalize.css@8.x/normalize.css'], html: [], js: [] },
+        name: 'normalize.css',
+        version: '8.x'
+      }
+    ]);
+  });
+
+  it('omits underscore-prefixed bundler output from all packages', () => {
+    const packages = parsePackages('v1', {
+      html: [],
+      sources: ['_chunks/ABCD1234.js', 'react@19.x/index.js'],
+      styles: []
+    });
+    expect(packages.map((pkg) => pkg.name)).toStrictEqual(['react']);
+  });
+});

--- a/packages/runtime-meta/tsconfig.json
+++ b/packages/runtime-meta/tsconfig.json
@@ -5,5 +5,5 @@
     "checkJs": true,
     "maxNodeModuleJsDepth": 0
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*.ts", "vitest.config.ts"]
 }

--- a/packages/runtime-meta/vitest.config.ts
+++ b/packages/runtime-meta/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+
+import baseConfig from '../../vitest.config';
+
+export default mergeConfig(
+  baseConfig,
+  defineProject({
+    test: {
+      name: 'runtime-meta',
+      root: import.meta.dirname
+    }
+  })
+);


### PR DESCRIPTION
## Problem

Any instrument that runs a React hook against the served runtime throws `TypeError: Cannot read properties of null (reading 'useState')` — React 19's null hook dispatcher (`c.H is null`). This affects interactive React instruments (`createRoot` from the runtime's react-dom) and the upcoming form-block feature.

**Root cause:** `runtime-bundler` builds with esbuild `splitting: false`, so every served runtime package is a self-contained bundle. A dependency shared by two entry points is inlined into each: `react@19.x/index.js` and `react-dom@19.x/client.js` each carried their own `ReactSharedInternals`. react-dom sets the hook dispatcher on its copy; the component reads the other (null) copy.

## History

- `5d75e3952` (2024-08) migrated the runtime build from Rollup to esbuild **with `splitting: true`** — both shared react via chunking.
- `1d5aa5ce1` (2025-09, "updates to handle tmb tasks") flipped `splitting: false`, introducing the duplication. That same commit added `runtime-internal/src/interactive/{bootstrap.js,worker.js,iframe.html}` — which is *why* splitting had to be disabled: `iframe.html` loads `bootstrap.js` as a classic `<script>` (no `type="module"`) and `bootstrap.js` registers `worker.js` as a classic service worker. With splitting on, esbuild hoists shared helpers (including the `__name` helper `keepNames` injects everywhere) into `chunk-*.js` and places a top-level `import "../chunk-*.js"` in every entry — top-level `import` in a classic script is a SyntaxError that fails silently inside the iframe.

So the two symptoms were a genuine dilemma: `splitting: true` fixed React but broke the interactive bootstrap; `splitting: false` fixed the bootstrap but duplicated React. No single value of the flag could ever be correct.

## Diagnosis process

This was diagnosed across two sessions. An initial session (Claude Opus 4.8) isolated the root cause of the hook crash, proved `splitting: true` fixes it at the artifact level, wrote the failing reproduction test in `packages/runtime-bundler/test/e2e.test.ts` (first commit here), and left a handoff documenting one open blocker: splitting had been reverted before because it "broke other things", but what it broke was never reproduced. It also documented a dead end for posterity: externalizing sibling runtime packages to `/runtime/v1/<pkg>` URLs via an `onResolve` plugin does **not** work, because real react-dom does `require("react")` and esbuild turns an *external* CJS require into a `__require` shim that throws `Dynamic require is not supported` in the browser. Splitting keeps react internal, which is why esbuild can rewrite the require into a chunk reference.

The follow-up session correlated the `splitting: false` flip with the interactive files added in the same commit, identified the classic-script/chunk-import conflict described above, and @joshunrau confirmed that this was the breakage observed at the time.

## Fix

The dist contains two kinds of artifacts, now distinguished structurally by their package.json export form — no configuration, no special-cased filenames:

- **Conditional exports** (`{ import, types }` / `{ default }`) form the ESM module graph and build with `splitting: true`, so shared dependencies exist exactly once. Chunks are emitted under `_chunks/` — npm forbids a leading underscore in package names, so `runtime-meta` skips these when grouping manifest files into package metadata (they are still served from the manifest).
- **Bare-path exports** (`"./interactive/bootstrap.js": "./src/..."`) are static assets, copied byte-for-byte with no module syntax. This generalizes the previous html-only copy plugin. `bootstrap.js`'s runtime `await import('../index.js')` (dynamic import *is* legal in classic scripts) now resolves over HTTP to the served, chunk-shared module instead of an inlined private copy. The only other bare-path exports across the whole `include` list are four vendor CSS files with no `url()` references, so verbatim copying is safe for all of them.

Legacy/TMB-style instruments are unaffected: their classic scripts are the instrument author's own code, injected via instrument-bundler's `?legacy` path (`__injectHead.scripts`), independent of the runtime dist format.

## Tests

- `packages/runtime-bundler/test/e2e.test.ts`: runs the real `Bundler` on fixture packages and asserts (1) a dependency shared by two entry points is a single runtime instance — **fails on main**, (2) bare-path exports are emitted byte-identical with no module syntax a classic script would reject, (3) chunks only ever land under `_chunks/`.
- `packages/runtime-meta/test/parse-packages.test.ts`: manifest-to-package grouping, including the underscore skip.

## Verification

Against the real rebuilt dist: `react@19.x/index.js` and `react-dom@19.x/client.js` import the same `_chunks/*` files; `renderToStaticMarkup` and `createRoot` + `useState` both render through the built artifacts; `bootstrap.js`/`worker.js` are byte-identical to source; all runtime URLs (including chunks) serve with correct MIME types through `vite-plugin-runtime`. Manually confirmed working in the playground (interactive React example, static-assets/service-worker example, jspsych).

## Out of scope (known, pre-existing)

- **React 18 never dedupes**: `react-dom@18.x`'s peer `react` resolves via pnpm hoisting to `react@19.1.0`, a different physical path than `vendor/react@18.x`'s `react@18.3.1`, so esbuild cannot share them — with splitting on or off. Current instruments target react 19 (`jsxImportSource: '/runtime/v1/react@19.x'`).
- **Host-vs-runtime React**: a form block's code is bundled against the runtime's React but renders inside the host app's React tree; hooks in blocks are a separate identity question belonging to the form-block branch, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
