### PR TITLE
feat(settings): let an instance turn off remote assignments

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -439,6 +439,7 @@ model SetupState {
   defaultAssignmentDurationDays Int?
   isDemo                        Boolean
   isExperimentalFeaturesEnabled Boolean?
+  isRemoteAssignmentsEnabled    Boolean?
   isSetup                       Boolean
   mailConfig                    MailConfig?
   newUserEmailTemplate          MailTemplate?

--- a/apps/api/src/setup/__tests__/setup.service.spec.ts
+++ b/apps/api/src/setup/__tests__/setup.service.spec.ts
@@ -43,6 +43,15 @@ describe('SetupService', () => {
         where: { id: 'setup-1' }
       });
     });
+
+    it('should persist isRemoteAssignmentsEnabled', async () => {
+      setupStateModel.findFirst.mockResolvedValue({ id: 'setup-1', isSetup: true });
+      await setupService.updateState({ isRemoteAssignmentsEnabled: false });
+      expect(setupStateModel.update.mock.lastCall?.[0]).toMatchObject({
+        data: { isRemoteAssignmentsEnabled: false },
+        where: { id: 'setup-1' }
+      });
+    });
   });
 
   describe('getState', () => {
@@ -54,6 +63,16 @@ describe('SetupService', () => {
     it('should return null when unset', async () => {
       setupStateModel.findFirst.mockResolvedValue({ isDemo: false, isSetup: true });
       await expect(setupService.getState()).resolves.toMatchObject({ defaultAssignmentDurationDays: null });
+    });
+
+    it('should report remote assignments as enabled when the setting was never saved', async () => {
+      setupStateModel.findFirst.mockResolvedValue({ isDemo: false, isSetup: true });
+      await expect(setupService.getState()).resolves.toMatchObject({ isRemoteAssignmentsEnabled: true });
+    });
+
+    it('should report remote assignments as disabled once an admin turns them off', async () => {
+      setupStateModel.findFirst.mockResolvedValue({ isDemo: false, isRemoteAssignmentsEnabled: false, isSetup: true });
+      await expect(setupService.getState()).resolves.toMatchObject({ isRemoteAssignmentsEnabled: false });
     });
   });
 

--- a/apps/api/src/setup/dto/update-setup-state.dto.ts
+++ b/apps/api/src/setup/dto/update-setup-state.dto.ts
@@ -17,4 +17,7 @@ export class UpdateSetupStateDto implements UpdateSetupStateData {
 
   @ApiProperty({ required: false })
   isExperimentalFeaturesEnabled?: boolean;
+
+  @ApiProperty({ required: false })
+  isRemoteAssignmentsEnabled?: boolean;
 }

--- a/apps/api/src/setup/setup.service.ts
+++ b/apps/api/src/setup/setup.service.ts
@@ -67,6 +67,9 @@ export class SetupService {
       // Non-secret flag so the client can hide email UI when mail is off. The SMTP
       // configuration itself is never exposed here (this is a public route).
       isMailEnabled: isMailEnabled(savedOptions?.mailConfig),
+      // Opt-out, not opt-in: an instance that never touched this setting — including every instance
+      // set up before it existed — keeps offering remote assignments.
+      isRemoteAssignmentsEnabled: savedOptions?.isRemoteAssignmentsEnabled ?? true,
       isSetup: Boolean(savedOptions?.isSetup),
       release: __RELEASE__,
       uptime: Math.round(process.uptime())

--- a/apps/web/src/hooks/__tests__/useIsRemoteAssignmentsEnabled.test.ts
+++ b/apps/web/src/hooks/__tests__/useIsRemoteAssignmentsEnabled.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useIsRemoteAssignmentsEnabled } from '../useIsRemoteAssignmentsEnabled';
+
+const setupState = { data: { isGatewayEnabled: true, isRemoteAssignmentsEnabled: true } };
+
+vi.mock('@/hooks/useSetupStateQuery', () => ({
+  useSetupStateQuery: () => setupState
+}));
+
+describe('useIsRemoteAssignmentsEnabled', () => {
+  it.each([
+    { expected: true, isGatewayEnabled: true, isRemoteAssignmentsEnabled: true },
+    { expected: false, isGatewayEnabled: true, isRemoteAssignmentsEnabled: false },
+    { expected: false, isGatewayEnabled: false, isRemoteAssignmentsEnabled: true },
+    { expected: false, isGatewayEnabled: false, isRemoteAssignmentsEnabled: false }
+  ])(
+    'should be $expected when the gateway is $isGatewayEnabled and the feature is $isRemoteAssignmentsEnabled',
+    ({ expected, isGatewayEnabled, isRemoteAssignmentsEnabled }) => {
+      setupState.data = { isGatewayEnabled, isRemoteAssignmentsEnabled };
+      expect(renderHook(() => useIsRemoteAssignmentsEnabled()).result.current).toBe(expected);
+    }
+  );
+});

--- a/apps/web/src/hooks/__tests__/useNavItems.test.ts
+++ b/apps/web/src/hooks/__tests__/useNavItems.test.ts
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { currentSession, currentUser } from '@/testing/stubs';
+
+import { useNavItems } from '../useNavItems';
+
+import '@/services/i18n';
+
+// Both mock factories only read these when a hook renders, so they may be declared here rather than
+// hoisted — and `currentUser` is an import, which `vi.hoisted` cannot reach.
+const store = { currentGroup: null, currentSession, currentUser };
+const setupState = {
+  data: { isExperimentalFeaturesEnabled: false, isGatewayEnabled: true, isRemoteAssignmentsEnabled: true }
+};
+
+vi.mock('@/store', () => ({
+  useAppStore: vi.fn((selector) => selector(store))
+}));
+
+vi.mock('@/hooks/useSetupStateQuery', () => ({
+  useSetupStateQuery: () => setupState
+}));
+
+const navUrls = () =>
+  renderHook(() => useNavItems())
+    .result.current.flat()
+    .map((item) => item.url);
+
+describe('useNavItems', () => {
+  beforeEach(() => {
+    setupState.data = {
+      isExperimentalFeaturesEnabled: false,
+      isGatewayEnabled: true,
+      isRemoteAssignmentsEnabled: true
+    };
+  });
+
+  it('should offer remote assignment when the gateway and the feature are both on', () => {
+    expect(navUrls()).toContain('/session/remote-assignment');
+  });
+
+  // An instance that only collects data in person turns the feature off, and nothing about remote
+  // assignment should remain reachable from the sidebar.
+  it('should hide remote assignment once an admin disables the feature', () => {
+    setupState.data.isRemoteAssignmentsEnabled = false;
+    expect(navUrls()).not.toContain('/session/remote-assignment');
+  });
+
+  it('should hide remote assignment when the gateway is off, even with the feature enabled', () => {
+    setupState.data.isGatewayEnabled = false;
+    expect(navUrls()).not.toContain('/session/remote-assignment');
+  });
+});

--- a/apps/web/src/hooks/useIsRemoteAssignmentsEnabled.ts
+++ b/apps/web/src/hooks/useIsRemoteAssignmentsEnabled.ts
@@ -1,0 +1,11 @@
+import { useSetupStateQuery } from './useSetupStateQuery';
+
+/**
+ * Whether this instance offers remote assignments at all. Two independent conditions: assignments are
+ * served through the gateway, so it must be deployed, and an admin may opt out of the feature on an
+ * instance that only collects data in person.
+ */
+export function useIsRemoteAssignmentsEnabled(): boolean {
+  const setupStateQuery = useSetupStateQuery();
+  return setupStateQuery.data.isGatewayEnabled && setupStateQuery.data.isRemoteAssignmentsEnabled;
+}

--- a/apps/web/src/hooks/useNavItems.ts
+++ b/apps/web/src/hooks/useNavItems.ts
@@ -21,6 +21,7 @@ import {
 
 import { useAppStore } from '@/store';
 
+import { useIsRemoteAssignmentsEnabled } from './useIsRemoteAssignmentsEnabled';
 import { useSetupStateQuery } from './useSetupStateQuery';
 
 export type NavItem = {
@@ -46,6 +47,7 @@ export function useNavItems() {
   const [navItems, setNavItems] = useState<NavItem[][]>([[], []]);
   const { resolvedLanguage, t } = useTranslation();
   const setupStateQuery = useSetupStateQuery();
+  const isRemoteAssignmentsEnabled = useIsRemoteAssignmentsEnabled();
 
   useEffect(() => {
     const ability = currentUser?.ability;
@@ -175,8 +177,7 @@ export function useNavItems() {
         url: '/instruments/accessible-instruments'
       });
     }
-    // Remote assignment requires the gateway to be enabled, since assignments are served through it
-    if (ability?.can('create', 'Assignment') && setupStateQuery.data.isGatewayEnabled) {
+    if (ability?.can('create', 'Assignment') && isRemoteAssignmentsEnabled) {
       sessionItems.push({
         disabled: currentSession === null,
         icon: SendIcon,
@@ -196,9 +197,9 @@ export function useNavItems() {
   }, [
     currentSession,
     currentUser,
+    isRemoteAssignmentsEnabled,
     resolvedLanguage,
     setupStateQuery.data.isExperimentalFeaturesEnabled,
-    setupStateQuery.data.isGatewayEnabled,
     setupStateQuery.data.isMailEnabled
   ]);
 

--- a/apps/web/src/routes/_app/admin/settings.tsx
+++ b/apps/web/src/routes/_app/admin/settings.tsx
@@ -49,6 +49,37 @@ const Toggle = ({
   </button>
 );
 
+const HelpHoverCard = ({ children }: { children: React.ReactNode }) => (
+  <HoverCard>
+    <HoverCard.Trigger asChild>
+      <button className="text-muted-foreground hover:text-foreground transition-colors" type="button">
+        <CircleHelpIcon className="h-4 w-4" />
+      </button>
+    </HoverCard.Trigger>
+    <HoverCard.Content className="w-72 text-sm">{children}</HoverCard.Content>
+  </HoverCard>
+);
+
+const FeatureToggle = ({
+  checked,
+  description,
+  label,
+  onCheckedChange
+}: {
+  checked: boolean;
+  description: string;
+  label: string;
+  onCheckedChange: (val: boolean) => void;
+}) => (
+  <div className="flex items-center justify-between gap-4">
+    <div className="flex items-center gap-2">
+      <p className="text-sm font-medium">{label}</p>
+      <HelpHoverCard>{description}</HelpHoverCard>
+    </div>
+    <Toggle checked={checked} label={label} onCheckedChange={onCheckedChange} />
+  </div>
+);
+
 const SettingSection = ({ children, title }: { children: React.ReactNode; title: string }) => (
   <section className="flex flex-col gap-4 p-6">
     <h3 className="text-base font-semibold">{title}</h3>
@@ -87,8 +118,8 @@ const RouteComponent = () => {
     [mutate]
   );
 
-  const uploaderLabel = t({ en: 'Enable Uploader', fr: 'Activer le téléversement' });
   const uploaderEnabled = setupStateQuery.data.isExperimentalFeaturesEnabled ?? false;
+  const remoteAssignmentsEnabled = setupStateQuery.data.isRemoteAssignmentsEnabled;
 
   const activeLanguages = setupStateQuery.data.activeLanguages;
 
@@ -163,29 +194,24 @@ const RouteComponent = () => {
         <Card>
           <Card.Content className="p-0">
             <SettingSection title={t({ en: 'Features', fr: 'Fonctionnalités' })}>
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-center gap-2">
-                  <p className="text-sm font-medium">{uploaderLabel}</p>
-                  <HoverCard>
-                    <HoverCard.Trigger asChild>
-                      <button className="text-muted-foreground hover:text-foreground transition-colors" type="button">
-                        <CircleHelpIcon className="h-4 w-4" />
-                      </button>
-                    </HoverCard.Trigger>
-                    <HoverCard.Content className="w-72 text-sm">
-                      {t({
-                        en: 'When enabled, an upload menu item appears in the sidebar that allows users to upload instrument records directly from data files, bypassing the normal session workflow.',
-                        fr: "Lorsqu'elle est activée, un élément de menu Téléversement apparaît dans le menu latéral et permet aux utilisateurs de téléverser des enregistrements d'instruments directement à partir de fichiers de données."
-                      })}
-                    </HoverCard.Content>
-                  </HoverCard>
-                </div>
-                <Toggle
-                  checked={uploaderEnabled}
-                  label={uploaderLabel}
-                  onCheckedChange={(checked) => autosave({ isExperimentalFeaturesEnabled: checked })}
-                />
-              </div>
+              <FeatureToggle
+                checked={uploaderEnabled}
+                description={t({
+                  en: 'When enabled, an upload menu item appears in the sidebar that allows users to upload instrument records directly from data files, bypassing the normal session workflow.',
+                  fr: "Lorsqu'elle est activée, un élément de menu Téléversement apparaît dans le menu latéral et permet aux utilisateurs de téléverser des enregistrements d'instruments directement à partir de fichiers de données."
+                })}
+                label={t({ en: 'Enable Uploader', fr: 'Activer le téléversement' })}
+                onCheckedChange={(checked) => autosave({ isExperimentalFeaturesEnabled: checked })}
+              />
+              <FeatureToggle
+                checked={remoteAssignmentsEnabled}
+                description={t({
+                  en: 'When enabled, subjects can be assigned instruments to complete at home through the gateway: the remote assignment menu item appears during a session, and each subject has an assignments tab. Turn this off on an instance that only collects data in person.',
+                  fr: "Lorsqu'elle est activée, des instruments peuvent être assignés aux clients pour être complétés à la maison par le biais de la passerelle : l'élément de menu Tâche à distance apparaît pendant une session, et chaque client possède un onglet Tâches. Désactivez cette option sur une instance qui ne recueille des données qu'en personne."
+                })}
+                label={t({ en: 'Enable Remote Assignments', fr: 'Activer les tâches à distance' })}
+                onCheckedChange={(checked) => autosave({ isRemoteAssignmentsEnabled: checked })}
+              />
             </SettingSection>
             <Separator />
             <SettingSection title={t({ en: 'Settings', fr: 'Paramètres' })}>
@@ -194,19 +220,12 @@ const RouteComponent = () => {
                   <p className="text-sm font-medium">
                     {t({ en: 'Default Assignment Validity (Days)', fr: 'Validité par défaut des tâches (jours)' })}
                   </p>
-                  <HoverCard>
-                    <HoverCard.Trigger asChild>
-                      <button className="text-muted-foreground hover:text-foreground transition-colors" type="button">
-                        <CircleHelpIcon className="h-4 w-4" />
-                      </button>
-                    </HoverCard.Trigger>
-                    <HoverCard.Content className="w-72 text-sm">
-                      {t({
-                        en: 'The number of days a new remote assignment stays valid by default. This only sets the initial expiry date when creating an assignment, which can still be changed for each one.',
-                        fr: "Le nombre de jours pendant lesquels une nouvelle tâche à distance reste valide par défaut. Ceci ne définit que la date d'expiration initiale lors de la création d'une tâche, qui peut toujours être modifiée pour chacune."
-                      })}
-                    </HoverCard.Content>
-                  </HoverCard>
+                  <HelpHoverCard>
+                    {t({
+                      en: 'The number of days a new remote assignment stays valid by default. This only sets the initial expiry date when creating an assignment, which can still be changed for each one.',
+                      fr: "Le nombre de jours pendant lesquels une nouvelle tâche à distance reste valide par défaut. Ceci ne définit que la date d'expiration initiale lors de la création d'une tâche, qui peut toujours être modifiée pour chacune."
+                    })}
+                  </HelpHoverCard>
                 </div>
                 <Input
                   className="w-[90px] shrink-0"

--- a/apps/web/src/routes/_app/datahub/$subjectId/route.tsx
+++ b/apps/web/src/routes/_app/datahub/$subjectId/route.tsx
@@ -8,7 +8,7 @@ import { createFileRoute, Link, Outlet, useLocation } from '@tanstack/react-rout
 
 import { LoadingFallback } from '@/components/LoadingFallback';
 import { PageHeader } from '@/components/PageHeader';
-import { config } from '@/config';
+import { useIsRemoteAssignmentsEnabled } from '@/hooks/useIsRemoteAssignmentsEnabled';
 import { useAppStore } from '@/store';
 
 const TabLink = ({ label, pathname, testId }: { label: string; pathname: string; testId?: string }) => {
@@ -36,6 +36,7 @@ const RouteComponent = () => {
   const subjectId = params.subjectId;
   const basePathname = `/datahub/${subjectId}`;
   const subjectIdDisplaySetting = useAppStore((store) => store.currentGroup?.settings.subjectIdDisplayLength);
+  const isRemoteAssignmentsEnabled = useIsRemoteAssignmentsEnabled();
 
   return (
     <React.Fragment>
@@ -55,7 +56,7 @@ const RouteComponent = () => {
       <div className="mb-5 flex">
         <TabLink label={t('layout.tabs.table')} pathname={`${basePathname}/table`} testId="subject-table" />
         <TabLink label={t('layout.tabs.graph')} pathname={`${basePathname}/graph`} testId="subject-graph" />
-        {config.setup.isGatewayEnabled && (
+        {isRemoteAssignmentsEnabled && (
           <TabLink
             label={t('layout.tabs.assignments')}
             pathname={`${basePathname}/assignments`}

--- a/packages/schemas/src/setup/setup.test.ts
+++ b/packages/schemas/src/setup/setup.test.ts
@@ -76,4 +76,18 @@ describe('$UpdateSetupStateData', () => {
       expect($UpdateSetupStateData.safeParse({}).success).toBe(true);
     });
   });
+
+  describe('isRemoteAssignmentsEnabled', () => {
+    it.each([true, false])('should accept the boolean %s', (value) => {
+      expect($UpdateSetupStateData.safeParse({ isRemoteAssignmentsEnabled: value }).success).toBe(true);
+    });
+
+    it('should allow the field to be omitted, so a save of another setting leaves it alone', () => {
+      expect($UpdateSetupStateData.safeParse({}).success).toBe(true);
+    });
+
+    it('should reject null, which would silently mean the default rather than off', () => {
+      expect($UpdateSetupStateData.safeParse({ isRemoteAssignmentsEnabled: null }).success).toBe(false);
+    });
+  });
 });

--- a/packages/schemas/src/setup/setup.ts
+++ b/packages/schemas/src/setup/setup.ts
@@ -203,6 +203,11 @@ const $SetupState = z.object({
    * endpoints) that lets the client hide all email-related UI when mail is off.
    */
   isMailEnabled: z.boolean().nullish(),
+  /**
+   * Whether remote assignments are offered at all. Unlike the stored column this is never null —
+   * the API resolves an unset value to `true`, so a client never has to know the default.
+   */
+  isRemoteAssignmentsEnabled: z.boolean(),
   isSetup: z.boolean().nullable(),
   release: $ReleaseInfo,
   uptime: z.number()
@@ -212,7 +217,8 @@ const $UpdateSetupStateData = z.object({
   activeLanguages: $ActiveLanguages.optional(),
   branding: $BrandingConfig.nullish(),
   defaultAssignmentDurationDays: $DefaultAssignmentDurationDays.nullish(),
-  isExperimentalFeaturesEnabled: z.boolean().nullish()
+  isExperimentalFeaturesEnabled: z.boolean().nullish(),
+  isRemoteAssignmentsEnabled: z.boolean().optional()
 });
 
 const $CreateAdminData = $CreateUserData.omit({

--- a/testing/src/pages/_app/admin/settings.page.ts
+++ b/testing/src/pages/_app/admin/settings.page.ts
@@ -7,12 +7,14 @@ export class AdminSettingsPage extends AppPage {
   readonly defaultAssignmentDurationInput: Locator;
   readonly groupSwitcherPositionSelect: Locator;
   readonly pageHeader: Locator;
+  readonly remoteAssignmentsToggle: Locator;
   readonly uploaderToggle: Locator;
 
   constructor(page: Page) {
     super(page);
     this.pageHeader = page.getByTestId('page-header');
     this.uploaderToggle = page.getByRole('switch', { name: 'Enable Uploader' });
+    this.remoteAssignmentsToggle = page.getByRole('switch', { name: 'Enable Remote Assignments' });
     this.defaultAssignmentDurationInput = page.getByTestId('default-assignment-duration-input');
     this.groupSwitcherPositionSelect = page.getByRole('combobox');
   }

--- a/testing/src/specs/admin-settings.spec.ts
+++ b/testing/src/specs/admin-settings.spec.ts
@@ -29,6 +29,26 @@ test.describe('admin settings', () => {
     await expect(page.getByTestId('nav-button-/upload')).toHaveCount(0);
   });
 
+  // Remote assignments are on unless an admin opts out, and the rest of the suite drives them, so
+  // this is the one test that touches the flag and it turns it back on before finishing.
+  test('should toggle remote assignments and reflect it in the sidebar nav', async ({ getPageModel, page }) => {
+    const settingsPage = await getPageModel('/admin/settings');
+    const remoteAssignmentNav = page.getByTestId('nav-button-/session/remote-assignment');
+
+    await expect(settingsPage.remoteAssignmentsToggle).toHaveAttribute('aria-checked', 'true');
+    await expect(remoteAssignmentNav).toBeVisible();
+
+    const disabled = waitForSetupPatch(page);
+    await settingsPage.remoteAssignmentsToggle.click();
+    expect((await disabled).ok()).toBe(true);
+    await expect(remoteAssignmentNav).toHaveCount(0);
+
+    const restored = waitForSetupPatch(page);
+    await settingsPage.remoteAssignmentsToggle.click();
+    expect((await restored).ok()).toBe(true);
+    await expect(remoteAssignmentNav).toBeVisible();
+  });
+
   test('should persist the default assignment duration @smoke', async ({ getPageModel, page, uniqueId }) => {
     // The setting is instance-wide and every project shares one database, so a fixed value would already
     // be stored by the time the second browser runs, and the settings page would skip the save entirely.


### PR DESCRIPTION
## What

Adds **Enable Remote Assignments** to the Features section of App Settings, directly under Enable
Uploader, with a `?` hover card explaining what it does. It is **enabled by default** — including on
every instance set up before the setting existed.

Instances that do not use the gateway never need remote assignments, so turning this off removes:

- the **Remote Assignment** item from the session nav in the sidebar
- the **Assignments** tab on a subject in the datahub

## How

- `packages/schemas`: `isRemoteAssignmentsEnabled` on `$SetupState` (a plain `boolean`, never null —
  the API resolves an unset value) and on `$UpdateSetupStateData` (optional).
- `apps/api`: `Boolean?` column on `SetupState`; `getState` resolves an unsaved value to `true`, so
  the opt-out defaults to off. `PATCH /v1/setup` already requires `manage all`.
- `apps/web`: `useIsRemoteAssignmentsEnabled` answers "does this instance offer remote assignments?"
  once — gateway deployed *and* feature on — and both the sidebar and the subject tab read it. The
  datahub tab previously read the build-time `config.setup.isGatewayEnabled` while the sidebar read
  the API's value; both now use the API's.
- The settings page's repeated label + help + toggle row is factored into one `FeatureToggle`, and
  the duplicated hover-card markup into `HelpHoverCard`.

## Tests

- `apps/web/src/hooks/__tests__/useIsRemoteAssignmentsEnabled.test.ts` — the full gateway × feature
  matrix.
- `apps/web/src/hooks/__tests__/useNavItems.test.ts` — the nav item appears only when both hold.
- `apps/api/src/setup/__tests__/setup.service.spec.ts` — unset reads as enabled, saved `false` reads
  as disabled, and the flag persists.
- `packages/schemas/src/setup/setup.test.ts` — the update field accepts booleans, may be omitted, and
  rejects `null`.
- `testing/src/specs/admin-settings.spec.ts` — toggling the setting adds and removes the sidebar item.
  It is the one spec that touches this instance-wide flag and it turns it back on before finishing,
  because the rest of the suite drives remote assignments.

`pnpm lint`, `pnpm test` (668 passed) and `pnpm test:e2e` (143 passed) are green.

## Note

Disabling the feature hides the UI; the `/session/remote-assignment` and
`/datahub/$id/assignments` routes and the API endpoints remain reachable by direct URL, matching how
the Enable Uploader flag behaves today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)