### PR TITLE
User group manadatory

### DIFF
--- a/apps/web/src/routes/_app/admin/users/create.tsx
+++ b/apps/web/src/routes/_app/admin/users/create.tsx
@@ -18,7 +18,7 @@ import { useCreateUserMutation } from '@/hooks/useCreateUserMutation';
 import { groupsQueryOptions, useGroupsQuery } from '@/hooks/useGroupsQuery';
 import { useMailErrorMessage } from '@/hooks/useMailErrorMessage';
 import { useSetupStateQuery } from '@/hooks/useSetupStateQuery';
-import { $Email, $PhoneNumber, omittedIfBlank } from '@/utils/validation';
+import { $Email, $PhoneNumber, omittedIfBlank, requiresGroup } from '@/utils/validation';
 
 const PASSWORD_ERROR_TRANSLATION_KEYS = {
   INSUFFICIENT_PASSWORD_STRENGTH: 'common.insufficientPasswordStrength',
@@ -309,6 +309,16 @@ const RouteComponent = () => {
                 input: ctx.value.confirmPassword,
                 message: t('common.passwordsMustMatch'),
                 path: ['confirmPassword']
+              });
+            }
+          })
+          .check((ctx) => {
+            if (requiresGroup(ctx.value) && !ctx.value.groupIds?.size) {
+              ctx.issues.push({
+                code: 'custom',
+                input: ctx.value.groupIds,
+                message: t('common.groupRequired'),
+                path: ['groupIds']
               });
             }
           })}

--- a/apps/web/src/routes/_app/admin/users/index.tsx
+++ b/apps/web/src/routes/_app/admin/users/index.tsx
@@ -19,7 +19,7 @@ import { groupsQueryOptions, useGroupsQuery } from '@/hooks/useGroupsQuery';
 import { useUpdateUserMutation } from '@/hooks/useUpdateUserMutation';
 import { usersQueryOptions, useUsersQuery } from '@/hooks/useUsersQuery';
 import { useAppStore } from '@/store';
-import { $Email, $PhoneNumber, clearedIfBlank, omittedIfUnchanged } from '@/utils/validation';
+import { $Email, $PhoneNumber, clearedIfBlank, omittedIfUnchanged, requiresGroup } from '@/utils/validation';
 
 type UpdateUserFormData = {
   additionalPermissions?: Partial<UserPermission>[];
@@ -93,14 +93,12 @@ const UpdateUserForm: React.FC<{
         });
       })
       .check((ctx) => {
-        if (ctx.value.groupIds.size <= 0 && data.selectedUserBasePermission !== 'ADMIN') {
+        const permissions = { basePermissionLevel: data.selectedUserBasePermission, disabled: ctx.value.disabled };
+        if (requiresGroup(permissions) && ctx.value.groupIds.size <= 0) {
           ctx.issues.push({
             code: 'custom',
-            input: ctx.value.confirmPassword,
-            message: t({
-              en: 'Standard user must be part of a group',
-              fr: "Un utilisateur standard doit faire partie d'un groupe"
-            }),
+            input: ctx.value.groupIds,
+            message: t('common.groupRequired'),
             path: ['groupIds']
           });
         }
@@ -115,7 +113,10 @@ const UpdateUserForm: React.FC<{
           });
         }
       }) satisfies z.ZodType<UpdateUserFormData>;
-  }, [resolvedLanguage, initialValues?.phoneNumber]);
+    // `selectedUserBasePermission` decides whether a group is required, so a schema built for the
+    // previously selected user must not be reused: two users differing only in permission level
+    // would otherwise share one schema and be validated against the wrong rule.
+  }, [data.selectedUserBasePermission, resolvedLanguage, initialValues?.phoneNumber]);
 
   return (
     <Dialog open={isConfirmDeleteOpen} onOpenChange={setIsConfirmDeleteOpen}>

--- a/apps/web/src/translations/common.json
+++ b/apps/web/src/translations/common.json
@@ -116,6 +116,11 @@
     "es": "Nombre del grupo",
     "fr": "Nom du groupe"
   },
+  "groupRequired": {
+    "en": "A user who is not an administrator must belong to at least one group",
+    "es": "Un usuario que no es administrador debe pertenecer al menos a un grupo",
+    "fr": "Un utilisateur qui n'est pas administrateur doit appartenir à au moins un groupe"
+  },
   "groupTrend": {
     "en": "Group Trend",
     "es": "Tendencia del grupo",

--- a/apps/web/src/utils/__tests__/validation.test.ts
+++ b/apps/web/src/utils/__tests__/validation.test.ts
@@ -3,7 +3,7 @@ import { MIN_PHONE_DIGITS } from '@opendatacapture/schemas/user';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 
-import { $Email, $PhoneNumber, clearedIfBlank, omittedIfBlank, omittedIfUnchanged } from '../validation';
+import { $Email, $PhoneNumber, clearedIfBlank, omittedIfBlank, omittedIfUnchanged, requiresGroup } from '../validation';
 
 const t: TranslateFunction<TranslationKey> = (arg) => (typeof arg === 'string' ? arg : (arg.en ?? ''));
 
@@ -104,5 +104,27 @@ describe('$Email', () => {
     const { issues } = parseEmail('jane.doe@');
     expect(issues).toHaveLength(1);
     expect(issues[0]!.message).toBe('Invalid email address');
+  });
+});
+
+describe('requiresGroup', () => {
+  it('should not require a group for an admin, who is never scoped to one', () => {
+    expect(requiresGroup({ basePermissionLevel: 'ADMIN' })).toBe(false);
+  });
+
+  it.each(['GROUP_MANAGER', 'STANDARD'] as const)('should require a group for a %s user', (basePermissionLevel) => {
+    expect(requiresGroup({ basePermissionLevel })).toBe(true);
+  });
+
+  it('should require a group when the permission level is null, since that is not an admin', () => {
+    expect(requiresGroup({ basePermissionLevel: null })).toBe(true);
+  });
+
+  it('should not require a group for a disabled account, which exists only to attribute uploaded data', () => {
+    expect(requiresGroup({ basePermissionLevel: 'STANDARD', disabled: true })).toBe(false);
+  });
+
+  it('should still require a group for a non-admin explicitly marked as enabled', () => {
+    expect(requiresGroup({ basePermissionLevel: 'STANDARD', disabled: false })).toBe(true);
   });
 });

--- a/apps/web/src/utils/validation.ts
+++ b/apps/web/src/utils/validation.ts
@@ -1,6 +1,6 @@
 import type { TranslateFunction, TranslationKey } from '@douglasneuroinformatics/libui/i18n';
 import { findPhoneNumberError, MIN_PHONE_DIGITS } from '@opendatacapture/schemas/user';
-import type { PhoneNumberErrorCode } from '@opendatacapture/schemas/user';
+import type { BasePermissionLevel, PhoneNumberErrorCode } from '@opendatacapture/schemas/user';
 import { z } from 'zod/v4';
 
 /**
@@ -65,4 +65,23 @@ function $PhoneNumber(t: TranslateFunction<TranslationKey>, storedValue?: null |
   });
 }
 
-export { $Email, $PhoneNumber, clearedIfBlank, omittedIfBlank, omittedIfUnchanged };
+/**
+ * Whether this user must belong to at least one group, shared by the create and update forms so the
+ * two cannot drift apart again.
+ *
+ * A disabled account exists only to attribute uploaded data, so it never needs one. Every other
+ * non-admin does: each read rule granted to a non-admin is scoped to the groups they belong to, so a
+ * groupless user can still create records that no group manager can ever read back. A null
+ * permission level is not an admin, and so counts.
+ */
+function requiresGroup({
+  basePermissionLevel,
+  disabled
+}: {
+  basePermissionLevel?: BasePermissionLevel | null;
+  disabled?: boolean | null;
+}) {
+  return basePermissionLevel !== 'ADMIN' && !disabled;
+}
+
+export { $Email, $PhoneNumber, clearedIfBlank, omittedIfBlank, omittedIfUnchanged, requiresGroup };

--- a/testing/src/specs/admin-management.spec.ts
+++ b/testing/src/specs/admin-management.spec.ts
@@ -104,6 +104,56 @@ test.describe('admin management', () => {
     await expect(page).toHaveURL('/admin/users/create');
   });
 
+  test('should reject a non-admin user created without a group', async ({ authenticateAs, page, uniqueId }) => {
+    await authenticateAs('ADMIN');
+    await page.goto('/admin/users/create');
+
+    await page.getByLabel('Username').fill(`user${uniqueId}`);
+    await page.getByLabel('Password', { exact: true }).fill(SEEDED_USER_PASSWORD);
+    await page.getByLabel('Confirm Password').fill(SEEDED_USER_PASSWORD);
+    await page.getByLabel('First Name').fill('Test');
+    await page.getByLabel('Last Name').fill('User');
+    // By testid rather than `getByRole('combobox').first()`: when mail is enabled a welcome-email
+    // language select renders above the form, and `.first()` then opens the wrong one.
+    await page.getByTestId('basePermissionLevel-select-trigger').click();
+    await page.getByTestId('basePermissionLevel-select-item-GROUP_MANAGER').click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(
+      page.getByTestId('error-message-text').filter({ hasText: 'must belong to at least one group' })
+    ).toBeVisible();
+    await expect(page).toHaveURL('/admin/users/create');
+  });
+
+  test('should allow a disabled non-admin user with no group, since such an account only attributes uploaded data', async ({
+    authenticateAs,
+    page,
+    uniqueId
+  }) => {
+    await authenticateAs('ADMIN');
+    await page.goto('/admin/users/create');
+
+    await page.getByLabel('Username').fill(`user${uniqueId}`);
+    await page.getByLabel('Password', { exact: true }).fill(SEEDED_USER_PASSWORD);
+    await page.getByLabel('Confirm Password').fill(SEEDED_USER_PASSWORD);
+    await page.getByLabel('First Name').fill('Test');
+    await page.getByLabel('Last Name').fill('User');
+    await page.getByTestId('basePermissionLevel-select-trigger').click();
+    await page.getByTestId('basePermissionLevel-select-item-GROUP_MANAGER').click();
+    // The radio items carry stable ids (`<name>-true`), unlike their labels, which libui translates.
+    await page.locator('#disabled-true').click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    // Same dual outcome as the creation test below: a user created without an email gets the
+    // copy-it-manually dialog when a parallel worker holds mail enabled.
+    const fallback = page.getByTestId('welcome-email-fallback');
+    await expect(fallback.or(page.getByTestId('data-table-search-bar'))).toBeVisible();
+    if (await fallback.isVisible()) {
+      await fallback.getByRole('button', { name: 'Done' }).click();
+    }
+    await expect(page).toHaveURL('/admin/users');
+  });
+
   test('should create a user through the UI and show it in the users list @smoke', async ({
     api,
     authenticateAs,
@@ -145,9 +195,9 @@ test.describe('admin management', () => {
   });
 
   test('should edit and delete a user through the manage sheet', async ({ api, authenticateAs, page, uniqueId }) => {
-    // The update form requires a non-empty `groupIds` for any non-ADMIN role (see #1472) --
-    // asymmetric with the create form, which allows an empty group set -- so a groupless user can
-    // never actually be saved from this sheet. Seed one with a group to isolate the behavior under test.
+    // Both forms require a non-empty `groupIds` for any non-ADMIN role that is not disabled, so a
+    // groupless user can never be saved from this sheet. Seed one with a group to isolate the
+    // behavior under test.
     const group = await api.createGroup({ name: `E2E Group ${uniqueId}` });
     const { user } = await api.createUser({ groupIds: [group.id] });
 


### PR DESCRIPTION
# feat(web): require a group for non-admin users in the admin user forms

## Summary

A non-admin user with no group is a broken account: every read rule granted to a
`GROUP_MANAGER` or `STANDARD` user is scoped to the groups they belong to, so a groupless
one can still create sessions, subjects and records — but nothing they produce is readable
by any group manager, only by an admin. `InstrumentRecordsService.upload` already rejects
such users outright ("The Non-Admin User must be part of a group"), so the app was happily
creating accounts guaranteed to fail later.

The update form already enforced this rule; the create form did not (the asymmetry noted in
#1472). This closes the gap and makes both forms enforce one shared rule:

| User                                    | Group required? |
| --------------------------------------- | --------------- |
| `ADMIN`                                 | No              |
| `GROUP_MANAGER` / `STANDARD`            | **Yes**         |
| `basePermissionLevel: null`             | **Yes**         |
| Any user marked *Disabled*              | No              |

Disabled accounts are exempt because they exist only to attribute uploaded data, never to
log in and read it.

## Implementation

- Adds `requiresGroup({ basePermissionLevel, disabled })` to `apps/web/src/utils/validation.ts`.
  Both forms call it, so the create/update pair cannot drift apart again, and the rationale
  lives in exactly one place.
- Wires the predicate into the create form's validation schema (new behaviour) and into the
  update form's existing check (which gains the disabled exemption).
- Moves the message to `common.groupRequired` (en/es/fr) now that it is used twice, and
  rewords it: the old string said *"Standard user must be part of a group"*, which was wrong —
  the rule also applies to group managers.

### Two defects fixed in the update form along the way

- **Stale validation schema.** The `useMemo` building the schema closed over
  `data.selectedUserBasePermission` but did not list it as a dependency. Opening an admin and
  then a non-admin whose phone number was also blank reused the schema built for the *previous*
  user, validating against the wrong permission level. Now a dependency.
- `input: ctx.value.confirmPassword` on an issue whose `path` is `['groupIds']` → `ctx.value.groupIds`.

## Scope

Deliberately client-side only. The API and shared schemas are unchanged, so a groupless
non-admin can still be created over the API or `cli/odc-cli`. Enforcing it at the boundary
was considered and consciously deferred — it changes `$CreateUserData`, `UsersService`, and
the e2e `createUser` helper's defaults, and is better as its own PR.

This is a data-governance fix, not a security fix: a groupless non-admin **fails closed**
(every read filter resolves to an empty set), so there is no privilege escalation in either
the old or new behaviour.

## Test plan

- [x] `pnpm lint` — 33/33 tasks
- [x] `pnpm test` — 657 passed, 1 skipped
- [x] `pnpm --filter @opendatacapture/testing test:e2e src/specs/admin-management.spec.ts` — 19/19
- [x] Unit: 6 cases in `validation.test.ts` covering admin, both non-admin levels, null, and
      disabled. Verified they fail when `requiresGroup` is stubbed out (4 red), then restored.
- [x] E2E: rejection of a groupless non-admin, and successful creation of a *disabled*
      groupless one. Verified the rejection test fails with the rule disabled.

> Note: `gateway-assignment … report it back to the clinician @smoke` fails on firefox in my
> environment, but it fails identically on unmodified `main` — pre-existing and unrelated.

Closes issue #1494 
Closes issue #1472 
model sonnet 5