### PR TITLE
chore(deps): bump vendored lodash-es from 4.17.21 to 4.18.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1661,8 +1661,8 @@ importers:
   vendor/lodash-es@4.x:
     dependencies:
       lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
 
   vendor/normalize.css@8.x:
     dependencies:
@@ -9706,10 +9706,6 @@ packages:
     resolution:
       { integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw== }
     engines: { node: '>=10' }
-
-  lodash-es@4.17.21:
-    resolution:
-      { integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw== }
 
   lodash-es@4.18.1:
     resolution:
@@ -20869,8 +20865,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash-es@4.18.1: {}
 

--- a/vendor/lodash-es@4.x/package.json
+++ b/vendor/lodash-es@4.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lodash-es__4.x",
   "type": "module",
-  "version": "4.17.21",
+  "version": "4.18.1",
   "license": "MIT",
   "exports": {
     ".": {
@@ -11,6 +11,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.18.1"
   }
 }


### PR DESCRIPTION
Resolves 2 dependabot alerts: #221 (high — code injection via `_.template` imports key names) and #222 (prototype pollution via array-path bypass in `_.unset`/`_.omit`), both patched in 4.18.0.

**Runtime caution (external consumers):** this is the vendored instrument-runtime lib `vendor/lodash-es@4.x`, exposed to instruments as `lodash-es__4.x`. The name advertises a 4.x contract and the re-export surface (`export * from 'lodash-es'`) is unchanged, so existing instruments keep working. 4.18.1 is the exact version already resolved elsewhere in the tree for `@douglasneuroinformatics/libui`, so this also dedupes the lockfile to a single lodash-es. The vendor package's `version` field mirrors the vendored lib version, per convention.

The published `@opendatacapture/runtime-v1` picks this up at the next lockstep version increment.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR