### PR TITLE
chore(deps): bump axios from 1.17.0 to 1.18.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: 4.3.0
       version: 4.3.0
     axios:
-      specifier: ^1.15.0
-      version: 1.17.0
+      specifier: ^1.18.0
+      version: 1.18.1
     commander:
       specifier: ^12.1.0
       version: 12.1.0
@@ -235,7 +235,7 @@ importers:
         version: 9.9.0
       '@nestjs/axios':
         specifier: ^4.0.0
-        version: 4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.17.0)(rxjs@7.8.2)
+        version: 4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.0.11
         version: 11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -292,7 +292,7 @@ importers:
         version: 6.19.3(prisma@6.19.3(typescript@6.0.3))(typescript@6.0.3)
       axios:
         specifier: 'catalog:'
-        version: 1.17.0
+        version: 1.18.1
       express:
         specifier: ^5.0.1
         version: 5.2.1
@@ -389,7 +389,7 @@ importers:
         version: 6.19.3(prisma@6.19.3(typescript@6.0.3))(typescript@6.0.3)
       axios:
         specifier: 'catalog:'
-        version: 1.17.0
+        version: 1.18.1
       compression:
         specifier: ^1.7.5
         version: 1.8.1
@@ -583,7 +583,7 @@ importers:
         version: 2.2.16(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       axios:
         specifier: 'catalog:'
-        version: 1.17.0
+        version: 1.18.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
@@ -737,7 +737,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.11(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x))(@tanstack/router-core@1.171.9)(csstype@3.2.3)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       axios:
         specifier: 'catalog:'
-        version: 1.17.0
+        version: 1.18.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1013,7 +1013,7 @@ importers:
         version: 1.170.11(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       axios:
         specifier: 'catalog:'
-        version: 1.17.0
+        version: 1.18.1
       http-status-codes:
         specifier: ^2.3.0
         version: 2.3.0
@@ -1365,7 +1365,7 @@ importers:
     dependencies:
       axios:
         specifier: 'catalog:'
-        version: 1.17.0
+        version: 1.18.1
       react:
         specifier: catalog:react19
         version: 19.1.0
@@ -6883,9 +6883,9 @@ packages:
       { integrity: sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg== }
     engines: { node: '>=4' }
 
-  axios@1.17.0:
+  axios@1.18.1:
     resolution:
-      { integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw== }
+      { integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g== }
 
   axobject-query@4.1.0:
     resolution:
@@ -15162,10 +15162,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.17.0)(rxjs@7.8.2)':
+  '@nestjs/axios@4.0.1(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      axios: 1.17.0
+      axios: 1.18.1
       rxjs: 7.8.2
 
   '@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2)':
@@ -18215,7 +18215,7 @@ snapshots:
 
   axe-core@4.12.0: {}
 
-  axios@1.17.0:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   '@testing-library/jest-dom': '^6.5.0'
   '@testing-library/react': '^16.0.1'
   '@testing-library/user-event': '^14.5.2'
-  axios: ^1.15.0
+  axios: ^1.18.0
   commander: '^12.1.0'
   esbuild: '0.23.x'
   esbuild-wasm: '0.23.x'


### PR DESCRIPTION
Resolves 10 dependabot alerts (#322, #330, #331, #337, #338, #339, #340, #341, #342, #343) — all patched in axios 1.18.0: prototype-pollution gadgets affecting request construction and auth subfields, NO_PROXY bypass for 0.0.0.0, `maxBodyLength` bypasses in the fetch adapter and HTTP/2 streamed uploads, `formDataToJSON` recursion DoS, form serializer `maxDepth` bypass, and an inherited-proxy flaw after interceptor config cloning.

axios is a direct dependency of api, gateway, web, playground, react-core, and storybook via the workspace catalog. This raises the catalog floor from `^1.15.0` to `^1.18.0` and the resolution from 1.17.0 to 1.18.1.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR