### PR TITLE
fix(api): 500 Internal Server Error when a remote assignent gets created

### DIFF
--- a/apps/api/src/gateway/__tests__/gateway.service.spec.ts
+++ b/apps/api/src/gateway/__tests__/gateway.service.spec.ts
@@ -1,0 +1,120 @@
+import { LoggingService } from '@douglasneuroinformatics/libnest';
+import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
+import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
+import { HttpService } from '@nestjs/axios';
+import { BadGatewayException, ServiceUnavailableException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import type { Assignment } from '@opendatacapture/schemas/assignment';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InstrumentsService } from '@/instruments/instruments.service';
+import { SetupService } from '@/setup/setup.service';
+
+import { createGatewayHttpOptions } from '../gateway.module';
+import { GatewayService } from '../gateway.service';
+
+vi.mock('@douglasneuroinformatics/libcrypto', () => ({
+  HybridCrypto: {
+    serializePublicKey: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+  }
+}));
+
+describe('createGatewayHttpOptions', () => {
+  // Every assertion GatewayService makes about a status depends on the response reaching it at all,
+  // which only happens because axios is told to resolve rather than reject on a non-2xx.
+  it('should resolve every status, so the gateway’s own answer reaches the service', () => {
+    const configService = { get: vi.fn().mockReturnValue('development'), getOrThrow: vi.fn() };
+    const { validateStatus } = createGatewayHttpOptions(configService as never);
+    expect(validateStatus?.(401)).toBe(true);
+    expect(validateStatus?.(500)).toBe(true);
+  });
+});
+
+describe('GatewayService', () => {
+  let gatewayService: GatewayService;
+  let instrumentsService: MockedInstance<InstrumentsService>;
+  let setupService: MockedInstance<SetupService>;
+  let axiosRef: { delete: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> };
+
+  const assignment = { id: 'assignment-1', instrumentId: 'instrument-1' } as Assignment;
+  const publicKey = {} as CryptoKey;
+
+  beforeEach(async () => {
+    axiosRef = { delete: vi.fn(), get: vi.fn(), post: vi.fn() };
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        GatewayService,
+        MockFactory.createForService(InstrumentsService),
+        MockFactory.createForService(LoggingService),
+        MockFactory.createForService(SetupService),
+        { provide: HttpService, useValue: { axiosRef } }
+      ]
+    }).compile();
+    gatewayService = moduleRef.get(GatewayService);
+    instrumentsService = moduleRef.get(InstrumentsService);
+    setupService = moduleRef.get(SetupService);
+
+    instrumentsService.findBundleById.mockResolvedValue({ bundle: '', id: 'instrument-1', kind: 'FORM' });
+    setupService.getState.mockResolvedValue({ activeLanguages: ['en', 'fr'] });
+  });
+
+  describe('createRemoteAssignment', () => {
+    it('should return the parsed body when the gateway creates the assignment', async () => {
+      axiosRef.post.mockResolvedValue({ data: { success: true }, status: 201, statusText: 'Created' });
+      await expect(gatewayService.createRemoteAssignment(assignment, publicKey)).resolves.toStrictEqual({
+        success: true
+      });
+    });
+
+    // A rejected API key is the gateway answering, not the request failing: without this the raw
+    // AxiosError escapes as a bare 500 that names neither the gateway nor the status it returned.
+    it('should throw a bad gateway exception naming the status when the gateway rejects the api key', async () => {
+      axiosRef.post.mockResolvedValue({
+        data: { message: 'Unauthorized' },
+        status: 401,
+        statusText: 'Unauthorized'
+      });
+      await expect(gatewayService.createRemoteAssignment(assignment, publicKey)).rejects.toThrow(BadGatewayException);
+      await expect(gatewayService.createRemoteAssignment(assignment, publicKey)).rejects.toThrow(/401/);
+    });
+
+    it('should throw a service unavailable exception when the gateway cannot be reached', async () => {
+      axiosRef.post.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      await expect(gatewayService.createRemoteAssignment(assignment, publicKey)).rejects.toThrow(
+        ServiceUnavailableException
+      );
+    });
+  });
+
+  describe('deleteRemoteAssignment', () => {
+    it('should throw a bad gateway exception when the gateway refuses the delete', async () => {
+      axiosRef.delete.mockResolvedValue({ data: { message: 'Not Found' }, status: 404, statusText: 'Not Found' });
+      await expect(gatewayService.deleteRemoteAssignment('assignment-1')).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('fetchRemoteAssignments', () => {
+    it('should throw a bad gateway exception when the gateway refuses the request', async () => {
+      axiosRef.get.mockResolvedValue({ data: { message: 'Unauthorized' }, status: 401, statusText: 'Unauthorized' });
+      await expect(gatewayService.fetchRemoteAssignments()).rejects.toThrow(BadGatewayException);
+    });
+  });
+
+  describe('healthcheck', () => {
+    // The route exists to report an unhealthy gateway, so an unreachable one must be reportable
+    // rather than throwing — otherwise "down" is indistinguishable from "broken".
+    it('should report a failure result rather than throwing when the gateway cannot be reached', async () => {
+      axiosRef.get.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      await expect(gatewayService.healthcheck()).resolves.toMatchObject({ ok: false, status: 503 });
+    });
+
+    it('should report a failure result carrying the status the gateway returned', async () => {
+      axiosRef.get.mockResolvedValue({ data: {}, status: 502, statusText: 'Bad Gateway' });
+      await expect(gatewayService.healthcheck()).resolves.toStrictEqual({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway'
+      });
+    });
+  });
+});

--- a/apps/api/src/gateway/__tests__/gateway.service.spec.ts
+++ b/apps/api/src/gateway/__tests__/gateway.service.spec.ts
@@ -20,13 +20,58 @@ vi.mock('@douglasneuroinformatics/libcrypto', () => ({
 }));
 
 describe('createGatewayHttpOptions', () => {
+  const createConfigService = (values: { [key: string]: unknown }) =>
+    ({ get: (key: string) => values[key], getOrThrow: (key: string) => values[key] }) as never;
+
   // Every assertion GatewayService makes about a status depends on the response reaching it at all,
   // which only happens because axios is told to resolve rather than reject on a non-2xx.
   it('should resolve every status, so the gateway’s own answer reaches the service', () => {
-    const configService = { get: vi.fn().mockReturnValue('development'), getOrThrow: vi.fn() };
-    const { validateStatus } = createGatewayHttpOptions(configService as never);
+    const { validateStatus } = createGatewayHttpOptions(createConfigService({ NODE_ENV: 'development' }));
     expect(validateStatus?.(401)).toBe(true);
     expect(validateStatus?.(500)).toBe(true);
+  });
+
+  it('should address the dev server and carry the api key outside production', () => {
+    const options = createGatewayHttpOptions(
+      createConfigService({ GATEWAY_API_KEY: 'secret', GATEWAY_DEV_SERVER_PORT: 3500, NODE_ENV: 'development' })
+    );
+    expect(options.baseURL).toBe('http://localhost:3500');
+    expect(options.headers).toMatchObject({ Authorization: 'Bearer secret' });
+  });
+
+  // The production branch is the one the e2e suite can never reach — it runs the api with
+  // NODE_ENV=test — and it is the one a deployment gets wrong, leaving every request to the gateway
+  // addressed somewhere nothing answers.
+  describe('in production', () => {
+    it('should address the internal network url when the site address is localhost, which a container cannot reach', () => {
+      const options = createGatewayHttpOptions(
+        createConfigService({
+          GATEWAY_INTERNAL_NETWORK_URL: new URL('http://gateway:80'),
+          GATEWAY_SITE_ADDRESS: new URL('http://localhost:3500'),
+          NODE_ENV: 'production'
+        })
+      );
+      // docker-compose.yaml sets this to `http://gateway:80`, whose origin drops the default port.
+      expect(options.baseURL).toBe('http://gateway');
+    });
+
+    it('should address the site address when it is a real host', () => {
+      const options = createGatewayHttpOptions(
+        createConfigService({
+          GATEWAY_INTERNAL_NETWORK_URL: new URL('http://gateway:80'),
+          GATEWAY_SITE_ADDRESS: new URL('https://gateway.example.org'),
+          NODE_ENV: 'production'
+        })
+      );
+      expect(options.baseURL).toBe('https://gateway.example.org');
+    });
+
+    it('should address the site address when no internal network url is configured', () => {
+      const options = createGatewayHttpOptions(
+        createConfigService({ GATEWAY_SITE_ADDRESS: new URL('http://localhost:3500'), NODE_ENV: 'production' })
+      );
+      expect(options.baseURL).toBe('http://localhost:3500');
+    });
   });
 });
 

--- a/apps/api/src/gateway/gateway.module.ts
+++ b/apps/api/src/gateway/gateway.module.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@douglasneuroinformatics/libnest';
 import { HttpModule } from '@nestjs/axios';
+import type { HttpModuleOptions } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 
 import { AssignmentsModule } from '@/assignments/assignments.module';
@@ -12,6 +13,33 @@ import { GatewayController } from './gateway.controller';
 import { GatewayService } from './gateway.service';
 import { GatewaySynchronizer } from './gateway.synchronizer';
 
+function createGatewayHttpOptions(configService: ConfigService): HttpModuleOptions {
+  let baseURL: string;
+  if (configService.get('NODE_ENV') === 'production') {
+    const internalNetworkUrl = configService.get('GATEWAY_INTERNAL_NETWORK_URL');
+    const siteAddress = configService.getOrThrow('GATEWAY_SITE_ADDRESS');
+    if (siteAddress.hostname === 'localhost' && internalNetworkUrl) {
+      baseURL = internalNetworkUrl.origin;
+    } else {
+      baseURL = siteAddress.origin;
+    }
+  } else {
+    const gatewayPort = configService.get('GATEWAY_DEV_SERVER_PORT');
+    baseURL = `http://localhost:${gatewayPort}`;
+  }
+  return {
+    baseURL,
+    headers: {
+      Authorization: `Bearer ${configService.get('GATEWAY_API_KEY')}`
+    },
+    // Axios rejects on a non-2xx by default, which would surface every answer the gateway gives — a
+    // rejected API key, a validation failure — as an unrecognized error, and so as a 500 naming
+    // neither the gateway nor the status. Resolving every status is what lets GatewayService report
+    // what actually came back.
+    validateStatus: () => true
+  };
+}
+
 @Module({
   controllers: [GatewayController],
   exports: [GatewayService],
@@ -19,27 +47,7 @@ import { GatewaySynchronizer } from './gateway.synchronizer';
     forwardRef(() => AssignmentsModule),
     HttpModule.registerAsync({
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        let baseURL: string;
-        if (configService.get('NODE_ENV') === 'production') {
-          const internalNetworkUrl = configService.get('GATEWAY_INTERNAL_NETWORK_URL');
-          const siteAddress = configService.getOrThrow('GATEWAY_SITE_ADDRESS');
-          if (siteAddress.hostname === 'localhost' && internalNetworkUrl) {
-            baseURL = internalNetworkUrl.origin;
-          } else {
-            baseURL = siteAddress.origin;
-          }
-        } else {
-          const gatewayPort = configService.get('GATEWAY_DEV_SERVER_PORT');
-          baseURL = `http://localhost:${gatewayPort}`;
-        }
-        return {
-          baseURL,
-          headers: {
-            Authorization: `Bearer ${configService.get('GATEWAY_API_KEY')}`
-          }
-        };
-      }
+      useFactory: createGatewayHttpOptions
     }),
     InstrumentRecordsModule,
     InstrumentsModule,
@@ -49,3 +57,5 @@ import { GatewaySynchronizer } from './gateway.synchronizer';
   providers: [GatewayService, GatewaySynchronizer]
 })
 export class GatewayModule {}
+
+export { createGatewayHttpOptions };

--- a/apps/api/src/gateway/gateway.service.ts
+++ b/apps/api/src/gateway/gateway.service.ts
@@ -3,7 +3,7 @@ import type { webcrypto } from 'node:crypto';
 import { HybridCrypto } from '@douglasneuroinformatics/libcrypto';
 import { LoggingService } from '@douglasneuroinformatics/libnest';
 import { HttpService } from '@nestjs/axios';
-import { BadGatewayException, HttpStatus, Injectable } from '@nestjs/common';
+import { BadGatewayException, HttpStatus, Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { $MutateAssignmentResponseBody, $RemoteAssignment } from '@opendatacapture/schemas/assignment';
 import type {
   Assignment,
@@ -13,6 +13,7 @@ import type {
 } from '@opendatacapture/schemas/assignment';
 import { $GatewayHealthcheckSuccessResult } from '@opendatacapture/schemas/gateway';
 import type { GatewayHealthcheckFailureResult, GatewayHealthcheckResult } from '@opendatacapture/schemas/gateway';
+import type { AxiosResponse } from 'axios';
 
 import { InstrumentsService } from '@/instruments/instruments.service';
 import { SetupService } from '@/setup/setup.service';
@@ -34,41 +35,33 @@ export class GatewayService {
     // The gateway cannot read this instance's setup state, so the languages it may offer this
     // patient are sent with the assignment.
     const { activeLanguages } = await this.setupService.getState();
-    const response = await this.httpService.axiosRef.post(`/api/assignments`, {
-      ...assignment,
-      activeLanguages,
-      instrumentContainer: instrument,
-      publicKey: Array.from(await HybridCrypto.serializePublicKey(publicKey))
-    } satisfies CreateRemoteAssignmentInputData);
-    if (response.status !== HttpStatus.CREATED) {
-      throw new BadGatewayException(`Unexpected Status Code From Gateway: ${response.status}`, {
-        cause: response.statusText
-      });
-    }
+    const serializedPublicKey = Array.from(await HybridCrypto.serializePublicKey(publicKey));
+    const response = await this.request(HttpStatus.CREATED, 'create remote assignment', () =>
+      this.httpService.axiosRef.post(`/api/assignments`, {
+        ...assignment,
+        activeLanguages,
+        instrumentContainer: instrument,
+        publicKey: serializedPublicKey
+      } satisfies CreateRemoteAssignmentInputData)
+    );
     return $MutateAssignmentResponseBody.parseAsync(response.data);
   }
 
   async deleteRemoteAssignment(id: string): Promise<MutateAssignmentResponseBody> {
-    const response = await this.httpService.axiosRef.delete(`/api/assignments/${id}`);
-    if (response.status !== HttpStatus.OK) {
-      throw new BadGatewayException(`Unexpected Status Code From Gateway: ${response.status}`, {
-        cause: response.statusText
-      });
-    }
+    const response = await this.request(HttpStatus.OK, `delete remote assignment '${id}'`, () =>
+      this.httpService.axiosRef.delete(`/api/assignments/${id}`)
+    );
     return $MutateAssignmentResponseBody.parseAsync(response.data);
   }
 
   async fetchRemoteAssignments({ subjectId }: { subjectId?: string } = {}): Promise<RemoteAssignment[]> {
-    const response = await this.httpService.axiosRef.get(`/api/assignments`, {
-      params: {
-        subjectId
-      }
-    });
-    if (response.status !== HttpStatus.OK) {
-      throw new BadGatewayException(`Unexpected Status Code From Gateway: ${response.status}`, {
-        cause: response.statusText
-      });
-    }
+    const response = await this.request(HttpStatus.OK, 'fetch remote assignments', () =>
+      this.httpService.axiosRef.get(`/api/assignments`, {
+        params: {
+          subjectId
+        }
+      })
+    );
     const result = await $RemoteAssignment.array().safeParseAsync(response.data);
     if (!result.success) {
       this.loggingService.error({
@@ -82,7 +75,19 @@ export class GatewayService {
   }
 
   async healthcheck(): Promise<GatewayHealthcheckResult> {
-    const response = await this.httpService.axiosRef.get('/api/healthcheck');
+    // This route exists to report an unhealthy gateway, so an unreachable one is an answer rather
+    // than an error: throwing here would leave the caller unable to distinguish "down" from "broken".
+    let response: AxiosResponse;
+    try {
+      response = await this.httpService.axiosRef.get('/api/healthcheck');
+    } catch (err) {
+      this.loggingService.error({ error: err, message: 'ERROR: Failed to reach gateway for healthcheck' });
+      return {
+        ok: false,
+        status: HttpStatus.SERVICE_UNAVAILABLE,
+        statusText: 'Failed to reach gateway'
+      };
+    }
     if (response.status !== HttpStatus.OK) {
       return {
         ok: false,
@@ -105,5 +110,36 @@ export class GatewayService {
       };
     }
     return result.data;
+  }
+
+  /**
+   * Perform a gateway request, distinguishing the two ways it can fail. A rejection means the gateway
+   * was never reached; any other status than the expected one means it answered and refused. Both
+   * carry what the gateway said into the thrown exception, so the cause is named rather than
+   * collapsing into an anonymous 500.
+   */
+  private async request(
+    expectedStatus: HttpStatus,
+    operation: string,
+    send: () => Promise<AxiosResponse>
+  ): Promise<AxiosResponse> {
+    let response: AxiosResponse;
+    try {
+      response = await send();
+    } catch (err) {
+      this.loggingService.error({ error: err, message: `ERROR: Failed to reach gateway to ${operation}` });
+      throw new ServiceUnavailableException(`Failed to reach gateway to ${operation}`, { cause: err });
+    }
+    if (response.status !== expectedStatus) {
+      this.loggingService.error({
+        data: response.data as unknown,
+        message: `ERROR: Gateway refused to ${operation}: ${response.status} ${response.statusText}`
+      });
+      throw new BadGatewayException(
+        `Gateway refused to ${operation}: responded ${response.status} ${response.statusText}, expected ${expectedStatus}`,
+        { cause: response.data }
+      );
+    }
+    return response;
   }
 }

--- a/apps/web/src/__tests__/transient-error.test.ts
+++ b/apps/web/src/__tests__/transient-error.test.ts
@@ -1,0 +1,47 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import type { AxiosResponse } from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: () => ({ accessToken: null }) })
+}));
+
+vi.mock('@/config', () => ({
+  config: { dev: { networkLatency: 0 }, setup: { apiBaseUrl: 'http://localhost' } }
+}));
+
+const { isTransientError } = await import('@/services/axios');
+
+function errorWithResponse(status: number, data: unknown): AxiosError {
+  const response = { config: {}, data, headers: {}, status, statusText: '' } as AxiosResponse;
+  return new AxiosError('failed', 'ERR_BAD_RESPONSE', { headers: new AxiosHeaders() }, null, response);
+}
+
+describe('isTransientError', () => {
+  it('should treat a request that never got a response as transient, so the retry budget applies', () => {
+    expect(isTransientError(new AxiosError('Network Error', 'ERR_NETWORK'))).toBe(true);
+  });
+
+  // A proxy in front of the API answers with HTML or nothing, which is the blip retrying exists for.
+  it('should treat a gateway status without an api error body as transient', () => {
+    expect(isTransientError(errorWithResponse(502, '<html>Bad Gateway</html>'))).toBe(true);
+    expect(isTransientError(errorWithResponse(503, undefined))).toBe(true);
+  });
+
+  // The API returning 502 because the remote-assignment gateway refused it is a deliberate answer:
+  // showing "Connection Problem, this is usually temporary" would send the user to retry forever.
+  it('should not treat a gateway status carrying an api error body as transient', () => {
+    expect(isTransientError(errorWithResponse(502, { message: 'Gateway refused', statusCode: 502 }))).toBe(false);
+    expect(isTransientError(errorWithResponse(503, { message: 'Failed to reach gateway', statusCode: 503 }))).toBe(
+      false
+    );
+  });
+
+  it('should not treat a client error as transient', () => {
+    expect(isTransientError(errorWithResponse(404, { message: 'Not Found', statusCode: 404 }))).toBe(false);
+  });
+
+  it('should not treat a non-axios error as transient', () => {
+    expect(isTransientError(new Error('boom'))).toBe(false);
+  });
+});

--- a/apps/web/src/services/axios.ts
+++ b/apps/web/src/services/axios.ts
@@ -41,6 +41,20 @@ const IDEMPOTENT_METHODS = new Set(['get', 'head', 'options']);
 axios.defaults.baseURL = config.setup.apiBaseUrl;
 
 /**
+ * Every failure our API answers deliberately carries libnest's error envelope. The network equipment
+ * this retry logic exists for — proxies, load balancers — answers with HTML, or with nothing. That is
+ * what separates a blip in front of the API from the API telling us something is wrong behind it,
+ * which no amount of retrying resolves.
+ */
+function isApiErrorBody(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const body = data as { message?: unknown; statusCode?: unknown };
+  return typeof body.message === 'string' && typeof body.statusCode === 'number';
+}
+
+/**
  * A transient error is one that is likely to succeed on a later attempt: a dropped/refused/reset
  * connection, a timeout (no response received), or an upstream gateway error. A "real" application error
  * (4xx, or a 5xx the server deliberately returned with a body) is not transient.
@@ -53,7 +67,7 @@ function isTransientError(error: unknown): boolean {
     // No response at all: network failure (ERR_NETWORK), connection reset, or timeout (ECONNABORTED).
     return true;
   }
-  return RETRYABLE_STATUS_CODES.has(error.response.status);
+  return RETRYABLE_STATUS_CODES.has(error.response.status) && !isApiErrorBody(error.response.data);
 }
 
 /** Only idempotent methods are safe to retry automatically — retrying a write risks duplicate submissions. */

--- a/testing/src/specs/error-handling.spec.ts
+++ b/testing/src/specs/error-handling.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '../support/fixtures';
+
+// `apps/web/src/services/axios.ts` retries idempotent requests on 502/503/504, for the proxies in
+// front of the API that answer with HTML or with nothing. A 5xx the API answers itself carries
+// libnest's error envelope, and retrying that only spends the whole budget arriving at the same
+// answer. No route in the app produces one on a GET — the gateway failures that return 502 arrive
+// on writes, which are never retried — so the response is faked at the browser instead.
+test.describe('server error handling', () => {
+  test('should surface an api error immediately rather than retrying it as a connection blip', async ({
+    authenticateAs,
+    page
+  }) => {
+    let attempts = 0;
+    await page.route('**/v1/subjects*', async (route) => {
+      attempts += 1;
+      await route.fulfill({
+        body: JSON.stringify({ message: 'Gateway refused to fetch remote assignments', statusCode: 503 }),
+        contentType: 'application/json',
+        status: 503
+      });
+    });
+
+    await authenticateAs('GROUP_MANAGER');
+    await page.goto('/datahub');
+
+    // The terminal error page, naming the status — not the self-healing "Connection Problem" screen,
+    // which invites the user to retry something that will never succeed.
+    await expect(page.getByRole('heading', { name: '503 - Service Unavailable' })).toBeVisible();
+    await expect(page.getByText('Connection Problem')).toBeHidden();
+    expect(attempts).toBe(1);
+  });
+});

--- a/testing/src/specs/gateway-assignment.spec.ts
+++ b/testing/src/specs/gateway-assignment.spec.ts
@@ -114,6 +114,45 @@ test.describe('gateway remote assignment', () => {
   });
 });
 
+// An admin holds no groups, so the create dialog sends no `groupId` and the assignment is created
+// unscoped. Every other test here acts as a GROUP_MANAGER, whose assignment always carries one, so
+// this is the only cover for the unscoped path reaching the gateway and back.
+test.describe('gateway remote assignment without a group', () => {
+  test.use({ actingRole: 'ADMIN' });
+  test.describe.configure({ timeout: 180_000 });
+
+  test('should let an admin with no groups create a remote assignment', async ({ getPageModel, page, uniqueId }) => {
+    const startSessionPage = await getPageModel('/session/start-session');
+    await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+    await startSessionPage.selectIdentificationMethod('PERSONAL_INFO');
+    await startSessionPage.fillSessionForm(`Ungrouped${uniqueId}`, `Patient${uniqueId}`, 'Female');
+    await startSessionPage.submitForm();
+    await expect(startSessionPage.successMessage).toBeVisible();
+
+    await page.getByTestId('nav-button-/session/remote-assignment').click();
+    await page.waitForURL('**/session/remote-assignment');
+
+    const card = page.locator('[data-testid^="instrument-card-"]').filter({ hasText: INSTRUMENT_TITLE }).first();
+    await expect(card).toBeVisible();
+    await card.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText('Create Remote Assignment');
+
+    // Asserting the status directly is what distinguishes "the gateway accepted this" from a 500 the
+    // UI would surface identically to any other failure.
+    const created = page.waitForResponse(
+      (response) => response.url().includes('/v1/assignments') && response.request().method() === 'POST'
+    );
+    await dialog.getByRole('button', { name: 'Submit' }).click();
+    expect((await created).status()).toBe(201);
+
+    const linkInput = page.locator('input[readonly]');
+    await expect(linkInput).toBeVisible();
+    expect(await linkInput.inputValue()).toMatch(/^https?:\/\/.+\/assignments\/.+/);
+  });
+});
+
 test.describe('gateway assignment errors', () => {
   test('should respond with 404 when the assignment id in the link does not exist', async ({
     context,

--- a/testing/src/specs/gateway-assignment.spec.ts
+++ b/testing/src/specs/gateway-assignment.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 
 import { RenderInstrumentPage } from '../pages/_app/instruments/render/$id.page';
 import { ApiClient } from '../support/api-client';
+import { gatewayApiKey } from '../support/env';
 import { expect, test } from '../support/fixtures';
 
 import type { GetPageModel } from '../support/fixtures';
@@ -193,6 +194,68 @@ test.describe('gateway assignment errors', () => {
     expect(await unknown!.text()).toContain('Overview');
 
     await gatewayPage.close();
+  });
+
+  // Every other test here drives a gateway that accepts, so the branch taken when it refuses had no
+  // cover at all — and that branch is the whole feature: without it the clinician gets a 500 naming
+  // neither the gateway nor what it said. Cancelling deletes the remote assignment, so cancelling
+  // the same one twice is the one way to make the real gateway refuse a real request without
+  // sabotaging the server every other worker shares.
+  test('should report what the gateway answered when it no longer holds the assignment', async ({
+    apiRequestContext,
+    getPageModel,
+    page,
+    roleAccount,
+    uniqueId
+  }) => {
+    const assignmentUrl = await createRemoteAssignmentLink(getPageModel, page, uniqueId);
+    const assignmentId = assignmentUrl.split('/').pop()!;
+    const { accessToken } = await roleAccount('GROUP_MANAGER');
+    const cancel = () =>
+      apiRequestContext.patch(`/api/v1/assignments/${assignmentId}`, {
+        data: { status: 'CANCELED' },
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+
+    expect((await cancel()).status()).toBe(200);
+
+    const response = await cancel();
+    expect(response.status()).toBe(502);
+    const body = (await response.json()) as { message: string };
+    expect(body.message).toMatch(/gateway/i);
+    expect(body.message).toContain('404');
+  });
+
+  // The clinician-facing half of the same fix, and the only case where a real gateway refusal
+  // reaches a real user. It must read as the error it is: 502 is a status the axios layer otherwise
+  // treats as a network blip, and the "Connection Problem" screen it would show offers a retry that
+  // can never succeed.
+  test('should show the clinician the gateway’s refusal rather than a connection problem', async ({
+    apiRequestContext,
+    getPageModel,
+    page,
+    uniqueId
+  }) => {
+    const assignmentUrl = await createRemoteAssignmentLink(getPageModel, page, uniqueId);
+    const assignmentId = assignmentUrl.split('/').pop()!;
+
+    // Drop the record on the gateway directly, which leaves this instance's assignment OUTSTANDING —
+    // the only status whose Cancel button is enabled, and so the only way a click reaches this path.
+    const forgotten = await apiRequestContext.delete(
+      `${new URL(assignmentUrl).origin}/api/assignments/${assignmentId}`,
+      { headers: { Authorization: `Bearer ${gatewayApiKey}` } }
+    );
+    expect(forgotten.status()).toBe(200);
+
+    await page.locator('[data-testid^="nav-button-/datahub/"]').click();
+    await page.waitForURL('**/datahub/**/table');
+    await page.getByRole('link', { name: 'Assignments' }).click();
+    await page.waitForURL('**/datahub/**/assignments');
+    await page.getByTestId('assignment-row').first().click();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page.getByRole('heading', { name: '502 - Bad Gateway' })).toBeVisible();
+    await expect(page.getByText('Connection Problem')).toBeHidden();
   });
 
   // `POST /v1/assignments/:id/email` mails a live assignment credential to a caller-supplied

--- a/testing/src/support/env.ts
+++ b/testing/src/support/env.ts
@@ -20,6 +20,11 @@ function requiredPort(name: string): number {
 // value differs from the `.env.template` one CI generates, so a literal here only passes locally.
 export const contactEmail = required('CONTACT_EMAIL');
 
+// The credential the API itself presents to the gateway. A test needs it to put the gateway into a
+// state the API cannot reach on its own — namely, having forgotten an assignment this instance
+// still holds.
+export const gatewayApiKey = required('GATEWAY_API_KEY');
+
 export const apiPort = requiredPort('API_DEV_SERVER_PORT');
 export const gatewayPort = requiredPort('GATEWAY_DEV_SERVER_PORT');
 export const webPort = requiredPort('WEB_DEV_SERVER_PORT');


### PR DESCRIPTION
## The bug

Submitting the Create Remote Assignment dialog returned `500 Internal Server Error` with no further detail, whatever the underlying cause.

## Root cause

`GatewayService` was written as though axios returned non-2xx responses, but **axios rejects on them by default**. So every `if (response.status !== HttpStatus.CREATED)` guard was dead code, the raw `AxiosError` escaped as a non-`HttpException`, and libnest's global exception filter collapsed it into an anonymous 500.

The practical effect: a rejected `GATEWAY_API_KEY`, a gateway-side validation failure, and a gateway that was simply down were indistinguishable from each other — and from a genuine bug in the API. In my case the gateway was answering **401** and nothing said so.

## What changed

**`apps/api/src/gateway/gateway.module.ts`** — the axios instance now resolves every status, so the gateway's answer reaches the service. The config moved into an exported `createGatewayHttpOptions` so that line is covered by a test; without it every status guard silently reverts to dead code and the unit tests still pass.

**`apps/api/src/gateway/gateway.service.ts`** — a private `request` helper separates the two ways a gateway call can fail:

| Failure | Exception | Carries |
| --- | --- | --- |
| Never reached (`ECONNREFUSED`, timeout) | `ServiceUnavailableException` | the underlying cause |
| Answered and refused | `BadGatewayException` | status and statusText, in the message |

Both log before throwing, the gateway's response body included. That body stays in the logs rather than reaching the client: libnest's exception filter serializes `getResponse()`, so an exception's `cause` never leaves the server. `healthcheck` gets the inverse fix — it *threw* on an unreachable gateway, so the one route whose job is reporting an unhealthy gateway couldn't report the case that matters most; it now returns a 503 failure result.

**`apps/web/src/services/axios.ts`** — surfacing those statuses exposed a second defect. `isTransientError` treats every 502/503/504 as a network blip, which drives both the "Connection Problem" recovery screen and a calm "check your connection" toast. A gateway refusal is neither. It arrives on a write, so it was never auto-retried — only idempotent methods are — but it was still presented as a passing network problem, advising a retry that can never work. Its docblock already promised the right rule:

> A "real" application error (4xx, or **a 5xx the server deliberately returned with a body**) is not transient.

…and never implemented it. A retryable status is now transient only when it does *not* carry libnest's `{ message, statusCode }` envelope. The proxies this retry budget exists for answer with HTML or nothing, so genuine blips still retry.

## Testing

Every gateway test before this PR drove a gateway that *accepts*, so the branch the fix replaces — a non-2xx answer, or no answer at all — had no cover at any tier. The production `baseURL` selection had none either: Playwright starts the API with `NODE_ENV=test`, so only the dev branch ever ran.

- `apps/api/src/gateway/__tests__/gateway.service.spec.ts` — new. Covers the refusal path, the unreachable path, pins `validateStatus`, and covers the three production `baseURL` cases the e2e suite structurally cannot reach.
- `apps/web/src/__tests__/transient-error.test.ts` — new. Confirmed non-vacuous: the two gateway-envelope assertions fail without the body check.
- `testing/src/specs/gateway-assignment.spec.ts` — adds an **ADMIN** case (an admin holds no groups, so the dialog sends no `groupId`; that's the reported flow, and every other case in the file acts as a `GROUP_MANAGER`), plus the two failure cases. Cancelling an assignment twice makes the real gateway refuse a real request, and the API answers **502** naming it and its 404. Then, with the gateway made to forget a record this instance still holds `OUTSTANDING` — the only status whose Cancel button is enabled — cancelling from the UI shows the clinician **`502 - Bad Gateway`** rather than the "Connection Problem" screen. That last case fails without *either* half of the fix.
- `testing/src/specs/error-handling.spec.ts` — new. A 503 carrying libnest's error envelope is surfaced on the first attempt instead of being retried.

**Run:** `pnpm exec vitest run` → 82 files, 671 passed / 1 skipped. `tsc --noEmit` clean in `apps/api`, `apps/web`, `testing`. `eslint` clean on all changed files. Playwright on `gateway-assignment.spec.ts` + `error-handling.spec.ts` → 14 passed.

**Still to run:** the full `pnpm test:e2e`. Only those two spec files were run, not the whole suite.

## Note for whoever hits this next

The trigger on my machine was a dev stack from a *different checkout* squatting on port 3500 with a mismatched `GATEWAY_API_KEY`. That's environmental, not a repo bug — but the API gave no way to tell, which is what this PR fixes. If remote assignments fail locally, check that the gateway on `GATEWAY_DEV_SERVER_PORT` is actually yours:

```sh
curl -s localhost:3500/api/healthcheck   # compare `release` against your API's /v1/setup
```

## Out of scope

While diagnosing I found a latent issue, not fixed here: `@default("[\"en\",\"fr\"]")` on `RemoteAssignmentModel.activeLanguages` generates the SQLite DDL `DEFAULT ["en","fr"]`. SQLite reads `[...]` as an identifier quote, so a row inserted without that column stores the string `"en","fr"` rather than the array. Current gateway code always sends the column explicitly, so nothing reaches it today — but an older client, or a `db:push` backfill of pre-existing rows, would. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

