### PR TITLE
feat(validation): write user-friendly messages for every zod issue

### DIFF
--- a/apps/gateway/AGENTS.md
+++ b/apps/gateway/AGENTS.md
@@ -98,6 +98,11 @@ hydrated tree can disagree with the SSR'd HTML until you do.
   `{}`, so every string is inline `t({ en, fr })`.
 - Shared UI comes from `packages/react-core` (`InstrumentRenderer`, `Branding`). Put anything both
   apps need there, not here.
+- Validation messages are localized by `src/services/zod.ts`, a thin call to react-core's
+  `localizeZodErrors`. **`entry-client.tsx` is the only place it may be called** — its `'runtime'`
+  target dynamically imports `/runtime/v1/zod@3.x/…`, a browser URL that does not resolve in node,
+  and nothing is validated during SSR anyway. The copy lives in
+  `packages/react-core/src/utils/zodErrorMap.ts`; do not add a message table here.
 - Instrument bundles arrive already built and are validated with `$InstrumentBundleContainer` in
   `src/routers/root.router.ts`. Background: `.agents/docs/architecture/instrument-pipeline.md`.
 

--- a/apps/gateway/src/entry-client.tsx
+++ b/apps/gateway/src/entry-client.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 
 import { Root } from './Root';
 import { i18n } from './services/i18n';
+import { localizeValidationErrors } from './services/zod';
 
 import '@opendatacapture/react-core/globals.css';
 import './globals.css';
@@ -11,6 +12,8 @@ const ROOT_PROPS = window.__ROOT_PROPS__;
 
 // Set before hydrating so the client resolves the same language the server rendered.
 i18n.changeLanguage(ROOT_PROPS.language);
+
+localizeValidationErrors().catch(console.error);
 
 ReactDOM.hydrateRoot(
   document.getElementById('root')!,

--- a/apps/gateway/src/services/zod.ts
+++ b/apps/gateway/src/services/zod.ts
@@ -1,0 +1,14 @@
+import { localizeZodErrors } from '@opendatacapture/react-core';
+
+import { i18n } from './i18n';
+
+/**
+ * Must only be called from `entry-client.tsx`. The runtime target resolves a browser URL that does
+ * not exist in node, and nothing is validated during SSR anyway — a patient's answers are parsed on
+ * submit, in the browser.
+ */
+const localizeValidationErrors = (): Promise<void> => {
+  return localizeZodErrors({ targets: ['app', 'runtime'], translator: i18n });
+};
+
+export { localizeValidationErrors };

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -110,11 +110,17 @@ per-leaf as `{ "en": ..., "fr": ... }` and kept sorted by
 **Adding a namespace means three edits in `src/services/i18n.ts`** — the import, the `declare module`
 interface member, and the `init` object. Without the interface member the keys do not type-check.
 
-Instrument validation errors are localized by `src/services/zod.ts`, which registers the
-required-field error map on **four** zod instances: this bundle's v3 and v4, plus the v3 and v4 of
-the runtime-served `/runtime/v1/zod@3.x` that instrument bundles import at runtime — a separate
-browser module instance with its own error registry. Change that file rather than calling
-`setErrorMap`/`z.config` anywhere else, or one of the four silently keeps the default messages.
+Validation errors are localized by `localizeZodErrors` from `@opendatacapture/react-core`, which
+`src/services/zod.ts` calls with `targets: ['app', 'runtime']` and `__root.tsx` invokes at module
+scope. That registers a map on **four** zod instances: this bundle's v3 and v4, plus the v3 and v4
+of the runtime-served `/runtime/v1/zod@3.x` that instrument bundles import at runtime — a separate
+browser module instance with its own error registry. Never call `setErrorMap`/`z.config` anywhere
+else, or one of the four silently keeps the default messages.
+
+**The messages themselves live in `packages/react-core/src/utils/zodErrorMap.ts`, not here**, so
+`apps/gateway` shares them. Adding copy for an issue code means editing that table, not this app.
+Note this covers `apps/web`'s own forms too — every schema fed to a libui `Form`, and everything
+`packages/schemas` composes — not only instruments.
 
 `react/jsx-no-literals` makes bare JSX text an **error**. Punctuation and proper nouns are
 allowlisted in `eslint.config.js` and `*.stories.tsx` is exempt; anything else it flags is a string

--- a/apps/web/src/__tests__/zod-error-maps.test.ts
+++ b/apps/web/src/__tests__/zod-error-maps.test.ts
@@ -1,35 +1,195 @@
-import { describe, expect, it } from 'vitest';
+import { createZodErrorMaps, localizeZodErrors } from '@opendatacapture/react-core';
+import { afterEach, describe, expect, it } from 'vitest';
 import { z as z3 } from 'zod/v3';
 import { z as z4 } from 'zod/v4';
 
-// Importing the service registers the maps on this bundle's v3 and v4 instances, which are the
-// same instances these 'zod/v3' and 'zod/v4' imports resolve to.
-import '@/services/zod';
+import i18n from '@/services/i18n';
 
-const REQUIRED_MESSAGE = 'This field is required';
+const maps = createZodErrorMaps(i18n);
 
-const firstMessage = (result: { error?: { issues: { message: string }[] } }) => result.error?.issues[0]?.message;
+// Both majors accept an error map for a single parse, so these exercise the maps without mutating
+// the global registries the app configures at startup.
+const v3Message = (schema: z3.ZodTypeAny, value: unknown) => {
+  return schema.safeParse(value, { errorMap: maps.v3 }).error?.issues[0]?.message;
+};
+
+const v4Message = (schema: z4.ZodType, value: unknown) => {
+  return schema.safeParse(value, { error: maps.v4 }).error?.issues[0]?.message;
+};
+
+const REQUIRED = 'This field is required';
+const INVALID = 'The value entered is not valid';
+
+afterEach(() => {
+  i18n.changeLanguage('en');
+});
 
 describe('zod v3 error map', () => {
-  it('should localize a missing field, so instrument forms report it as required', () => {
-    expect(firstMessage(z3.object({ name: z3.string() }).safeParse({}))).toBe(REQUIRED_MESSAGE);
+  it.each([
+    ['a missing field is the required message', z3.object({ x: z3.string() }), {}, REQUIRED],
+    ['a null value reads as missing rather than a type error', z3.object({ x: z3.string() }), { x: null }, REQUIRED],
+    ['an empty string against min(1), which untouched text fields submit', z3.string().min(1), '', REQUIRED],
+    [
+      'an untouched union of literals, which zod would otherwise report as "Invalid input"',
+      z3.object({ x: z3.union([z3.literal(1), z3.literal(2)]) }),
+      {},
+      REQUIRED
+    ],
+    ['a decimal in an integer field', z3.number().int(), 1.5, 'Must be a whole number'],
+    ['a number where text is expected', z3.string(), 1, 'Must be text'],
+    ['text where a number is expected', z3.number(), 'x', 'Must be a number'],
+    ['text where a boolean is expected', z3.boolean(), 'x', 'Must be a valid selection'],
+    ['an unparseable date', z3.date(), new Date('nope'), 'Must be a valid date'],
+    ['a number below an inclusive minimum', z3.number().gte(1), 0, 'Must be 1 or greater'],
+    ['a number at an exclusive minimum', z3.number().gt(1), 1, 'Must be greater than 1'],
+    ['a number above an inclusive maximum', z3.number().lte(10), 12, 'Must be 10 or less'],
+    ['a large bound, grouped for readability', z3.number().lte(1000000), 2000000, 'Must be 1,000,000 or less'],
+    ['a string below its minimum length', z3.string().min(3), 'ab', 'Must be at least 3 characters'],
+    ['a string of the wrong exact length', z3.string().length(5), 'ab', 'Must be exactly 5 characters'],
+    ['a set below its minimum size', z3.set(z3.string()).min(2), new Set(['a']), 'Must select at least 2 options'],
+    [
+      'a single-option minimum, in the singular',
+      z3.set(z3.string()).min(1),
+      new Set(),
+      'Must select at least 1 option'
+    ],
+    ['an array above its maximum size', z3.array(z3.string()).max(1), ['a', 'b'], 'Must select at most 1 option'],
+    [
+      'a value failing a regex, without leaking the pattern',
+      z3.string().regex(/^[A-Z]$/),
+      'zz',
+      'Does not match the expected format'
+    ],
+    ['a malformed email address', z3.string().email(), 'x', 'Must be a valid email address'],
+    ['a malformed url', z3.string().url(), 'x', 'Must be a valid web address'],
+    ['a string missing its required prefix', z3.string().startsWith('ab'), 'zz', 'Must start with "ab"'],
+    ['a value outside an enum', z3.enum(['A', 'B']), 'C', 'Must be a valid selection'],
+    ['a number that is not a multiple of the divisor', z3.number().multipleOf(5), 7, 'Must be a multiple of 5'],
+    [
+      'a union whose branches disagree, which has no single explanation',
+      z3.union([z3.string(), z3.number()]),
+      true,
+      INVALID
+    ],
+    ['an issue the map does not model', z3.number().finite(), Infinity, INVALID],
+    [
+      'an unexpected key, which no form field can produce',
+      z3.object({ x: z3.string() }).strict(),
+      { x: 'a', y: 1 },
+      INVALID
+    ]
+  ])('should describe %s', (_, schema, value, expected) => {
+    expect(v3Message(schema, value)).toBe(expected);
   });
-  it('should localize an empty string bounded by min(1), which forms submit for untouched text fields', () => {
-    expect(firstMessage(z3.string().min(1).safeParse(''))).toBe(REQUIRED_MESSAGE);
+
+  it('should format a date bound as a date rather than a timestamp', () => {
+    expect(v3Message(z3.date().min(new Date(2020, 0, 15)), new Date(2019, 0, 1))).toBe(
+      'Must be on or after January 15, 2020'
+    );
   });
-  it('should leave other issues at their default message', () => {
-    expect(firstMessage(z3.number().safeParse('x'))).not.toBe(REQUIRED_MESSAGE);
+
+  it('should leave a message written by the schema author untouched', () => {
+    expect(v3Message(z3.string().min(3, { message: 'Trop court' }), 'ab')).toBe('Trop court');
+  });
+
+  it('should follow the language the reader switched to, since messages are built at parse time', () => {
+    i18n.changeLanguage('fr');
+    expect(v3Message(z3.object({ x: z3.string() }), {})).toBe('Ce champ est obligatoire');
+    expect(v3Message(z3.number().int(), 1.5)).toBe('Doit être un nombre entier');
+    expect(v3Message(z3.string().min(3), 'ab')).toBe('Doit contenir au moins 3 caractères');
+  });
+
+  it('should put zero in the singular in French, where English keeps it plural', () => {
+    expect(v3Message(z3.array(z3.string()).max(0), ['a'])).toBe('Must select at most 0 options');
+    i18n.changeLanguage('fr');
+    expect(v3Message(z3.array(z3.string()).max(0), ['a'])).toBe('Doit sélectionner au plus 0 option');
   });
 });
 
 describe('zod v4 error map', () => {
-  it('should localize a missing field, so instrument forms report it as required', () => {
-    expect(firstMessage(z4.object({ name: z4.string() }).safeParse({}))).toBe(REQUIRED_MESSAGE);
+  it.each([
+    ['a missing field is the required message', z4.object({ x: z4.string() }), {}, REQUIRED],
+    ['a null value reads as missing rather than a type error', z4.object({ x: z4.string() }), { x: null }, REQUIRED],
+    ['an empty string against min(1), which untouched text fields submit', z4.string().min(1), '', REQUIRED],
+    [
+      'an untouched union of literals, which zod would otherwise report as "Invalid input"',
+      z4.object({ x: z4.union([z4.literal(1), z4.literal(2)]) }),
+      {},
+      REQUIRED
+    ],
+    ['a decimal in an integer field', z4.number().int(), 1.5, 'Must be a whole number'],
+    ['a number where text is expected', z4.string(), 1, 'Must be text'],
+    ['text where a number is expected', z4.number(), 'x', 'Must be a number'],
+    ['text where a boolean is expected', z4.boolean(), 'x', 'Must be a valid selection'],
+    ['a number below an inclusive minimum', z4.number().gte(1), 0, 'Must be 1 or greater'],
+    ['a number at an exclusive minimum', z4.number().gt(1), 1, 'Must be greater than 1'],
+    ['a number above an inclusive maximum', z4.number().lte(10), 12, 'Must be 10 or less'],
+    ['a large bound, grouped for readability', z4.number().lte(1000000), 2000000, 'Must be 1,000,000 or less'],
+    ['a string below its minimum length', z4.string().min(3), 'ab', 'Must be at least 3 characters'],
+    ['a string of the wrong exact length', z4.string().length(5), 'ab', 'Must be exactly 5 characters'],
+    ['a set below its minimum size', z4.set(z4.string()).min(2), new Set(['a']), 'Must select at least 2 options'],
+    [
+      'a single-option minimum, in the singular',
+      z4.set(z4.string()).min(1),
+      new Set(),
+      'Must select at least 1 option'
+    ],
+    ['an array above its maximum size', z4.array(z4.string()).max(1), ['a', 'b'], 'Must select at most 1 option'],
+    [
+      'a value failing a regex, without leaking the pattern',
+      z4.string().regex(/^[A-Z]$/),
+      'zz',
+      'Does not match the expected format'
+    ],
+    ['a malformed email address', z4.email(), 'x', 'Must be a valid email address'],
+    ['a malformed url', z4.url(), 'x', 'Must be a valid web address'],
+    ['a string missing its required prefix', z4.string().startsWith('ab'), 'zz', 'Must start with "ab"'],
+    ['a value outside an enum', z4.enum(['A', 'B']), 'C', 'Must be a valid selection'],
+    ['a number that is not a multiple of the divisor', z4.number().multipleOf(5), 7, 'Must be a multiple of 5'],
+    [
+      'a union whose branches disagree, which has no single explanation',
+      z4.union([z4.string(), z4.number()]),
+      true,
+      INVALID
+    ],
+    [
+      'an unexpected key, which no form field can produce',
+      z4.strictObject({ x: z4.string() }),
+      { x: 'a', y: 1 },
+      INVALID
+    ]
+  ])('should describe %s', (_, schema, value, expected) => {
+    expect(v4Message(schema, value)).toBe(expected);
   });
-  it('should localize an empty string bounded by min(1), which forms submit for untouched text fields', () => {
-    expect(firstMessage(z4.string().min(1).safeParse(''))).toBe(REQUIRED_MESSAGE);
+
+  it('should format a date bound as a date rather than a timestamp', () => {
+    expect(v4Message(z4.date().min(new Date(2020, 0, 15)), new Date(2019, 0, 1))).toBe(
+      'Must be on or after January 15, 2020'
+    );
   });
-  it('should leave other issues at their default message', () => {
-    expect(firstMessage(z4.number().safeParse('x'))).not.toBe(REQUIRED_MESSAGE);
+
+  it('should leave a message written by the schema author untouched', () => {
+    expect(v4Message(z4.string().min(3, { message: 'Trop court' }), 'ab')).toBe('Trop court');
+  });
+
+  it('should follow the language the reader switched to, since messages are built at parse time', () => {
+    i18n.changeLanguage('fr');
+    expect(v4Message(z4.object({ x: z4.string() }), {})).toBe('Ce champ est obligatoire');
+    expect(v4Message(z4.number().int(), 1.5)).toBe('Doit être un nombre entier');
+    expect(v4Message(z4.string().min(3), 'ab')).toBe('Doit contenir au moins 3 caractères');
+  });
+
+  it('should translate to Spanish, which the language table covers but few inline strings do', () => {
+    i18n.changeLanguage('es');
+    expect(v4Message(z4.object({ x: z4.string() }), {})).toBe('Este campo es obligatorio');
+    expect(v4Message(z4.string().min(3), 'ab')).toBe('Debe tener al menos 3 caracteres');
+  });
+});
+
+describe('localizeZodErrors', () => {
+  it("should register on this bundle's zod, so app forms need no per-parse map", async () => {
+    await localizeZodErrors({ targets: ['app'], translator: i18n });
+    expect(z3.object({ x: z3.string() }).safeParse({}).error?.issues[0]?.message).toBe(REQUIRED);
+    expect(z4.object({ x: z4.string() }).safeParse({}).error?.issues[0]?.message).toBe(REQUIRED);
   });
 });

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -5,12 +5,12 @@ import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 
 import { ConnectivityBanner } from '../components/ConnectivityBanner';
-import { localizeInstrumentValidationErrors } from '../services/zod';
+import { localizeValidationErrors } from '../services/zod';
 
 import '../services/axios';
 import '../services/i18n';
 
-localizeInstrumentValidationErrors().catch(console.error);
+localizeValidationErrors().catch(console.error);
 
 type RouterContext = {
   queryClient: QueryClient;

--- a/apps/web/src/services/zod.ts
+++ b/apps/web/src/services/zod.ts
@@ -1,53 +1,14 @@
-import { z as z3 } from 'zod/v3';
-import { z as z4 } from 'zod/v4';
+import { localizeZodErrors } from '@opendatacapture/react-core';
 
 import i18n from './i18n';
 
-const requiredFieldMessage = () => i18n.t('core.form.requiredField');
-
-const v3ErrorMap: z3.ZodErrorMap = (issue, ctx) => {
-  const isUndefined = issue.code === 'invalid_type' && issue.received === 'undefined';
-  const isEmptyString = issue.code === 'too_small' && issue.minimum === 1 && issue.type === 'string';
-  if (isUndefined || isEmptyString) {
-    return { message: requiredFieldMessage() };
-  }
-  return { message: ctx.defaultError };
-};
-
-const v4ErrorMap: z4.core.$ZodErrorMap = (issue) => {
-  const isUndefined = issue.code === 'invalid_type' && issue.input === undefined;
-  const isEmptyString = issue.code === 'too_small' && issue.minimum === 1 && issue.origin === 'string';
-  if (isUndefined || isEmptyString) {
-    return requiredFieldMessage();
-  }
-  return undefined;
-};
-
-z3.setErrorMap(v3ErrorMap);
-z4.config({ customError: v4ErrorMap });
-
 /**
- * Instrument bundles load zod with a native browser `import('/runtime/v1/zod@3.x/...')`, which is a
- * different module instance (and therefore a different global error registry) than the copy bundled
- * into this app — configuring the app's zod above does nothing for instrument validation schemas.
- * Importing the same URLs the bundles use shares the browser's module cache with them, so the maps
- * registered here are the ones their schemas see. v3 and v4 also keep separate registries, so both
- * must be configured.
+ * Localizes validation messages for this bundle's zod, which backs the app's own forms, and for the
+ * runtime-served zod that instrument bundles import at runtime. See `localizeZodErrors` for why the
+ * two are distinct module instances.
  */
-// Vite rewrites every import() it can see — in dev it appends ?import to the URL — which would
-// load a second copy of the runtime module under a different URL and configure the wrong one.
-// Constructing the import inside a Function hides it from vite, so the URL resolves exactly the
-// way it does inside an instrument bundle (whose code is evaluated the same way).
-
-const importRuntimeModule = new Function('url', 'return import(url)') as <TModule>(url: string) => Promise<TModule>;
-
-const localizeInstrumentValidationErrors = async (): Promise<void> => {
-  const [runtimeV3, runtimeV4] = await Promise.all([
-    importRuntimeModule<typeof import('/runtime/v1/zod@3.x/index.js')>('/runtime/v1/zod@3.x/index.js'),
-    importRuntimeModule<typeof import('/runtime/v1/zod@3.x/v4.js')>('/runtime/v1/zod@3.x/v4.js')
-  ]);
-  runtimeV3.z.setErrorMap(v3ErrorMap);
-  runtimeV4.z.config({ customError: v4ErrorMap });
+const localizeValidationErrors = (): Promise<void> => {
+  return localizeZodErrors({ targets: ['app', 'runtime'], translator: i18n });
 };
 
-export { localizeInstrumentValidationErrors, v3ErrorMap, v4ErrorMap };
+export { localizeValidationErrors };

--- a/packages/react-core/AGENTS.md
+++ b/packages/react-core/AGENTS.md
@@ -29,7 +29,9 @@ belongs in `apps/web/src/components`.
 ## No translation resource files
 
 There are no JSON translations here and there should never be: `apps/gateway` initialises i18n with
-`i18n.init({ translations: {} })`, so a namespaced key would render as the raw key string there.
+`i18n.init({ translations: {} })`, so a namespaced key resolves to nothing there — `t()` logs
+`Failed to extract translation from object '{}'` and returns the **empty string**, which renders as
+missing copy rather than as a visible key.
 
 Use inline `t({ en: '...', fr: '...' })`. The only keyed calls that are safe are libui's own
 namespace — `t('libui.yes')`, `t('libui.no')`, `t('libui.form.submit')` — which libui registers.
@@ -37,6 +39,31 @@ namespace — `t('libui.yes')`, `t('libui.no')`, `t('libui.form.submit')` — wh
 Copy supplied by the host app arrives as a prop typed `LocalizedText` (`src/types.ts`), a partial
 `{ en?, fr? }` record the component resolves with `t()`. `submitButtonLabel` is the only prop using
 it today; follow that shape rather than inventing a namespace.
+
+## Validation messages
+
+`src/utils/zodErrorMap.ts` owns the localized copy for **every** zod validation error either
+frontend shows — instruments and the apps' own forms alike. `apps/web/src/services/zod.ts` and
+`apps/gateway/src/services/zod.ts` are thin adapters over its `localizeZodErrors`.
+
+- **`MESSAGES` / `COUNTED_MESSAGES` are the only place message copy belongs.** Both carry
+  `as const satisfies { ... { [L in Language]: string } }`, so a new interface language fails to
+  compile until every message has one. `COUNTED_MESSAGES` exists because French puts zero in the
+  singular where English and Spanish do not; the form is picked by `Intl.PluralRules`.
+- **zod v3 and v4 name almost every issue field differently.** `normalizeV3Issue` and
+  `normalizeV4Issue` reduce both to one `FormIssue`, and `describeIssue` writes the message once.
+  Add an issue code to the normalizers, not a second message table.
+- **`V4Issue` is a deliberate widening.** `vendor/zod@3.x` pins declarations older than the zod it
+  resolves at runtime, so `exact` and a string-format issue's `prefix`/`suffix`/`includes` are
+  emitted but not declared.
+- Anything unmapped renders the generic `invalid` message rather than `undefined`. Returning
+  `undefined` from the v4 map would defer to `config.localeError`, which the runtime bundle sets to
+  zod's **English** locale at module init.
+- A message written by the schema author always wins — both majors skip the error map entirely when
+  an issue already carries one.
+
+Tests live in `apps/web/src/__tests__/zod-error-maps.test.ts` (this package has no vitest project).
+They drive `createZodErrorMaps` through per-parse maps rather than registering globally.
 
 ## `@tanstack/react-router` is an optional peer — never import it
 

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -13,3 +13,4 @@ export * from './components/Logo';
 export * from './components/NavigationBlockerDialog';
 export * from './types';
 export * from './utils/language';
+export * from './utils/zodErrorMap';

--- a/packages/react-core/src/utils/zodErrorMap.ts
+++ b/packages/react-core/src/utils/zodErrorMap.ts
@@ -1,0 +1,560 @@
+import type { TranslateFunction } from '@douglasneuroinformatics/libui/i18n';
+import type { Language } from '@opendatacapture/schemas/core';
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
+
+/**
+ * The subset of libui's `i18n` singleton these maps need. Taking it as a parameter keeps
+ * {@link createZodErrorMaps} pure, so it can be exercised with a stub instead of an initialized
+ * translator, and lets each frontend supply its own instance.
+ *
+ * `TranslateFunction<never>` makes the keyed overload uncallable, leaving only `t({ en, fr, es })`.
+ * That is a requirement rather than a preference: `apps/gateway` initializes i18n with
+ * `translations: {}`, where a keyed lookup resolves to an empty string.
+ */
+type TranslatorLike = {
+  resolvedLanguage: Language;
+  t: TranslateFunction<never>;
+};
+
+type ZodErrorMaps = {
+  v3: z3.ZodErrorMap;
+  v4: z4.core.$ZodErrorMap;
+};
+
+type ZodErrorMapTarget = 'app' | 'runtime';
+
+/**
+ * The v4 issue fields these normalizers read, for two reasons neither of which `$ZodIssue` covers
+ * on its own. What an error map is handed is a `$ZodRawIssue`, which intersects every issue with
+ * `Record<string, any>` — so each field read off it is `any`. And `vendor/zod@3.x` pins type
+ * declarations older than the zod it resolves at runtime: `exact` (set by `length`) and the
+ * `prefix` / `suffix` / `includes` of a string-format issue are emitted but not declared.
+ */
+type V4Issue = z4.core.$ZodIssue & {
+  exact?: boolean;
+  includes?: string;
+  prefix?: string;
+  suffix?: string;
+};
+
+type FormatKind = 'date' | 'email' | 'endsWith' | 'includes' | 'pattern' | 'startsWith' | 'time' | 'url';
+
+type SizeOrigin = 'characters' | 'date' | 'items' | 'number';
+
+type TypeKind = 'boolean' | 'date' | 'integer' | 'list' | 'number' | 'text';
+
+/**
+ * A zod issue reduced to what a message depends on. zod v3 and v4 disagree on nearly every field
+ * name — `received`/`input`, `type`/`origin`, `invalid_string`/`invalid_format`,
+ * `invalid_enum_value`/`invalid_value` — so each major gets a normalizer and both share one
+ * describer, rather than the message copy being written twice.
+ */
+type FormIssue =
+  | {
+      bound: 'max' | 'min';
+      exact: boolean;
+      inclusive: boolean;
+      kind: 'size';
+      limit: bigint | number | string;
+      origin: SizeOrigin;
+    }
+  | { divisor: bigint | number; kind: 'multipleOf' }
+  | { expected: TypeKind; kind: 'type' }
+  | { format: FormatKind; kind: 'format'; value?: string }
+  | { kind: 'invalid' }
+  | { kind: 'option' }
+  | { kind: 'required' }
+  | { kind: 'union'; messages: (string | undefined)[] };
+
+/**
+ * Messages whose wording does not depend on a count. The `satisfies` keeps this in step with
+ * {@link Language}: adding an interface language fails to compile until every message has one,
+ * rather than silently falling back to English at runtime.
+ *
+ * `{}` is libui's interpolation placeholder, filled left to right from the `args` array.
+ */
+const MESSAGES = {
+  exactNumber: { en: 'Must be exactly {}', es: 'Debe ser exactamente {}', fr: 'Doit être exactement {}' },
+  formatEmail: {
+    en: 'Must be a valid email address',
+    es: 'Debe ser un correo electrónico válido',
+    fr: 'Doit être une adresse courriel valide'
+  },
+  formatEndsWith: { en: 'Must end with "{}"', es: 'Debe terminar con «{}»', fr: 'Doit se terminer par « {} »' },
+  formatIncludes: { en: 'Must include "{}"', es: 'Debe incluir «{}»', fr: 'Doit contenir « {} »' },
+  formatPattern: {
+    en: 'Does not match the expected format',
+    es: 'No coincide con el formato esperado',
+    fr: 'Ne correspond pas au format attendu'
+  },
+  formatStartsWith: { en: 'Must start with "{}"', es: 'Debe comenzar con «{}»', fr: 'Doit commencer par « {} »' },
+  formatTime: { en: 'Must be a valid time', es: 'Debe ser una hora válida', fr: 'Doit être une heure valide' },
+  formatUrl: {
+    en: 'Must be a valid web address',
+    es: 'Debe ser una dirección web válida',
+    fr: 'Doit être une adresse web valide'
+  },
+  invalid: {
+    en: 'The value entered is not valid',
+    es: 'El valor introducido no es válido',
+    fr: "La valeur saisie n'est pas valide"
+  },
+  maxDate: { en: 'Must be on or before {}', es: 'Debe ser el {} o anterior', fr: 'Doit être le {} ou avant' },
+  maxDateExclusive: { en: 'Must be before {}', es: 'Debe ser anterior al {}', fr: 'Doit être avant le {}' },
+  maxNumber: { en: 'Must be {} or less', es: 'Debe ser {} o menor', fr: 'Doit être inférieur ou égal à {}' },
+  maxNumberExclusive: { en: 'Must be less than {}', es: 'Debe ser menor que {}', fr: 'Doit être inférieur à {}' },
+  minDate: { en: 'Must be on or after {}', es: 'Debe ser el {} o posterior', fr: 'Doit être le {} ou après' },
+  minDateExclusive: { en: 'Must be after {}', es: 'Debe ser posterior al {}', fr: 'Doit être après le {}' },
+  minNumber: { en: 'Must be {} or greater', es: 'Debe ser {} o mayor', fr: 'Doit être supérieur ou égal à {}' },
+  minNumberExclusive: { en: 'Must be greater than {}', es: 'Debe ser mayor que {}', fr: 'Doit être supérieur à {}' },
+  multipleOf: { en: 'Must be a multiple of {}', es: 'Debe ser un múltiplo de {}', fr: 'Doit être un multiple de {}' },
+  option: {
+    en: 'Must be a valid selection',
+    es: 'Debe ser una selección válida',
+    fr: 'Doit être une sélection valide'
+  },
+  required: { en: 'This field is required', es: 'Este campo es obligatorio', fr: 'Ce champ est obligatoire' },
+  typeBoolean: {
+    en: 'Must be a valid selection',
+    es: 'Debe ser una selección válida',
+    fr: 'Doit être une sélection valide'
+  },
+  typeDate: { en: 'Must be a valid date', es: 'Debe ser una fecha válida', fr: 'Doit être une date valide' },
+  typeInteger: { en: 'Must be a whole number', es: 'Debe ser un número entero', fr: 'Doit être un nombre entier' },
+  typeList: {
+    en: 'Must be a list of values',
+    es: 'Debe ser una lista de valores',
+    fr: 'Doit être une liste de valeurs'
+  },
+  typeNumber: { en: 'Must be a number', es: 'Debe ser un número', fr: 'Doit être un nombre' },
+  typeText: { en: 'Must be text', es: 'Debe ser texto', fr: 'Doit être du texte' }
+} as const satisfies { [key: string]: { [L in Language]: string } };
+
+/**
+ * Messages that interpolate a count, and so need a singular form. French puts zero in the singular
+ * where English and Spanish do not, which is why the form is chosen by `Intl.PluralRules` against
+ * the reader's language rather than by comparing the count to one.
+ */
+const COUNTED_MESSAGES = {
+  exactCharacters: {
+    one: {
+      en: 'Must be exactly {} character',
+      es: 'Debe tener exactamente {} carácter',
+      fr: 'Doit contenir exactement {} caractère'
+    },
+    other: {
+      en: 'Must be exactly {} characters',
+      es: 'Debe tener exactamente {} caracteres',
+      fr: 'Doit contenir exactement {} caractères'
+    }
+  },
+  exactItems: {
+    one: {
+      en: 'Must select exactly {} option',
+      es: 'Debe seleccionar exactamente {} opción',
+      fr: 'Doit sélectionner exactement {} option'
+    },
+    other: {
+      en: 'Must select exactly {} options',
+      es: 'Debe seleccionar exactamente {} opciones',
+      fr: 'Doit sélectionner exactement {} options'
+    }
+  },
+  maxCharacters: {
+    one: {
+      en: 'Must be at most {} character',
+      es: 'Debe tener como máximo {} carácter',
+      fr: 'Doit contenir au plus {} caractère'
+    },
+    other: {
+      en: 'Must be at most {} characters',
+      es: 'Debe tener como máximo {} caracteres',
+      fr: 'Doit contenir au plus {} caractères'
+    }
+  },
+  maxItems: {
+    one: {
+      en: 'Must select at most {} option',
+      es: 'Debe seleccionar como máximo {} opción',
+      fr: 'Doit sélectionner au plus {} option'
+    },
+    other: {
+      en: 'Must select at most {} options',
+      es: 'Debe seleccionar como máximo {} opciones',
+      fr: 'Doit sélectionner au plus {} options'
+    }
+  },
+  minCharacters: {
+    one: {
+      en: 'Must be at least {} character',
+      es: 'Debe tener al menos {} carácter',
+      fr: 'Doit contenir au moins {} caractère'
+    },
+    other: {
+      en: 'Must be at least {} characters',
+      es: 'Debe tener al menos {} caracteres',
+      fr: 'Doit contenir au moins {} caractères'
+    }
+  },
+  minItems: {
+    one: {
+      en: 'Must select at least {} option',
+      es: 'Debe seleccionar al menos {} opción',
+      fr: 'Doit sélectionner au moins {} option'
+    },
+    other: {
+      en: 'Must select at least {} options',
+      es: 'Debe seleccionar al menos {} opciones',
+      fr: 'Doit sélectionner au moins {} options'
+    }
+  }
+} as const satisfies { [key: string]: { [F in 'one' | 'other']: { [L in Language]: string } } };
+
+const V3_TYPE_KINDS: { [key: string]: TypeKind } = {
+  array: 'list',
+  bigint: 'number',
+  boolean: 'boolean',
+  date: 'date',
+  float: 'number',
+  integer: 'integer',
+  map: 'list',
+  nan: 'number',
+  number: 'number',
+  set: 'list',
+  string: 'text'
+};
+
+const V4_TYPE_KINDS: { [key: string]: TypeKind } = {
+  array: 'list',
+  bigint: 'number',
+  boolean: 'boolean',
+  date: 'date',
+  int: 'integer',
+  map: 'list',
+  number: 'number',
+  set: 'list',
+  string: 'text',
+  tuple: 'list'
+};
+
+const V3_SIZE_ORIGINS: { [key: string]: SizeOrigin } = {
+  array: 'items',
+  bigint: 'number',
+  date: 'date',
+  number: 'number',
+  set: 'items',
+  string: 'characters'
+};
+
+const V4_SIZE_ORIGINS: { [key: string]: SizeOrigin } = {
+  array: 'items',
+  bigint: 'number',
+  date: 'date',
+  int: 'number',
+  number: 'number',
+  set: 'items',
+  string: 'characters'
+};
+
+/**
+ * Every string format either gets its own message or falls back to `formatPattern`. That fallback
+ * is deliberate for `regex`: zod's own message interpolates the pattern, which is meaningless to a
+ * clinician and leaks the schema into the interface.
+ */
+const FORMAT_KINDS: { [key: string]: FormatKind } = {
+  date: 'date',
+  datetime: 'date',
+  email: 'email',
+  ends_with: 'endsWith',
+  includes: 'includes',
+  starts_with: 'startsWith',
+  time: 'time',
+  url: 'url'
+};
+
+const FORMAT_MESSAGE_KEYS = {
+  date: 'typeDate',
+  email: 'formatEmail',
+  endsWith: 'formatEndsWith',
+  includes: 'formatIncludes',
+  pattern: 'formatPattern',
+  startsWith: 'formatStartsWith',
+  time: 'formatTime',
+  url: 'formatUrl'
+} as const satisfies { [K in FormatKind]: keyof typeof MESSAGES };
+
+const TYPE_MESSAGE_KEYS = {
+  boolean: 'typeBoolean',
+  date: 'typeDate',
+  integer: 'typeInteger',
+  list: 'typeList',
+  number: 'typeNumber',
+  text: 'typeText'
+} as const satisfies { [K in TypeKind]: keyof typeof MESSAGES };
+
+const BOUND_MESSAGE_KEYS = {
+  date: {
+    exclusive: { max: 'maxDateExclusive', min: 'minDateExclusive' },
+    inclusive: { max: 'maxDate', min: 'minDate' }
+  },
+  number: {
+    exclusive: { max: 'maxNumberExclusive', min: 'minNumberExclusive' },
+    inclusive: { max: 'maxNumber', min: 'minNumber' }
+  }
+} as const satisfies {
+  [O in 'date' | 'number']: { [I in 'exclusive' | 'inclusive']: { [B in 'max' | 'min']: keyof typeof MESSAGES } };
+};
+
+const formatNumber = (language: Language, value: bigint | number | string): string => {
+  return typeof value === 'string' ? value : value.toLocaleString(language);
+};
+
+const formatDate = (language: Language, value: bigint | number | string): string => {
+  return new Date(typeof value === 'bigint' ? Number(value) : value).toLocaleDateString(language, {
+    dateStyle: 'long'
+  });
+};
+
+const describeIssue = (issue: FormIssue, translator: TranslatorLike): string => {
+  const language = translator.resolvedLanguage;
+  const translate = (key: keyof typeof MESSAGES, args?: string[]) => translator.t(MESSAGES[key], { args });
+
+  switch (issue.kind) {
+    case 'format':
+      return translate(FORMAT_MESSAGE_KEYS[issue.format], issue.value === undefined ? undefined : [issue.value]);
+    case 'multipleOf':
+      return translate('multipleOf', [formatNumber(language, issue.divisor)]);
+    case 'option':
+      return translate('option');
+    case 'required':
+      return translate('required');
+    case 'size': {
+      if (issue.origin === 'characters' || issue.origin === 'items') {
+        const noun = issue.origin === 'characters' ? 'Characters' : 'Items';
+        const count = Number(issue.limit);
+        const plural = new Intl.PluralRules(language).select(count) === 'one' ? 'one' : 'other';
+        return translator.t(COUNTED_MESSAGES[`${issue.exact ? 'exact' : issue.bound}${noun}`][plural], {
+          args: [formatNumber(language, count)]
+        });
+      } else if (issue.origin === 'number' && issue.exact) {
+        return translate('exactNumber', [formatNumber(language, issue.limit)]);
+      }
+      const key = BOUND_MESSAGE_KEYS[issue.origin][issue.inclusive ? 'inclusive' : 'exclusive'][issue.bound];
+      const value = issue.origin === 'date' ? formatDate(language, issue.limit) : formatNumber(language, issue.limit);
+      return translate(key, [value]);
+    }
+    case 'type':
+      return translate(TYPE_MESSAGE_KEYS[issue.expected]);
+    case 'union': {
+      // Every branch has already been through this map, so its message is the localized one. When
+      // the branches agree the union is really one failure reported N times — most often an
+      // untouched `z.union([z.literal(1), ...])` radio, where each branch reports "required".
+      const [first, ...rest] = issue.messages;
+      return first !== undefined && rest.every((message) => message === first) ? first : translate('invalid');
+    }
+    default:
+      return translate('invalid');
+  }
+};
+
+const toFormatIssue = (
+  format: string,
+  affix: { endsWith?: unknown; includes?: unknown; startsWith?: unknown }
+): FormIssue => {
+  const kind = FORMAT_KINDS[format] ?? 'pattern';
+  const value = kind === 'endsWith' || kind === 'includes' || kind === 'startsWith' ? affix[kind] : undefined;
+  return { format: kind, kind: 'format', value: typeof value === 'string' ? value : undefined };
+};
+
+const normalizeV3Issue = (issue: z3.ZodIssueOptionalMessage): FormIssue => {
+  switch (issue.code) {
+    case 'invalid_date':
+      return { expected: 'date', kind: 'type' };
+    case 'invalid_enum_value':
+    case 'invalid_union_discriminator':
+      return { kind: 'option' };
+    case 'invalid_literal':
+      return issue.received === undefined || issue.received === null ? { kind: 'required' } : { kind: 'option' };
+    case 'invalid_string': {
+      if (typeof issue.validation === 'string') {
+        return toFormatIssue(issue.validation, {});
+      } else if ('includes' in issue.validation) {
+        return toFormatIssue('includes', { includes: issue.validation.includes });
+      } else if ('startsWith' in issue.validation) {
+        return toFormatIssue('starts_with', { startsWith: issue.validation.startsWith });
+      }
+      return toFormatIssue('ends_with', { endsWith: issue.validation.endsWith });
+    }
+    case 'invalid_type': {
+      if (issue.received === 'undefined' || (issue.received === 'null' && issue.expected !== 'null')) {
+        return { kind: 'required' };
+      }
+      const expected = V3_TYPE_KINDS[issue.expected];
+      return expected ? { expected, kind: 'type' } : { kind: 'invalid' };
+    }
+    case 'invalid_union':
+      return { kind: 'union', messages: issue.unionErrors.map((error) => error.issues[0]?.message) };
+    case 'not_multiple_of':
+      return { divisor: issue.multipleOf, kind: 'multipleOf' };
+    case 'too_big': {
+      const origin = V3_SIZE_ORIGINS[issue.type];
+      return origin
+        ? {
+            bound: 'max',
+            exact: issue.exact ?? false,
+            inclusive: issue.inclusive,
+            kind: 'size',
+            limit: issue.maximum,
+            origin
+          }
+        : { kind: 'invalid' };
+    }
+    case 'too_small': {
+      // An untouched text field submits '', which every `min(1)` rejects. Reporting that as a
+      // length problem rather than a missing value would be true but useless.
+      if (issue.type === 'string' && issue.minimum === 1) {
+        return { kind: 'required' };
+      }
+      const origin = V3_SIZE_ORIGINS[issue.type];
+      return origin
+        ? {
+            bound: 'min',
+            exact: issue.exact ?? false,
+            inclusive: issue.inclusive,
+            kind: 'size',
+            limit: issue.minimum,
+            origin
+          }
+        : { kind: 'invalid' };
+    }
+    default:
+      return { kind: 'invalid' };
+  }
+};
+
+const normalizeV4Issue = (raw: z4.core.$ZodRawIssue): FormIssue => {
+  const issue = raw as V4Issue;
+
+  // Unlike v3, every issue raised while parsing carries the offending value, so one check covers a
+  // missing field of any type. `'input' in issue` guards against an issue pushed by hand from a
+  // `.check()` without one, which is not a missing value.
+  if ('input' in issue && issue.input === undefined) {
+    return { kind: 'required' };
+  } else if (
+    'input' in issue &&
+    issue.input === null &&
+    !(issue.code === 'invalid_type' && issue.expected === 'null')
+  ) {
+    return { kind: 'required' };
+  }
+
+  switch (issue.code) {
+    case 'invalid_format':
+      return toFormatIssue(issue.format, {
+        endsWith: issue.suffix,
+        includes: issue.includes,
+        startsWith: issue.prefix
+      });
+    case 'invalid_type': {
+      const expected = V4_TYPE_KINDS[issue.expected];
+      return expected ? { expected, kind: 'type' } : { kind: 'invalid' };
+    }
+    case 'invalid_union':
+      return { kind: 'union', messages: issue.errors.map((branch) => branch[0]?.message) };
+    case 'invalid_value':
+      return { kind: 'option' };
+    case 'not_multiple_of':
+      return { divisor: issue.divisor, kind: 'multipleOf' };
+    case 'too_big': {
+      const origin = V4_SIZE_ORIGINS[issue.origin];
+      return origin
+        ? {
+            bound: 'max',
+            exact: issue.exact ?? false,
+            // zod omits `inclusive` on some size checks (`z.set().min(n)`) where the bound is
+            // nonetheless inclusive; it is only ever explicitly false for `gt`/`lt`.
+            inclusive: issue.inclusive ?? true,
+            kind: 'size',
+            limit: issue.maximum,
+            origin
+          }
+        : { kind: 'invalid' };
+    }
+    case 'too_small': {
+      if (issue.origin === 'string' && issue.minimum === 1) {
+        return { kind: 'required' };
+      }
+      const origin = V4_SIZE_ORIGINS[issue.origin];
+      return origin
+        ? {
+            bound: 'min',
+            exact: issue.exact ?? false,
+            inclusive: issue.inclusive ?? true,
+            kind: 'size',
+            limit: issue.minimum,
+            origin
+          }
+        : { kind: 'invalid' };
+    }
+    default:
+      return { kind: 'invalid' };
+  }
+};
+
+/**
+ * Builds the error maps both zod majors expect. Pure — it registers nothing, needs no zod instance
+ * and no initialized translator, so it can be tested against a stub translator.
+ *
+ * The v4 map returns a string for every issue rather than `undefined` for the ones it does not
+ * recognize. Returning `undefined` would defer to `config.localeError`, which the runtime bundle
+ * sets to zod's English locale at module init.
+ */
+const createZodErrorMaps = (translator: TranslatorLike): ZodErrorMaps => ({
+  v3: (issue) => ({ message: describeIssue(normalizeV3Issue(issue), translator) }),
+  v4: (issue) => describeIssue(normalizeV4Issue(issue), translator)
+});
+
+// Vite rewrites every import() it can see — in dev it appends ?import to the URL — which would
+// load a second copy of the runtime module under a different URL and configure the wrong one.
+// Constructing the import inside a Function hides it from vite, so the URL resolves exactly the
+// way it does inside an instrument bundle (whose code is evaluated the same way).
+const importRuntimeModule = new Function('url', 'return import(url)') as <TModule>(url: string) => Promise<TModule>;
+
+/**
+ * Registers the maps on the zod instances named by `targets`.
+ *
+ * `'app'` is the copy bundled into the calling frontend, which backs its own forms. `'runtime'` is
+ * the copy instrument bundles reach with a native browser `import('/runtime/v1/zod@3.x/...')` — a
+ * different module instance with its own error registry, so configuring the bundled copy does
+ * nothing for instrument validation schemas. Importing the same URLs the bundles use shares the
+ * browser's module cache with them. Within each, v3 and v4 keep separate registries.
+ *
+ * `'runtime'` only resolves in a browser, and only in a host that installs the runtime Vite plugin.
+ * The `'app'` registration happens before the first await, so it is in place synchronously.
+ */
+const localizeZodErrors = async ({
+  targets,
+  translator
+}: {
+  targets: readonly ZodErrorMapTarget[];
+  translator: TranslatorLike;
+}): Promise<void> => {
+  const maps = createZodErrorMaps(translator);
+  if (targets.includes('app')) {
+    z3.setErrorMap(maps.v3);
+    z4.config({ customError: maps.v4 });
+  }
+  if (!targets.includes('runtime')) {
+    return;
+  }
+  const [runtimeV3, runtimeV4] = await Promise.all([
+    importRuntimeModule<typeof import('/runtime/v1/zod@3.x/index.js')>('/runtime/v1/zod@3.x/index.js'),
+    importRuntimeModule<typeof import('/runtime/v1/zod@3.x/v4.js')>('/runtime/v1/zod@3.x/v4.js')
+  ]);
+  runtimeV3.z.setErrorMap(maps.v3);
+  runtimeV4.z.config({ customError: maps.v4 });
+};
+
+export { createZodErrorMaps, localizeZodErrors };
+export type { TranslatorLike, ZodErrorMaps, ZodErrorMapTarget };

--- a/testing/src/specs/admin-management.spec.ts
+++ b/testing/src/specs/admin-management.spec.ts
@@ -36,7 +36,13 @@ test.describe('admin management', () => {
 
     await page.getByRole('button', { name: 'Submit' }).click();
 
-    await expect(page.getByTestId('error-message-text').filter({ hasText: 'This field is required' })).toBeVisible();
+    // Every missing field reports the same thing, including the ones backed by a select — those
+    // raise an issue code that used to fall through to zod's untranslated default.
+    const errorMessages = page.getByTestId('error-message-text');
+    await expect(errorMessages.first()).toBeVisible();
+    for (const message of await errorMessages.allTextContents()) {
+      expect(message).toBe('This field is required');
+    }
     await expect(page).toHaveURL('/admin/groups/create');
   });
 

--- a/testing/src/specs/gateway-assignment.spec.ts
+++ b/testing/src/specs/gateway-assignment.spec.ts
@@ -73,6 +73,16 @@ test.describe('gateway remote assignment', () => {
     const gatewayInstrument = new RenderInstrumentPage(gatewayPage);
     await expect(gatewayInstrument.beginButton).toBeEnabled({ timeout: 120_000 });
     await gatewayInstrument.begin();
+
+    // Submitting empty first, before answering, so the one expensive Cap proof-of-work above covers
+    // this too. The gateway registers the shared zod error maps in `entry-client.tsx`; without that
+    // a patient sees zod's untranslated default here regardless of the language they chose.
+    await gatewayInstrument.submit();
+    await expect(gatewayInstrument.errorMessages.first()).toBeVisible();
+    for (const message of await gatewayInstrument.errorMessages.allTextContents()) {
+      expect(message).toBe('This field is required');
+    }
+
     await gatewayInstrument.completeHappinessQuestionnaire();
     await gatewayInstrument.submit();
     await expect(gatewayInstrument.summaryHeading).toBeVisible();

--- a/testing/src/specs/instrument-completion.spec.ts
+++ b/testing/src/specs/instrument-completion.spec.ts
@@ -159,6 +159,10 @@ test.describe('instrument completion', () => {
     await instrumentPage.$ref.locator('[name="postalCode"]').fill('invalid');
     await instrumentPage.submit();
 
+    // This instrument is authored against zod v3, whose own message for a failed regex is the bare
+    // word "Invalid". Asserting the text is what proves the runtime-served v3 instance carries the
+    // shared error map, and that the map does not echo the pattern back at the clinician.
     await expect(instrumentPage.errorMessages).toBeVisible();
+    await expect(instrumentPage.errorMessages).toHaveText('Does not match the expected format');
   });
 });

--- a/testing/src/specs/static-pages.spec.ts
+++ b/testing/src/specs/static-pages.spec.ts
@@ -37,7 +37,14 @@ test.describe('contact', () => {
   test('should require a reason and a message before submitting', async ({ getPageModel, page }) => {
     const contactPage = await getPageModel('/contact');
     await contactPage.submitButton.click();
-    await expect(page.getByText('This field is required')).toBeVisible();
+
+    // Both fields report it: the message textarea, and the reason select — whose unselected value
+    // raises an issue code that used to fall through to zod's untranslated default.
+    const errorMessages = page.getByTestId('error-message-text');
+    await expect(errorMessages.first()).toBeVisible();
+    for (const message of await errorMessages.allTextContents()) {
+      expect(message).toBe('This field is required');
+    }
   });
 
   // The page never renders the contact address as visible text; it only surfaces in the mailto link


### PR DESCRIPTION
## Why

Only two zod issue shapes were localized — a missing value, and an empty string against `min(1)`. Everything else fell through to zod's own English developer copy, which is not written for the clinicians and patients who read it:

| What the user did | What they saw |
| --- | --- |
| Typed `1.5` in an integer field | `Expected integer, received float` |
| Typed a bad postal code | `Invalid` (v3) / `Invalid string: must match pattern /^[A-Z]\d…/` (v4) |
| Entered `12` where `.gte(1).lte(10)` | `Number must be less than or equal to 10` |
| Left an untouched number radio | `Invalid input` — not even the required message |
| Anything in **apps/gateway** | raw English zod defaults, in every language |

`apps/gateway` had no error map at all, so a patient completing a remote assignment saw untranslated zod defaults regardless of the language they picked.

## What changed

The copy now lives in `packages/react-core/src/utils/zodErrorMap.ts`, so both frontends share one table covering every issue code either zod major can produce, in `en`/`fr`/`es`.

zod v4's built-in locales (`z.locales.fr()`) were considered and rejected: they exist only for v4 — 19 of 22 instrument schemas are authored against v3, which has no locale API — and they are a translation of the same developer-facing wording (`Trop petit : number attendu avec >=5`).

- **`MESSAGES` / `COUNTED_MESSAGES`** carry `as const satisfies { … [L in Language]: string }`, so a new interface language fails to compile until every message has one rather than silently falling back to English. The counted table exists because French puts zero in the singular where English and Spanish do not; the form is picked by `Intl.PluralRules`, not by comparing the count to one.
- **v3 and v4 disagree on nearly every issue field name** (`received`/`input`, `type`/`origin`, `invalid_string`/`invalid_format`, `invalid_enum_value`/`invalid_value`). Each major gets a normalizer onto one `FormIssue`, and `describeIssue` writes the copy once — rather than two tables that must be kept in agreement.
- **`createZodErrorMaps` is pure** (no zod instance, no initialized translator), and `localizeZodErrors({ targets, translator })` registers it on the instances a caller names, keeping the `'app'` registration synchronous.
- Nothing echoes a raw value back at the user: the regex message deliberately drops the pattern that v4's default interpolates, and enum members are not listed (instrument enums are opaque codes like `EXISTENTIAL_CRISIS`).

`apps/web/src/services/zod.ts` collapses to a thin adapter; `apps/gateway/src/services/zod.ts` is new and called from `entry-client.tsx` only — its `'runtime'` target dynamically imports a browser URL that does not resolve in node, and nothing is validated during SSR.

## Two bugs fixed along the way

- An untouched `z.union([z.literal(1), …])` number radio reported `Invalid input` instead of the required message, because zod discards the issues raised inside a union. The union case now compares its branches' messages, which have already been through this map — so when they agree it is one failure reported N times.
- `z.set().min(n)` produced a bare `Invalid input` on v3, whose default map has no branch for a set.

## Behaviour worth reviewing

Registering on the app-bundled zod means this reaches the frontends' **own** forms too — every schema fed to a libui `Form`, and everything `packages/schemas` composes — not only instruments. All are improvements (`Invalid URL` → `Must be a valid web address`), but it is a wider blast radius than instruments alone.

Two e2e assertions had to widen as a direct result: a select's unselected value now reports `This field is required` alongside the text field next to it, where it previously fell through to zod's default and so matched a single element. Both were rewritten to the loop-over-all-messages pattern `instrument-completion.spec.ts` already used.

Messages written by a schema author are untouched — both majors skip the error map when an issue already carries one, so every `ctx.issues.push({ code: 'custom', message: t(…) })` and the `blankOr` helper in `apps/web/src/utils/validation.ts` behave exactly as before.

## Testing

- `pnpm lint` — 33/33
- `pnpm test` — 709 passed. 61 of those are new: `apps/web/src/__tests__/zod-error-maps.test.ts` drives the maps through per-parse error maps (no global state), covering every issue kind on both majors plus French and Spanish passes.
- `pnpm test:e2e` — 140 passed, 2 failed. **Both failures are pre-existing**: `gateway-assignment.spec.ts` `@smoke` times out waiting for the assignments table to read `Complete`. Verified by stashing every change and running against a clean tree, where it fails identically — the API's `GatewaySynchronizer` never sweeps the completed assignment. Unrelated to this PR, but worth a separate look.

The issue shapes were confirmed by probing the zod that actually runs, not the vendored types — worth it, because `vendor/zod@3.x` pins declarations older than the zod it resolves: `exact` and a string-format issue's `prefix`/`suffix`/`includes` are emitted but not declared. That is what `V4Issue` is for, and it is documented at the type.

## Docs

`apps/web`, `apps/gateway` and `packages/react-core` `AGENTS.md` all updated. Also corrected a stale claim in `packages/react-core/AGENTS.md`: a keyed translation in the gateway renders as the **empty string**, not "the raw key string" — `t()` logs and returns `''`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)