### PR TITLE
chore(deps): bump js-yaml to 4.3.0 (root devDep + @nestjs/swagger 11.4.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint": "9.23.x",
     "expect-type": "^0.20.0",
     "husky": "^9.1.7",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "knip": "^5.46.0",
     "prettier": "^3.4.2",
     "prettier-plugin-astro": "^0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.2.0
+        specifier: ^4.3.0
+        version: 4.3.0
       knip:
         specifier: ^5.46.0
         version: 5.88.1(@types/node@24.13.0)(typescript@6.0.3)
@@ -256,7 +256,7 @@ importers:
         version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)
       '@nestjs/swagger':
         specifier: ^11.0.6
-        version: 11.4.4(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)
+        version: 11.4.5(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)
       '@nestjs/throttler':
         specifier: ^6.5.0
         version: 6.5.0(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)
@@ -4051,9 +4051,9 @@ packages:
       '@fastify/view':
         optional: true
 
-  '@nestjs/swagger@11.4.4':
+  '@nestjs/swagger@11.4.5':
     resolution:
-      { integrity: sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA== }
+      { integrity: sha512-lvndlJmWBVDOUT0uEtLi6sSpW1syK2/nbAlHBhiELBORMpJGe9+EiWAT9qHtB10jW91L2Jmlwkr0/lttsYZrig== }
     peerDependencies:
       '@fastify/static': ^8.0.0 || ^9.0.0
       '@nestjs/common': ^11.0.1
@@ -9429,14 +9429,9 @@ packages:
     resolution:
       { integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ== }
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     resolution:
-      { integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA== }
-    hasBin: true
-
-  js-yaml@4.2.0:
-    resolution:
-      { integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw== }
+      { integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q== }
     hasBin: true
 
   jsdoc-type-pratt-parser@4.1.0:
@@ -12189,9 +12184,9 @@ packages:
     engines: { node: '>=16' }
     hasBin: true
 
-  swagger-ui-dist@5.32.6:
+  swagger-ui-dist@5.32.8:
     resolution:
-      { integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA== }
+      { integrity: sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA== }
 
   synckit@0.11.13:
     resolution:
@@ -13343,7 +13338,7 @@ snapshots:
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
       import-meta-resolve: 4.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -13412,7 +13407,7 @@ snapshots:
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 23.16.8
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       klona: 2.0.6
       mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
@@ -13953,7 +13948,7 @@ snapshots:
       '@nestjs/common': 11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/platform-fastify': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)
-      '@nestjs/swagger': 11.4.4(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)
+      '@nestjs/swagger': 11.4.5(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)
       '@nestjs/testing': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@nestjs/platform-express@11.1.24)
       '@nestjs/throttler': 6.5.0(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)
       '@prisma/client': 6.19.3(prisma@6.19.3(typescript@6.0.3))(typescript@6.0.3)
@@ -14557,7 +14552,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -15237,17 +15232,17 @@ snapshots:
       reusify: 1.1.0
       tslib: 2.8.1
 
-  '@nestjs/swagger@11.4.4(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)':
+  '@nestjs/swagger@11.4.5(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.1.14)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@nestjs/common': 11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.1.14
-      swagger-ui-dist: 5.32.6
+      swagger-ui-dist: 5.32.8
 
   '@nestjs/testing@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.24)(@nestjs/platform-express@11.1.24)':
     dependencies:
@@ -18116,7 +18111,7 @@ snapshots:
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
       import-meta-resolve: 4.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       magic-string: 0.30.21
       magicast: 0.5.3
       mrmime: 2.0.1
@@ -20650,11 +20645,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -23495,7 +23486,7 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swagger-ui-dist@5.32.6:
+  swagger-ui-dist@5.32.8:
     dependencies:
       '@scarf/scarf': 1.4.0
 


### PR DESCRIPTION
Resolves 2 dependabot alerts: #336 (high — CVE-2026-59869, YAML merge-key chains force quadratic CPU, patched 4.3.0) and #321 (medium — CVE-2026-53550, quadratic merge-key DoS via repeated aliases, patched 4.2.0).

Two js-yaml instances existed in the lockfile:
- **4.2.0** — the root devDependency (and astro/eslint consumers, all `^4.x`): the root floor is raised `^4.1.1` → `^4.3.0` and everything re-resolves to 4.3.0.
- **4.1.1** — pinned exactly by `@nestjs/swagger`: fixed by bumping swagger 11.4.4 → 11.4.5 (within the API's `^11.0.6`), the release that moves its pin to js-yaml 4.3.0. Deliberately **not** 11.4.6, which jumps to js-yaml 5.x — a larger change than a security fix warrants.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR