### PR TITLE
Properly attaching username to data within datahub export

### DIFF
--- a/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
+++ b/apps/api/src/instrument-records/__tests__/instrument-records.service.spec.ts
@@ -419,5 +419,22 @@ describe('InstrumentRecordsService', () => {
         value: 85
       });
     });
+
+    it('should join and project the session user by a cast-hardened lookup, so the export includes the username of whoever ran the session', async () => {
+      instrumentRecordModel.aggregateRaw.mockResolvedValueOnce([]);
+      const ability = { can: () => true } as any;
+
+      await instrumentRecordsService.exportRecords({}, { ability });
+
+      const [{ pipeline }] = instrumentRecordModel.aggregateRaw.mock.lastCall as [{ pipeline: any[] }];
+
+      // Session documents only ever store a userId reference, never an embedded user object, so
+      // resolving a username requires an explicit join against UserModel.
+      const userLookupStage = pipeline.find((stage) => stage.$lookup?.from === 'UserModel');
+      expect(userLookupStage).toBeDefined();
+
+      const projectStage = pipeline.find((stage) => stage.$project);
+      expect(projectStage.$project.session.user.username).toBe('$sessionUser.username');
+    });
   });
 });

--- a/apps/api/src/instrument-records/instrument-records.service.ts
+++ b/apps/api/src/instrument-records/instrument-records.service.ts
@@ -498,6 +498,26 @@ export class InstrumentRecordsService {
       },
       { $unwind: { path: '$session', preserveNullAndEmptyArrays: true } },
       {
+        // session.userId is an ObjectId reference to UserModel, but a small number of legacy
+        // sessions have it stored as a plain string; $convert normalizes both to a real ObjectId
+        // (or null, if the session has no user) so the following $lookup can match on it.
+        $addFields: {
+          'session.userObjectId': {
+            $convert: { input: '$session.userId', onError: null, onNull: null, to: 'objectId' }
+          }
+        }
+      },
+      {
+        // Join with User collection, to resolve the username of whoever ran the session
+        $lookup: {
+          as: 'sessionUser',
+          foreignField: '_id',
+          from: 'UserModel',
+          localField: 'session.userObjectId'
+        }
+      },
+      { $unwind: { path: '$sessionUser', preserveNullAndEmptyArrays: true } },
+      {
         // Join with Subject collection
         $lookup: {
           as: 'subject',
@@ -543,7 +563,7 @@ export class InstrumentRecordsService {
               $toString: '$session._id'
             },
             type: '$session.type',
-            user: { username: '$session.user.username' } // TBD test this works
+            user: { username: '$sessionUser.username' }
           },
           // sessionId: 1,
           subject: {


### PR DESCRIPTION
# fix(api): resolve session username in instrument records export

## Summary

- The datahub's "Export" flow (`GET /instrument-records/export`) always showed `N/A` for every
  record's username, regardless of who actually logged the data. `queryRecordsRaw`'s aggregation
  pipeline joined the `Session` collection but then read `session.user.username` in its `$project`
  stage — `Session` documents never embed a `user` object, they only store a `userId` reference, so
  that field was always empty.
- Fix the pipeline to actually resolve the user: cast `session.userId` to a proper `ObjectId` via
  `$convert` (this also normalizes a small number of legacy sessions whose `userId` had been
  persisted as a plain string instead of an `ObjectId`), `$lookup` against `UserModel` on the cast
  field, and project the username from the joined document.
- Add a regression test asserting the pipeline handed to `aggregateRaw` contains the `UserModel`
  lookup and projects `$sessionUser.username`. The existing export test mocked `aggregateRaw`'s
  return value directly, so it exercised the worker's row-mapping logic but could never have caught
  a broken aggregation pipeline shape — which is exactly how this bug shipped silently.

## Why this was invisible until now

`aggregateRaw` bypasses Prisma's typed query builder, so neither `tsc` nor a schema check could
catch the mismatch between the assumed `session.user` shape and the actual `Session` model. The
inline comment removed by this PR (`// TBD test this works`) was a pre-existing admission that this
exact line had never been verified.

## Test plan

- [x] `pnpm exec vitest --project api` — all tests pass, including the new regression test
- [x] `pnpm lint` / `pnpm test` from the repo root
- [x] Replayed the new pipeline shape directly against a full copy of production-scale data: went
      from 0 resolved usernames on any exported record to correctly resolving the username on every
      record whose session actually has one attached, including the legacy string-typed `userId`
      cases

closes issue #1489 

assisted with claude  Sonnet 5