### PR TITLE
chore(deps): bump find-my-way from 9.6.0 to 9.7.0 via scoped override

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
       "@types/react": "-",
       "@types/react-dom": "-",
       "framer-motion": "11.15.0",
-      "typescript": "6.0.x"
+      "typescript": "6.0.x",
+      "find-my-way@9": "^9.7.0"
     },
     "onlyBuiltDependencies": [
       "@import-meta-env/unplugin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,7 @@ overrides:
   '@types/react-dom': '-'
   framer-motion: 11.15.0
   typescript: 6.0.x
+  find-my-way@9: ^9.7.0
 
 importers:
   .:
@@ -8497,9 +8498,9 @@ packages:
       { integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig== }
     engines: { node: '>=8' }
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     resolution:
-      { integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ== }
+      { integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ== }
     engines: { node: '>=20' }
 
   find-up@4.1.0:
@@ -15231,7 +15232,7 @@ snapshots:
       fast-querystring: 1.1.2
       fastify: 5.8.5
       fastify-plugin: 5.1.0
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       path-to-regexp: 8.4.2
       reusify: 1.1.0
@@ -19705,7 +19706,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 6.4.0
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -19783,7 +19784,7 @@ snapshots:
       make-dir: 3.1.0
       pkg-dir: 4.2.0
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2


### PR DESCRIPTION
Resolves dependabot alert #355 (high — CVE-2026-47219, DDoS with HTTP/2), patched in find-my-way 9.7.0. find-my-way is the fastify router serving the API.

**Why an override:** find-my-way has two dependents — fastify@5.8.5 (`^9.0.0`, bumps cleanly) and `@nestjs/platform-fastify` (pins **exact 9.6.0** in every current release, including 11.1.28). The vulnerable copy can only be removed from the lockfile with a scoped override `"find-my-way@9": "^9.7.0"`. Drop the override once `@nestjs/platform-fastify` ships a release depending on find-my-way ≥ 9.7.0.

**minimumReleaseAge note:** 9.7.0 was published 2026-07-21, inside the repo's 7-day gate; the lockfile resolution was made with a one-off `--config.minimumReleaseAge=0` for this security patch. The window lapses 2026-07-28, after which ordinary installs resolve it anyway.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR