### PR TITLE
chore(deps): bump vendored runtime libs (dompurify 3.4.12, lodash-es 4.18.1)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1619,8 +1619,8 @@ importers:
   vendor/dompurify@3.x:
     dependencies:
       dompurify:
-        specifier: 3.1.6
-        version: 3.1.6
+        specifier: 3.4.12
+        version: 3.4.12
 
   vendor/jquery-ui@1.x:
     dependencies:
@@ -1661,8 +1661,8 @@ importers:
   vendor/lodash-es@4.x:
     dependencies:
       lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
 
   vendor/normalize.css@8.x:
     dependencies:
@@ -6286,6 +6286,10 @@ packages:
     resolution:
       { integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w== }
 
+  '@types/trusted-types@2.0.7':
+    resolution:
+      { integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw== }
+
   '@types/unist@2.0.11':
     resolution:
       { integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA== }
@@ -7837,9 +7841,9 @@ packages:
       { integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w== }
     engines: { node: '>= 4' }
 
-  dompurify@3.1.6:
+  dompurify@3.4.12:
     resolution:
-      { integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ== }
+      { integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg== }
 
   domutils@3.2.2:
     resolution:
@@ -9706,10 +9710,6 @@ packages:
     resolution:
       { integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw== }
     engines: { node: '>=10' }
-
-  lodash-es@4.17.21:
-    resolution:
-      { integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw== }
 
   lodash-es@4.18.1:
     resolution:
@@ -17452,6 +17452,9 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.10
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -18937,7 +18940,9 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.6: {}
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -20869,8 +20874,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash-es@4.18.1: {}
 

--- a/vendor/dompurify@3.x/package.json
+++ b/vendor/dompurify@3.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dompurify__3.x",
   "type": "module",
-  "version": "3.1.6",
+  "version": "3.4.12",
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -11,6 +11,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "dompurify": "3.1.6"
+    "dompurify": "3.4.12"
   }
 }

--- a/vendor/lodash-es@4.x/package.json
+++ b/vendor/lodash-es@4.x/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lodash-es__4.x",
   "type": "module",
-  "version": "4.17.21",
+  "version": "4.18.1",
   "license": "MIT",
   "exports": {
     ".": {
@@ -11,6 +11,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.18.1"
   }
 }


### PR DESCRIPTION
Resolves 17 dependabot alerts in the two vendored instrument-runtime libraries.

## dompurify 3.1.6 → 3.4.12 (15 alerts)
Alerts #214, #225, #226, #240, #243, #244, #245, #285, #286, #287, #288, #290, #291, #319, #351 — sanitizer bypasses in DOMPurify ≤ 3.4.11: mutation-XSS via re-contextualization, IN_PLACE bypasses (clobbered root, shadow root in `<template>`, cross-realm), prototype-pollution config bypasses (`USE_PROFILES`, `CUSTOM_ELEMENT_HANDLING`), `ADD_ATTR`/`ADD_TAGS` predicate flaws, `SAFE_FOR_TEMPLATES` bypasses, and hook/config pollution. Directly hardens patient- and clinician-facing instrument rendering.

## lodash-es 4.17.21 → 4.18.1 (2 alerts)
Alert #221 (high — code injection via `_.template` imports key names) and #222 (prototype pollution via array-path bypass in `_.unset`/`_.omit`), both patched in 4.18.0. 4.18.1 is the version already resolved for `@douglasneuroinformatics/libui`, so the lockfile dedupes to a single lodash-es.

## Runtime caution (external consumers)
These are the vendored libs `vendor/dompurify@3.x` and `vendor/lodash-es@4.x`, exposed to instruments as `dompurify__3.x` / `lodash-es__4.x`. The names advertise within-major contracts and the re-export surfaces (`export { default, default as DOMPurify }` / `export * from 'lodash-es'`) are unchanged, so existing instruments keep working; the only behavior change is stricter sanitization, which is the point of the fix. Vendor `version` fields mirror the vendored lib versions, per convention.

No package version bumps are included — publishable versions move in lockstep maintainer commits; the published `@opendatacapture/runtime-v1` picks this up at the next increment (dist is built in CI at publish).

**Validation:** `pnpm lint` and `pnpm test` (48 files, 334 tests) pass locally on the union of these three dependency PRs; CI validates each in isolation. The three PRs touch overlapping lines of `pnpm-lock.yaml`, so after one merges the others may need a trivial rebase/lockfile regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012j6xhfL8M9kKaNwhAHshAR