### PR TITLE
pin vendor 
  wrapper peer dependencies to their paired versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1438,7 +1438,10 @@ importers:
     dependencies:
       '@jspsych/plugin-html-button-response':
         specifier: 1.2.0
-        version: 1.2.0(jspsych@8.0.1)
+        version: 1.2.0(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1448,6 +1451,9 @@ importers:
       '@jspsych/plugin-html-button-response':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1456,7 +1462,10 @@ importers:
     dependencies:
       '@jspsych/plugin-html-keyboard-response':
         specifier: 1.1.3
-        version: 1.1.3(jspsych@8.0.1)
+        version: 1.1.3(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1466,6 +1475,9 @@ importers:
       '@jspsych/plugin-html-keyboard-response':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1474,7 +1486,10 @@ importers:
     dependencies:
       '@jspsych/plugin-image-button-response':
         specifier: 1.2.0
-        version: 1.2.0(jspsych@8.0.1)
+        version: 1.2.0(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1484,6 +1499,9 @@ importers:
       '@jspsych/plugin-image-button-response':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1492,7 +1510,10 @@ importers:
     dependencies:
       '@jspsych/plugin-image-keyboard-response':
         specifier: 1.1.3
-        version: 1.1.3(jspsych@8.0.1)
+        version: 1.1.3(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1502,6 +1523,9 @@ importers:
       '@jspsych/plugin-image-keyboard-response':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1511,6 +1535,9 @@ importers:
       '@jspsych/plugin-instructions':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1519,7 +1546,10 @@ importers:
     dependencies:
       '@jspsych/plugin-preload':
         specifier: 1.1.3
-        version: 1.1.3(jspsych@8.0.1)
+        version: 1.1.3(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1529,6 +1559,9 @@ importers:
       '@jspsych/plugin-preload':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1537,7 +1570,10 @@ importers:
     dependencies:
       '@jspsych/plugin-survey-html-form':
         specifier: 1.0.3
-        version: 1.0.3(jspsych@8.0.1)
+        version: 1.0.3(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1547,6 +1583,9 @@ importers:
       '@jspsych/plugin-survey-html-form':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1555,7 +1594,10 @@ importers:
     dependencies:
       '@jspsych/plugin-survey-text':
         specifier: 1.1.3
-        version: 1.1.3(jspsych@8.0.1)
+        version: 1.1.3(jspsych@7.3.4)
+      jspsych:
+        specifier: 7.3.4
+        version: 7.3.4
       jspsych__7.x:
         specifier: workspace:*
         version: link:../../jspsych@7.x
@@ -1565,6 +1607,9 @@ importers:
       '@jspsych/plugin-survey-text':
         specifier: 2.0.0
         version: 2.0.0(jspsych@8.0.1)
+      jspsych:
+        specifier: 8.0.1
+        version: 8.0.1
       jspsych__8.x:
         specifier: workspace:*
         version: link:../../jspsych@8.x
@@ -1653,15 +1698,21 @@ importers:
 
   vendor/react-dom@18.x:
     dependencies:
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
       react-dom:
         specifier: 18.3.1
-        version: 18.3.1(react@19.1.0)
+        version: 18.3.1(react@18.3.1)
       react__18.x:
         specifier: 'workspace:'
         version: link:../react@18.x
 
   vendor/react-dom@19.x:
     dependencies:
+      react:
+        specifier: catalog:react19
+        version: 19.1.0
       react-dom:
         specifier: catalog:react19
         version: 19.1.0(react@19.1.0)
@@ -14860,33 +14911,33 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jspsych/plugin-html-button-response@1.2.0(jspsych@8.0.1)':
+  '@jspsych/plugin-html-button-response@1.2.0(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-html-button-response@2.0.0(jspsych@8.0.1)':
     dependencies:
       jspsych: 8.0.1
 
-  '@jspsych/plugin-html-keyboard-response@1.1.3(jspsych@8.0.1)':
+  '@jspsych/plugin-html-keyboard-response@1.1.3(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-html-keyboard-response@2.0.0(jspsych@8.0.1)':
     dependencies:
       jspsych: 8.0.1
 
-  '@jspsych/plugin-image-button-response@1.2.0(jspsych@8.0.1)':
+  '@jspsych/plugin-image-button-response@1.2.0(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-image-button-response@2.0.0(jspsych@8.0.1)':
     dependencies:
       jspsych: 8.0.1
 
-  '@jspsych/plugin-image-keyboard-response@1.1.3(jspsych@8.0.1)':
+  '@jspsych/plugin-image-keyboard-response@1.1.3(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-image-keyboard-response@2.0.0(jspsych@8.0.1)':
     dependencies:
@@ -14896,25 +14947,25 @@ snapshots:
     dependencies:
       jspsych: 8.0.1
 
-  '@jspsych/plugin-preload@1.1.3(jspsych@8.0.1)':
+  '@jspsych/plugin-preload@1.1.3(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-preload@2.0.0(jspsych@8.0.1)':
     dependencies:
       jspsych: 8.0.1
 
-  '@jspsych/plugin-survey-html-form@1.0.3(jspsych@8.0.1)':
+  '@jspsych/plugin-survey-html-form@1.0.3(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-survey-html-form@2.0.0(jspsych@8.0.1)':
     dependencies:
       jspsych: 8.0.1
 
-  '@jspsych/plugin-survey-text@1.1.3(jspsych@8.0.1)':
+  '@jspsych/plugin-survey-text@1.1.3(jspsych@7.3.4)':
     dependencies:
-      jspsych: 8.0.1
+      jspsych: 7.3.4
 
   '@jspsych/plugin-survey-text@2.0.0(jspsych@8.0.1)':
     dependencies:
@@ -22325,10 +22376,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@18.3.1(react@19.1.0):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
-      react: 19.1.0
+      react: 18.3.1
       scheduler: 0.23.2
 
   react-dom@19.1.0(react@19.1.0):

--- a/runtime/v1/package.json
+++ b/runtime/v1/package.json
@@ -30,7 +30,8 @@
     "global.d.ts"
   ],
   "scripts": {
-    "build": "pnpm exec runtime-bundler"
+    "build": "pnpm exec runtime-bundler",
+    "test": "vitest"
   },
   "devDependencies": {
     "@jspsych/plugin-html-button-response__1.x": "workspace:*",

--- a/runtime/v1/test/vendor-pairing.test.ts
+++ b/runtime/v1/test/vendor-pairing.test.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as module from 'module';
+import * as path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const VENDOR_DIR = path.resolve(import.meta.dirname, '../../../vendor');
+
+/**
+ * Each vendor wrapper declares its intended pairings through workspace dependencies on sibling
+ * wrappers (e.g. `react-dom__18.x` depends on `react__18.x`). The wrapped package's own peer
+ * resolution must honor that pairing: the physical package its peer resolves to must be the same
+ * one the sibling wrapper serves. Otherwise the runtime ships two instances (or two versions) of
+ * a package that must exist once, which pnpm will happily produce unless the wrapper pins the
+ * real peer explicitly.
+ */
+
+function physicalPackageDir(entryPath: string, packageName: string): string {
+  const realPath = fs.realpathSync(entryPath);
+  const needle = `${path.sep}node_modules${path.sep}${packageName}${path.sep}`;
+  const index = realPath.lastIndexOf(needle);
+  return index === -1 ? path.dirname(realPath) : realPath.slice(0, index + needle.length);
+}
+
+function resolveFrom(dir: string, id: string): null | string {
+  const require = module.createRequire(path.join(dir, 'package.json'));
+  try {
+    return require.resolve(id);
+  } catch {
+    return null;
+  }
+}
+
+function findWrapperDirs(): string[] {
+  const dirs: string[] = [];
+  for (const entry of fs.readdirSync(VENDOR_DIR)) {
+    const abspath = path.join(VENDOR_DIR, entry);
+    if (!fs.lstatSync(abspath).isDirectory()) {
+      continue;
+    }
+    if (entry.startsWith('@')) {
+      for (const scopedEntry of fs.readdirSync(abspath)) {
+        const scopedPath = path.join(abspath, scopedEntry);
+        if (fs.existsSync(path.join(scopedPath, 'package.json'))) {
+          dirs.push(scopedPath);
+        }
+      }
+    } else if (fs.existsSync(path.join(abspath, 'package.json'))) {
+      dirs.push(abspath);
+    }
+  }
+  return dirs;
+}
+
+describe('vendor wrapper pairing', () => {
+  it('resolves each wrapped package peer to the same instance its paired wrapper serves', () => {
+    const violations: string[] = [];
+    for (const wrapperDir of findWrapperDirs()) {
+      const pkg = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'package.json'), 'utf-8')) as {
+        dependencies?: { [key: string]: string };
+        name: string;
+      };
+      const wrappedName = pkg.name.split('__')[0]!;
+      const wrappedEntry = resolveFrom(wrapperDir, wrappedName);
+      if (!wrappedEntry) {
+        continue;
+      }
+      const wrappedDir = physicalPackageDir(wrappedEntry, wrappedName);
+      for (const dependency of Object.keys(pkg.dependencies ?? {})) {
+        if (!dependency.includes('__')) {
+          continue;
+        }
+        const peerName = dependency.split('__')[0]!;
+        if (peerName === wrappedName) {
+          continue;
+        }
+        const actualEntry = resolveFrom(wrappedDir, peerName);
+        if (!actualEntry) {
+          continue;
+        }
+        const pairedWrapperDir = path.join(VENDOR_DIR, dependency.split('__').join('@'));
+        const expectedEntry = resolveFrom(pairedWrapperDir, peerName);
+        if (!expectedEntry) {
+          continue;
+        }
+        const actual = physicalPackageDir(actualEntry, peerName);
+        const expected = physicalPackageDir(expectedEntry, peerName);
+        if (actual !== expected) {
+          violations.push(
+            `${pkg.name}: '${peerName}' resolves to '${actual}' but '${dependency}' serves '${expected}'`
+          );
+        }
+      }
+    }
+    expect(violations).toStrictEqual([]);
+  });
+});

--- a/runtime/v1/vitest.config.ts
+++ b/runtime/v1/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+
+import baseConfig from '../../vitest.config';
+
+export default mergeConfig(
+  baseConfig,
+  defineProject({
+    test: {
+      name: 'runtime-v1',
+      root: import.meta.dirname
+    }
+  })
+);

--- a/vendor/@jspsych/plugin-html-button-response@1.x/package.json
+++ b/vendor/@jspsych/plugin-html-button-response@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-html-button-response": "1.2.0",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-html-button-response@2.x/package.json
+++ b/vendor/@jspsych/plugin-html-button-response@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-html-button-response": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-html-keyboard-response@1.x/package.json
+++ b/vendor/@jspsych/plugin-html-keyboard-response@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-html-keyboard-response": "1.1.3",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-html-keyboard-response@2.x/package.json
+++ b/vendor/@jspsych/plugin-html-keyboard-response@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-html-keyboard-response": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-image-button-response@1.x/package.json
+++ b/vendor/@jspsych/plugin-image-button-response@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-image-button-response": "1.2.0",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-image-button-response@2.x/package.json
+++ b/vendor/@jspsych/plugin-image-button-response@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-image-button-response": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-image-keyboard-response@1.x/package.json
+++ b/vendor/@jspsych/plugin-image-keyboard-response@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-image-keyboard-response": "1.1.3",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-image-keyboard-response@2.x/package.json
+++ b/vendor/@jspsych/plugin-image-keyboard-response@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-image-keyboard-response": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-instructions@2.x/package.json
+++ b/vendor/@jspsych/plugin-instructions@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-instructions": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-preload@1.x/package.json
+++ b/vendor/@jspsych/plugin-preload@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-preload": "1.1.3",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-preload@2.x/package.json
+++ b/vendor/@jspsych/plugin-preload@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-preload": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-survey-html-form@1.x/package.json
+++ b/vendor/@jspsych/plugin-survey-html-form@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-survey-html-form": "1.0.3",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-survey-html-form@2.x/package.json
+++ b/vendor/@jspsych/plugin-survey-html-form@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-survey-html-form": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-survey-text@1.x/package.json
+++ b/vendor/@jspsych/plugin-survey-text@1.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-survey-text": "1.1.3",
+    "jspsych": "7.3.4",
     "jspsych__7.x": "workspace:*"
   }
 }

--- a/vendor/@jspsych/plugin-survey-text@2.x/package.json
+++ b/vendor/@jspsych/plugin-survey-text@2.x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@jspsych/plugin-survey-text": "2.0.0",
+    "jspsych": "8.0.1",
     "jspsych__8.x": "workspace:*"
   }
 }

--- a/vendor/react-dom@18.x/package.json
+++ b/vendor/react-dom@18.x/package.json
@@ -19,7 +19,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "react-dom": "18.3.1",
-    "react__18.x": "workspace:"
+    "react": "18.3.1",
+    "react__18.x": "workspace:",
+    "react-dom": "18.3.1"
   }
 }

--- a/vendor/react-dom@19.x/package.json
+++ b/vendor/react-dom@19.x/package.json
@@ -31,7 +31,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "react-dom": "catalog:react19",
-    "react__19.x": "workspace:"
+    "react": "catalog:react19",
+    "react__19.x": "workspace:",
+    "react-dom": "catalog:react19"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['apps/*/vitest.config.ts', 'packages/*/vitest.config.ts'],
+    projects: ['apps/*/vitest.config.ts', 'packages/*/vitest.config.ts', 'runtime/*/vitest.config.ts'],
     coverage: {
       exclude: [
         '**/.storybook/**',


### PR DESCRIPTION
## Problem

Side-finding from the runtime-splitting investigation (#see fix/runtime-bundler-splitting): each vendor wrapper declares its intended pairing through a workspace dependency on a sibling wrapper — `react-dom__18.x` depends on `react__18.x`, `plugin-preload__1.x` depends on `jspsych__7.x`. But that convention only pairs the *wrappers*. pnpm resolves the **wrapped package's** peer dependencies with no knowledge of it:

| Wrapped package | Peer range | pnpm linked it to | Should be |
|---|---|---|---|
| `react-dom@18.3.1` | `react@^18.3.1` | `react@19.1.0` (bad peer match) | `react@18.3.1` |
| `@jspsych/plugin-*@1.x` (all 7) | `jspsych@>=7.1.0` | `jspsych@8.0.1` (legal, wrong intent) | `jspsych@7.3.4` |
| `react-dom@19.1.0` | `react@^19` | `react@19.1.0` — correct by hoisting luck only | declared |

So a React 18 instrument pairs react-dom 18 (carrying React 19 internals) with the served `react@18.x` (18.3.1) — mismatched instances and mismatched majors — and jspsych 7 instruments get v1 plugins built against jspsych 8.

## Fix

Each wrapper now also pins the **real** peer at the exact version its paired sibling serves. pnpm then materializes the wrapped package against the same physical instance (`react-dom@18.3.1_react@18.3.1`, `@jspsych/plugin-*@1.x_jspsych@7.3.4`), which is also the precondition for esbuild code splitting to collapse the pair into one shared chunk once the splitting fix lands. The two PRs are independent but complementary: this one makes the pairings correct; splitting makes the paired instance physically shared in the dist.

## Guard

`runtime/v1/test/vendor-pairing.test.ts` (new `runtime-v1` vitest project): for every vendor wrapper, every sibling-wrapper pairing it declares must match where the wrapped package's peer physically resolves. Fails with a per-wrapper diff of resolved vs served paths — before this fix it reported exactly the 8 violations in the table. Nothing else stops `pnpm install` from silently reproducing this, so the invariant is enforced rather than remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
