### PR TITLE
chore(deps): resolve yaml@2 to 2.9.0 via scoped override

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
       "@types/react": "-",
       "@types/react-dom": "-",
       "framer-motion": "11.15.0",
-      "typescript": "6.0.x"
+      "typescript": "6.0.x",
+      "yaml@2": "^2.9.0"
     },
     "onlyBuiltDependencies": [
       "@import-meta-env/unplugin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,7 @@ overrides:
   '@types/react-dom': '-'
   framer-motion: 11.15.0
   typescript: 6.0.x
+  yaml@2: ^2.9.0
 
 importers:
   .:
@@ -12809,7 +12810,7 @@ packages:
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.9.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -13178,12 +13179,6 @@ packages:
     resolution:
       { integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA== }
     engines: { node: '>= 6' }
-
-  yaml@2.7.1:
-    resolution:
-      { integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ== }
-    engines: { node: '>= 14' }
-    hasBin: true
 
   yaml@2.9.0:
     resolution:
@@ -24322,11 +24317,9 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
-      yaml: 2.7.1
+      yaml: 2.9.0
 
   yaml@1.10.3: {}
-
-  yaml@2.7.1: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
Resolves dependabot alert #210 (medium — CVE-2026-33532, stack overflow via deeply nested YAML collections in yaml 2.x < 2.8.3).

The vulnerable yaml@2.7.1 is pinned exactly by `yaml-language-server@1.20.0`, which is itself pinned (`~1.20.0`) by `volar-service-yaml` in the astro docs toolchain — so no in-range bump can reach it. A scoped override `"yaml@2": "^2.9.0"` dedupes it onto the yaml 2.9.0 already present in the tree, while the `@2` scope leaves the unaffected yaml@1.10.3 (postcss-load-config) untouched — matching the repo's existing scoped-override practice.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR