### PR TITLE
chore(deps): bump vendored dompurify from 3.1.6 to 3.4.12

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1619,8 +1619,8 @@ importers:
   vendor/dompurify@3.x:
     dependencies:
       dompurify:
-        specifier: 3.1.6
-        version: 3.1.6
+        specifier: 3.4.12
+        version: 3.4.12
 
   vendor/jquery-ui@1.x:
     dependencies:
@@ -6286,6 +6286,10 @@ packages:
     resolution:
       { integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w== }
 
+  '@types/trusted-types@2.0.7':
+    resolution:
+      { integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw== }
+
   '@types/unist@2.0.11':
     resolution:
       { integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA== }
@@ -7837,9 +7841,9 @@ packages:
       { integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w== }
     engines: { node: '>= 4' }
 
-  dompurify@3.1.6:
+  dompurify@3.4.12:
     resolution:
-      { integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ== }
+      { integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg== }
 
   domutils@3.2.2:
     resolution:
@@ -17452,6 +17456,9 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.10
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -18937,7 +18944,9 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.6: {}
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:

--- a/vendor/dompurify@3.x/package.json
+++ b/vendor/dompurify@3.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dompurify__3.x",
   "type": "module",
-  "version": "3.1.6",
+  "version": "3.4.12",
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -11,6 +11,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "dompurify": "3.1.6"
+    "dompurify": "3.4.12"
   }
 }


### PR DESCRIPTION
Resolves 15 dependabot alerts (#214, #225, #226, #240, #243, #244, #245, #285, #286, #287, #288, #290, #291, #319, #351) covering sanitizer bypasses in DOMPurify ≤ 3.4.11: mutation-XSS via re-contextualization, IN_PLACE bypasses (clobbered root, shadow root in `<template>`, cross-realm), prototype-pollution config bypasses (`USE_PROFILES`, `CUSTOM_ELEMENT_HANDLING`), `ADD_ATTR`/`ADD_TAGS` predicate flaws, `SAFE_FOR_TEMPLATES` bypasses, and hook/config pollution issues.

**Runtime caution (external consumers):** this is the vendored instrument-runtime lib `vendor/dompurify@3.x`, exposed to instruments as `dompurify__3.x`. The name advertises a 3.x contract and the re-export surface (`export { default, default as DOMPurify }`) is unchanged between 3.1.6 and 3.4.12, so existing instruments keep working; any behavior change is stricter sanitization, which is the point of the fix — this directly hardens patient- and clinician-facing instrument rendering. The vendor package's `version` field mirrors the vendored lib version, per convention.

The published `@opendatacapture/runtime-v1` picks this up at the next lockstep version increment (dist is built in CI at publish time); no version bump is included here since increments are done as dedicated maintainer commits.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR