### PR TITLE
chore(deps): bump svgo from 4.0.1 to 4.0.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12183,9 +12183,9 @@ packages:
       svelte:
         optional: true
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     resolution:
-      { integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w== }
+      { integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng== }
     engines: { node: '>=16' }
     hasBin: true
 
@@ -18131,7 +18131,7 @@ snapshots:
       semver: 7.8.1
       shiki: 3.23.0
       smol-toml: 1.6.1
-      svgo: 4.0.1
+      svgo: 4.0.2
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tsconfck: 3.1.6(typescript@6.0.3)
@@ -23485,7 +23485,7 @@ snapshots:
       postcss: 8.5.15
       postcss-scss: 4.0.9(postcss@8.5.15)
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2


### PR DESCRIPTION
Resolves dependabot alert #352 (high — the removeScripts plugin leaves some executable scripts intact), patched in 4.0.2.

Transitive dependency of astro (`^4.0.0`) in the outreach site's build toolchain, so this is a lockfile-only re-resolution.

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of all 13 per-package dependency PRs; CI validates this change in isolation. These PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges some of the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR