### PR TITLE
fix(release): give the gateway image build access to RELEASE_VERSION

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,22 +1,17 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env", "eslint.config.js", "tsconfig.base.json", "prettier.config.js"],
-  "globalEnv": ["NODE_ENV", "NODE_OPTIONS"],
+  "globalEnv": ["NODE_ENV", "NODE_OPTIONS", "RELEASE_VERSION"],
   "tasks": {
+    // A package-scoped task replaces the generic one rather than merging with it,
+    // so anything the generic build declares must be repeated here.
     "@opendatacapture/gateway#build": {
-      "dependsOn": ["^build", "db:push"]
+      "dependsOn": ["^build", "db:push"],
+      "outputs": ["dist/**"]
     },
     "build": {
       "dependsOn": ["^build", "db:generate"],
-      "env": [
-        "API_BASE_URL",
-        "CONTACT_EMAIL",
-        "DOCS_URL",
-        "GITHUB_REPO_URL",
-        "LICENSE_URL",
-        "GATEWAY_ENABLED",
-        "RELEASE_VERSION"
-      ],
+      "env": ["API_BASE_URL", "CONTACT_EMAIL", "DOCS_URL", "GITHUB_REPO_URL", "LICENSE_URL", "GATEWAY_ENABLED"],
       "outputs": ["dist/**"]
     },
     "db:generate": {


### PR DESCRIPTION
## Problem

Every `Release` run since `f7bb3f833` (2026-07-26) has failed at the gateway image build:

```
@opendatacapture/gateway:build: ZodError: [{ "path": ["version"],
  "message": "Invalid input: expected string, received undefined" }]
    at getReleaseInfo (/app/packages/release-info/src/index.ts:45:37)
```

`fail-fast: true` then cancels the web and api image builds, so `publish-npm` and `release` never run — no images, no npm packages, no tag since the last green release on 2026-07-26.

## Cause

A `pkg#task` entry in `turbo.json` *replaces* the generic `task` entry instead of merging with it. `f7bb3f833` renamed the key `gateway#build` (which matched no package, so it was inert) to `@opendatacapture/gateway#build`, activating an override that declares only `dependsOn`. That dropped both the `env` allowlist and `outputs` for the gateway build:

```
$ pnpm exec turbo run build --filter=@opendatacapture/gateway --dry=json
{ "taskId": "@opendatacapture/gateway#build", "envMode": "strict",
  "outputs": null, "env": { "specified": { "env": [] } } }
```

Under turbo's default strict env mode an empty `env` list means `RELEASE_VERSION` — which the workflow does pass correctly as a Docker build arg — is filtered out of the task's environment, so `getReleaseInfo()` reads `undefined` in its `NODE_ENV=production` branch.

## Fix

- `RELEASE_VERSION` moves to `globalEnv`, so no package-scoped override can drop it again.
- `outputs: ["dist/**"]` restored on `@opendatacapture/gateway#build` (it was caching nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)