### PR TITLE
Custom identifier combobox with allowCustomValue flag

### DIFF
--- a/apps/web/src/__tests__/start-session-form.test.tsx
+++ b/apps/web/src/__tests__/start-session-form.test.tsx
@@ -1,0 +1,100 @@
+import { DEFAULT_GROUP_NAME } from '@opendatacapture/schemas/core';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StartSessionForm } from '@/components/StartSessionForm';
+
+import '@/services/i18n';
+
+const onSubmit = vi.fn();
+
+const renderForm = (customSubjectIds: string[]) => {
+  render(
+    <StartSessionForm
+      currentGroup={null}
+      customSubjectIds={customSubjectIds}
+      readOnly={false}
+      username="admin"
+      onSubmit={onSubmit}
+    />
+  );
+  const form = screen.getByTestId('start-session-form');
+  fireEvent.change(form.querySelector('[name="subjectIdentificationMethod"]')!, {
+    target: { value: 'CUSTOM_ID' }
+  });
+  return form;
+};
+
+const identifierInput = () => screen.getByTestId<HTMLInputElement>('subjectId-combobox-input');
+
+/**
+ * Base UI reads `inputType` to tell typing from autofill and only opens the popup for the former,
+ * so `fireEvent.change` — which sets no `inputType` — would leave it closed.
+ */
+const typeIdentifier = (identifier: string) => {
+  fireEvent.input(identifierInput(), { inputType: 'insertText', target: { value: identifier } });
+};
+
+/** A custom value is committed when the popup closes, not on each keystroke. */
+const closeIdentifierPopup = () => {
+  fireEvent.keyDown(identifierInput(), { key: 'Enter' });
+};
+
+const submit = (form: HTMLElement) => {
+  fireEvent.change(form.querySelector('[name="sessionType"]')!, { target: { value: 'IN_PERSON' } });
+  fireEvent.click(screen.getByLabelText('Submit'));
+};
+
+const submittedSubjectId = () => onSubmit.mock.lastCall?.[0].subjectData.id;
+
+beforeEach(() => {
+  // There are no vitest setup files in this repo, so RTL never auto-unmounts between tests.
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('StartSessionForm', () => {
+  // A new subject's identifier is by definition absent from the options, so the combobox has to keep
+  // text matching no option rather than reverting to the empty selection when the popup closes.
+  it('should submit an identifier that matches no existing subject, so a new subject can be enrolled', async () => {
+    const form = renderForm(['alpha']);
+    typeIdentifier('gamma');
+    closeIdentifierPopup();
+    submit(form);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(submittedSubjectId()).toBe(`${DEFAULT_GROUP_NAME}$gamma`);
+  });
+
+  it('should leave an identifier matching no existing subject in the input, so the clinician sees what they typed', () => {
+    renderForm(['alpha']);
+    typeIdentifier('gamma');
+    closeIdentifierPopup();
+    expect(identifierInput().value).toBe('gamma');
+  });
+
+  it('should offer the identifiers already in use as options, so an existing subject can be chosen', () => {
+    renderForm(['alpha']);
+    typeIdentifier('alpha');
+    expect(screen.getByTestId('subjectId-combobox-item-alpha')).toBeTruthy();
+  });
+
+  it('should submit an identifier picked from the options, so a returning subject reuses their own id', async () => {
+    const form = renderForm(['alpha']);
+    typeIdentifier('alpha');
+    fireEvent.click(screen.getByTestId('subjectId-combobox-item-alpha'));
+    submit(form);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(submittedSubjectId()).toBe(`${DEFAULT_GROUP_NAME}$alpha`);
+  });
+
+  // The identifier is scoped by prefixing the group name and a `$`, so one inside the identifier
+  // would make the stored id ambiguous. Validation has to reach a custom value too, not just an option.
+  it('should reject a custom identifier containing the scope separator', async () => {
+    const form = renderForm(['alpha']);
+    typeIdentifier('gam$ma');
+    closeIdentifierPopup();
+    submit(form);
+    await waitFor(() => expect(screen.getByText('Illegal character: $')).toBeTruthy());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.stories.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.stories.tsx
@@ -8,6 +8,7 @@ export default { component: StartSessionForm } as Meta<typeof StartSessionForm>;
 
 export const Default: Story = {
   args: {
+    customSubjectIds: ['SUBJECT_001', 'SUBJECT_002', 'SUBJECT_003'],
     onSubmit(data) {
       alert(JSON.stringify(data, null, 2));
     }

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -30,6 +30,7 @@ type StartSessionFormData = {
 
 type StartSessionFormProps = {
   currentGroup: Group | null;
+  customSubjectIds: string[];
   initialValues?: FormTypes.PartialNullableData<StartSessionFormData>;
   onSubmit: (data: CreateSessionData) => Promisable<void>;
   readOnly: boolean;
@@ -38,6 +39,7 @@ type StartSessionFormProps = {
 
 export const StartSessionForm = ({
   currentGroup,
+  customSubjectIds,
   username,
   initialValues,
   readOnly,
@@ -80,7 +82,8 @@ export const StartSessionForm = ({
                   ? {
                       kind: 'string',
                       label: t('common.identifier'),
-                      variant: 'input'
+                      variant: 'combobox',
+                      options: Object.fromEntries(customSubjectIds.map((id) => [id, id]))
                     }
                   : null;
               }

--- a/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
+++ b/apps/web/src/components/StartSessionForm/StartSessionForm.tsx
@@ -83,6 +83,7 @@ export const StartSessionForm = ({
                       kind: 'string',
                       label: t('common.identifier'),
                       variant: 'combobox',
+                      allowCustomValue: true,
                       options: Object.fromEntries(customSubjectIds.map((id) => [id, id]))
                     }
                   : null;

--- a/apps/web/src/routes/_app/session/start-session.tsx
+++ b/apps/web/src/routes/_app/session/start-session.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Card, Heading } from '@douglasneuroinformatics/libui/components';
 import { useTranslation } from '@douglasneuroinformatics/libui/hooks';
 import type { FormTypes } from '@opendatacapture/runtime-core';
+import { isSubjectWithPersonalInfo, removeSubjectIdScope } from '@opendatacapture/subject-utils';
 import { createFileRoute, useLocation } from '@tanstack/react-router';
 import { AnimatePresence, motion } from 'motion/react';
 
@@ -10,6 +11,7 @@ import { PageHeader } from '@/components/PageHeader';
 import { StartSessionForm } from '@/components/StartSessionForm';
 import type { StartSessionFormData } from '@/components/StartSessionForm';
 import { useCreateSessionMutation } from '@/hooks/useCreateSessionMutation';
+import { subjectsQueryOptions, useSubjectsQuery } from '@/hooks/useSubjectsQuery';
 import { useAppStore } from '@/store';
 
 const RouteComponent = () => {
@@ -28,6 +30,11 @@ const RouteComponent = () => {
 
   const { t } = useTranslation('session');
   const createSessionMutation = useCreateSessionMutation();
+  const subjectsQuery = useSubjectsQuery({ params: { groupId: currentGroup?.id } });
+
+  const customSubjectIds = subjectsQuery.data
+    .filter((subject) => !isSubjectWithPersonalInfo(subject))
+    .map((subject) => removeSubjectIdScope(subject.id));
 
   useEffect(() => {
     if (currentSession === null) {
@@ -45,6 +52,7 @@ const RouteComponent = () => {
       {currentSession === null && (
         <StartSessionForm
           currentGroup={currentGroup}
+          customSubjectIds={customSubjectIds}
           initialValues={initialValues}
           readOnly={currentSession !== null || createSessionMutation.isPending}
           username={currentUser?.username}
@@ -110,5 +118,9 @@ const RouteComponent = () => {
 };
 
 export const Route = createFileRoute('/_app/session/start-session')({
-  component: RouteComponent
+  component: RouteComponent,
+  loader: async ({ context }) => {
+    const { currentGroup } = useAppStore.getState();
+    await context.queryClient.ensureQueryData(subjectsQueryOptions({ params: { groupId: currentGroup?.id } }));
+  }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,11 +25,11 @@ catalogs:
       specifier: ^0.2.1
       version: 0.2.1
     '@douglasneuroinformatics/libui':
-      specifier: ^6.14.0
-      version: 6.14.0
+      specifier: ^6.16.0
+      version: 6.16.0
     '@douglasneuroinformatics/libui-form-types':
-      specifier: ^1.3.0
-      version: 1.3.0
+      specifier: ^1.4.0
+      version: 1.4.0
     '@microsoft/api-extractor':
       specifier: ^7.47.6
       version: 7.58.7
@@ -386,7 +386,7 @@ importers:
         version: 0.0.6
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@opendatacapture/react-core':
         specifier: workspace:*
         version: link:../../packages/react-core
@@ -486,7 +486,7 @@ importers:
     dependencies:
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
       '@opendatacapture/licenses':
         specifier: workspace:*
         version: link:../../packages/licenses
@@ -571,7 +571,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
@@ -698,7 +698,7 @@ importers:
         version: 0.0.3(typescript@6.0.3)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@vendor+react@19.x)
@@ -992,7 +992,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@opendatacapture/instrument-bundler':
         specifier: workspace:*
         version: link:../instrument-bundler
@@ -1107,7 +1107,7 @@ importers:
     dependencies:
       '@douglasneuroinformatics/libui-form-types':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.4.0
       '@opendatacapture/licenses':
         specifier: workspace:*
         version: link:../licenses
@@ -1183,7 +1183,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@opendatacapture/instrument-bundler':
         specifier: 'workspace:'
         version: link:../instrument-bundler
@@ -1396,7 +1396,7 @@ importers:
     devDependencies:
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
+        version: 6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
       '@opendatacapture/instrument-stubs':
         specifier: workspace:*
         version: link:../packages/instrument-stubs
@@ -2230,24 +2230,16 @@ packages:
     resolution: {integrity: sha512-weXJgsNBdz26ldMMEh20Cn9EtR+ynn3O9v81ZEWnfBmzZmFxSlUxnevLlncJxbVM6s6SgH97C4B/L8AdGvlCxA==}
     engines: {node: '>=20'}
 
-  '@douglasneuroinformatics/libui-form-types@1.1.0':
-    resolution: {integrity: sha512-Jnc04kQArUK6tMcv7+snOymj3YwwLaahwXpsDKCqOm/nS/ki0O6sbSyVZvh2VoN3aC0cYefEehSs5Hb+h/K/vA==}
+  '@douglasneuroinformatics/libui-form-types@1.4.0':
+    resolution: {integrity: sha512-XspWaw0fAXqn6Mm6CHm3mAlV/4H7sKo2dSZYiZFsFGR8x47Mu1Rgd8EZ8tv07UBx6a8vRxzIbqbrqU3htIcv4Q==}
     peerDependencies:
       '@types/react': '*'
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@douglasneuroinformatics/libui-form-types@1.3.0':
-    resolution: {integrity: sha512-F+q2MVGET3vw8/pg2gYFoa9wtBhFxxE/oLdjIl98RYGc7iSt6D0izTHuSWIcfJNcZPluGM9KkykVF1fYR2sVyg==}
-    peerDependencies:
-      '@types/react': '*'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@douglasneuroinformatics/libui@6.14.0':
-    resolution: {integrity: sha512-17z7FQnxEVq8Su+aTXlyTqkkam3Lbe094Tr5tb+8AQ3l22sfFAgvOlwddYVXxvtnkEEalUPtIafPi4PVvA6G4g==}
+  '@douglasneuroinformatics/libui@6.16.0':
+    resolution: {integrity: sha512-37WOjyN+t2WIrET7bvRuikPbbL84j1QsH4B43AlJ/ftLvr/AsXDPGW6NGti7sdJuOcmaixXJFYbivnOS2yOCGg==}
     engines: {node: 24.x}
     peerDependencies:
       react: ^19.1.0
@@ -11996,19 +11988,15 @@ snapshots:
       '@douglasneuroinformatics/libstats-win32-arm64-msvc': 0.2.1
       '@douglasneuroinformatics/libstats-win32-x64-msvc': 0.2.1
 
-  '@douglasneuroinformatics/libui-form-types@1.1.0':
+  '@douglasneuroinformatics/libui-form-types@1.4.0':
     dependencies:
       type-fest: 4.41.0
 
-  '@douglasneuroinformatics/libui-form-types@1.3.0':
-    dependencies:
-      type-fest: 4.41.0
-
-  '@douglasneuroinformatics/libui@6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)':
+  '@douglasneuroinformatics/libui@6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)':
     dependencies:
       '@base-ui/react': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@douglasneuroinformatics/libjs': 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
-      '@douglasneuroinformatics/libui-form-types': 1.1.0
+      '@douglasneuroinformatics/libui-form-types': 1.4.0
       '@radix-ui/react-accordion': 1.2.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-alert-dialog': 1.1.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar': 1.1.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12061,11 +12049,11 @@ snapshots:
       - neverthrow
       - use-sync-external-store
 
-  '@douglasneuroinformatics/libui@6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)':
+  '@douglasneuroinformatics/libui@6.16.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)':
     dependencies:
       '@base-ui/react': 1.6.0(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       '@douglasneuroinformatics/libjs': 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
-      '@douglasneuroinformatics/libui-form-types': 1.1.0
+      '@douglasneuroinformatics/libui-form-types': 1.4.0
       '@radix-ui/react-accordion': 1.2.12(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       '@radix-ui/react-alert-dialog': 1.1.15(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       '@radix-ui/react-avatar': 1.1.11(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,11 +25,11 @@ catalogs:
       specifier: ^0.2.1
       version: 0.2.1
     '@douglasneuroinformatics/libui':
-      specifier: ^6.11.2
-      version: 6.11.2
+      specifier: ^6.14.0
+      version: 6.14.0
     '@douglasneuroinformatics/libui-form-types':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^1.3.0
+      version: 1.3.0
     '@microsoft/api-extractor':
       specifier: ^7.47.6
       version: 7.58.7
@@ -386,7 +386,7 @@ importers:
         version: 0.0.6
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@opendatacapture/react-core':
         specifier: workspace:*
         version: link:../../packages/react-core
@@ -486,7 +486,7 @@ importers:
     dependencies:
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
       '@opendatacapture/licenses':
         specifier: workspace:*
         version: link:../../packages/licenses
@@ -571,7 +571,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
@@ -698,7 +698,7 @@ importers:
         version: 0.0.3(typescript@6.0.3)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@vendor+react@19.x)
@@ -992,7 +992,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@opendatacapture/instrument-bundler':
         specifier: workspace:*
         version: link:../instrument-bundler
@@ -1107,7 +1107,7 @@ importers:
     dependencies:
       '@douglasneuroinformatics/libui-form-types':
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 1.3.0
       '@opendatacapture/licenses':
         specifier: workspace:*
         version: link:../licenses
@@ -1183,7 +1183,7 @@ importers:
         version: 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)
       '@opendatacapture/instrument-bundler':
         specifier: 'workspace:'
         version: link:../instrument-bundler
@@ -1396,7 +1396,7 @@ importers:
     devDependencies:
       '@douglasneuroinformatics/libui':
         specifier: 'catalog:'
-        version: 6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
+        version: 6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)
       '@opendatacapture/instrument-stubs':
         specifier: workspace:*
         version: link:../packages/instrument-stubs
@@ -2238,8 +2238,16 @@ packages:
       '@types/react':
         optional: true
 
-  '@douglasneuroinformatics/libui@6.11.2':
-    resolution: {integrity: sha512-sLPNCaCWbmP2N8DM8NXH2bPNSikjnThNPuILvGqy0NlNjAsTSuaHa198vHQHYbE6nVEO3N7lwRjyreM35O1lsw==}
+  '@douglasneuroinformatics/libui-form-types@1.3.0':
+    resolution: {integrity: sha512-F+q2MVGET3vw8/pg2gYFoa9wtBhFxxE/oLdjIl98RYGc7iSt6D0izTHuSWIcfJNcZPluGM9KkykVF1fYR2sVyg==}
+    peerDependencies:
+      '@types/react': '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@douglasneuroinformatics/libui@6.14.0':
+    resolution: {integrity: sha512-17z7FQnxEVq8Su+aTXlyTqkkam3Lbe094Tr5tb+8AQ3l22sfFAgvOlwddYVXxvtnkEEalUPtIafPi4PVvA6G4g==}
     engines: {node: 24.x}
     peerDependencies:
       react: ^19.1.0
@@ -11992,7 +12000,11 @@ snapshots:
     dependencies:
       type-fest: 4.41.0
 
-  '@douglasneuroinformatics/libui@6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)':
+  '@douglasneuroinformatics/libui-form-types@1.3.0':
+    dependencies:
+      type-fest: 4.41.0
+
+  '@douglasneuroinformatics/libui@6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@19.1.0))(zod@vendor+zod@3.x)':
     dependencies:
       '@base-ui/react': 1.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@douglasneuroinformatics/libjs': 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)
@@ -12049,7 +12061,7 @@ snapshots:
       - neverthrow
       - use-sync-external-store
 
-  '@douglasneuroinformatics/libui@6.11.2(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)':
+  '@douglasneuroinformatics/libui@6.14.0(immer@10.2.0)(neverthrow@8.2.0)(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)(tailwindcss@4.3.0)(use-sync-external-store@1.6.0(react@vendor+react@19.x))(zod@vendor+zod@3.x)':
     dependencies:
       '@base-ui/react': 1.6.0(react-dom@vendor+react-dom@19.x)(react@vendor+react@19.x)
       '@douglasneuroinformatics/libjs': 3.2.1(neverthrow@8.2.0)(zod@vendor+zod@3.x)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,8 +22,8 @@ catalog:
   '@douglasneuroinformatics/libjs': ^3.2.1
   '@douglasneuroinformatics/libpasswd': '^0.0.3'
   '@douglasneuroinformatics/libstats': '^0.2.1'
-  '@douglasneuroinformatics/libui': ^6.14.0
-  '@douglasneuroinformatics/libui-form-types': ^1.3.0
+  '@douglasneuroinformatics/libui': ^6.16.0
+  '@douglasneuroinformatics/libui-form-types': ^1.4.0
   '@microsoft/api-extractor': '^7.47.6'
   '@prisma/client': '^6.9.0'
   '@tailwindcss/vite': '4.3.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,8 +22,8 @@ catalog:
   '@douglasneuroinformatics/libjs': ^3.2.1
   '@douglasneuroinformatics/libpasswd': '^0.0.3'
   '@douglasneuroinformatics/libstats': '^0.2.1'
-  '@douglasneuroinformatics/libui': ^6.11.2
-  '@douglasneuroinformatics/libui-form-types': ^1.1.0
+  '@douglasneuroinformatics/libui': ^6.14.0
+  '@douglasneuroinformatics/libui-form-types': ^1.3.0
   '@microsoft/api-extractor': '^7.47.6'
   '@prisma/client': '^6.9.0'
   '@tailwindcss/vite': '4.3.0'

--- a/testing/src/pages/_app/session/start-session.page.ts
+++ b/testing/src/pages/_app/session/start-session.page.ts
@@ -3,6 +3,7 @@ import type { Locator, Page } from '@playwright/test';
 import { AppPage } from '../route.page';
 
 export class StartSessionPage extends AppPage {
+  readonly endSessionButton: Locator;
   readonly errorMessages: Locator;
   readonly pageHeader: Locator;
   readonly selectField: Locator;
@@ -18,17 +19,32 @@ export class StartSessionPage extends AppPage {
     this.successMessage = page.getByRole('heading', { name: 'Session Successfully Started' });
     this.errorMessages = page.getByTestId('error-message-text');
     this.subjectIdField = this.sessionForm.locator('[name="subjectId"]');
+    // The end session nav item opens a dialog rather than navigating, so it carries no route.
+    this.endSessionButton = page.getByTestId('nav-button-#');
+  }
+
+  /** Clicks outside the identifier combobox, which closes its popup and commits what was typed. */
+  async dismissSubjectIdOptions() {
+    await this.pageHeader.click();
+  }
+
+  async endSession() {
+    await this.endSessionButton.click();
+    await this.$ref.getByRole('button', { name: 'Yes' }).click();
+    await this.sessionForm.waitFor({ state: 'visible' });
   }
 
   async fillCustomIdentifier(customIdentifier: string, sex: string) {
-    const subjectIdField = this.sessionForm.locator('[name="subjectId"]');
+    await this.typeSubjectId(customIdentifier);
+    await this.fillSessionDetails(sex);
+  }
+
+  /** Everything the form needs beyond how the subject was identified. */
+  async fillSessionDetails(sex: string) {
     const dateOfBirthField = this.sessionForm.locator('[name="subjectDateOfBirth"]');
     const sexSelector = this.sessionForm.locator('[name="subjectSex"]');
     const sessionTypeSelector = this.sessionForm.locator('[name="sessionType"]');
     const sessionDate = this.sessionForm.locator('[name="sessionDate"]');
-
-    await subjectIdField.waitFor({ state: 'visible' });
-    await subjectIdField.fill(customIdentifier);
 
     await dateOfBirthField.waitFor({ state: 'visible' });
     await dateOfBirthField.fill('1990-01-01');
@@ -45,10 +61,6 @@ export class StartSessionPage extends AppPage {
   async fillSessionForm(firstName: string, lastName: string, sex: string) {
     const firstNameField = this.sessionForm.locator('[name="subjectFirstName"]');
     const lastNameField = this.sessionForm.locator('[name="subjectLastName"]');
-    const dateOfBirthField = this.sessionForm.locator('[name="subjectDateOfBirth"]');
-    const sexSelector = this.sessionForm.locator('[name="subjectSex"]');
-    const sessionTypeSelector = this.sessionForm.locator('[name="sessionType"]');
-    const sessionDate = this.sessionForm.locator('[name="sessionDate"]');
 
     await firstNameField.waitFor({ state: 'visible' });
     await firstNameField.fill(firstName);
@@ -56,20 +68,16 @@ export class StartSessionPage extends AppPage {
     await lastNameField.waitFor({ state: 'visible' });
     await lastNameField.fill(lastName);
 
-    await dateOfBirthField.waitFor({ state: 'visible' });
-    await dateOfBirthField.fill('1990-01-01');
-
-    await sexSelector.selectOption(sex);
-
-    await sessionTypeSelector.selectOption('Retrospective');
-
-    await sessionDate.waitFor({ state: 'visible' });
-    const expectedSessionDate = new Date().toISOString().split('T')[0]!;
-    await sessionDate.fill(expectedSessionDate);
+    await this.fillSessionDetails(sex);
   }
 
   async selectIdentificationMethod(methodName: string) {
     await this.selectField.selectOption(methodName);
+  }
+
+  /** An identifier already in use by a subject in the current group, offered in the popup. */
+  subjectIdOption(identifier: string) {
+    return this.$ref.getByTestId(`subjectId-combobox-item-${identifier}`);
   }
 
   async submitForm() {
@@ -78,5 +86,11 @@ export class StartSessionPage extends AppPage {
     await submitButton.waitFor({ state: 'visible' });
 
     await submitButton.click();
+  }
+
+  /** Types into the identifier combobox, leaving the options popup open. */
+  async typeSubjectId(identifier: string) {
+    await this.subjectIdField.waitFor({ state: 'visible' });
+    await this.subjectIdField.fill(identifier);
   }
 }

--- a/testing/src/specs/start-session.spec.ts
+++ b/testing/src/specs/start-session.spec.ts
@@ -30,6 +30,56 @@ test.describe('start session', () => {
     await expect(startSessionPage.successMessage).toBeVisible();
   });
 
+  // The identifier combobox offers the subjects already enrolled in the group, so a brand new
+  // subject's identifier necessarily matches no option. Clicking away used to discard it.
+  test('should keep a custom identifier matching no existing subject when the options popup is dismissed', async ({
+    getPageModel,
+    uniqueId
+  }) => {
+    const startSessionPage = await getPageModel('/session/start-session');
+    await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+
+    await startSessionPage.selectIdentificationMethod('CUSTOM_ID');
+    await startSessionPage.typeSubjectId(`unmatched-${uniqueId}`);
+    await startSessionPage.dismissSubjectIdOptions();
+
+    await expect(startSessionPage.subjectIdField).toHaveValue(`unmatched-${uniqueId}`);
+
+    await startSessionPage.fillSessionDetails('Male');
+    await startSessionPage.submitForm();
+    await expect(startSessionPage.successMessage).toBeVisible();
+  });
+
+  test('should start a session for a subject chosen from the existing custom identifiers', async ({
+    getPageModel,
+    page,
+    uniqueId
+  }) => {
+    const identifier = `returning-${uniqueId}`;
+    const startSessionPage = await getPageModel('/session/start-session');
+    await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+
+    await startSessionPage.selectIdentificationMethod('CUSTOM_ID');
+    await startSessionPage.fillCustomIdentifier(identifier, 'Male');
+    await startSessionPage.submitForm();
+    await expect(startSessionPage.successMessage).toBeVisible();
+
+    // The subject only becomes an option once it exists, and the options are read by the route
+    // loader, so the second visit has to be a fresh load rather than a client-side navigation.
+    await startSessionPage.endSession();
+    await page.reload();
+    await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+
+    await startSessionPage.selectIdentificationMethod('CUSTOM_ID');
+    await startSessionPage.typeSubjectId(identifier);
+    await startSessionPage.subjectIdOption(identifier).click();
+    await expect(startSessionPage.subjectIdField).toHaveValue(identifier);
+
+    await startSessionPage.fillSessionDetails('Male');
+    await startSessionPage.submitForm();
+    await expect(startSessionPage.successMessage).toBeVisible();
+  });
+
   test('should show a required-field error for every missing field when submitting the personal information form empty', async ({
     getPageModel
   }) => {


### PR DESCRIPTION
## Suggest existing custom identifiers on the Start Session form

The identifier field for the `CUSTOM_ID` identification method was a free-text input, so a
clinician re-enrolling an existing subject had to remember and retype that subject's identifier
exactly, with a typo silently creating a second subject.

This turns that field into a combobox that suggests the custom identifiers already in use in the
current group, while still accepting a brand new identifier typed in full.

### Changes

**`apps/web/src/routes/_app/session/start-session.tsx`**
- Adds a `loader` that prefetches `subjectsQueryOptions({ params: { groupId } })` into React Query,
  and a matching `useSubjectsQuery` in the component, per the repo's data-hook convention (loader
  and component share one key).
- Derives `customSubjectIds` from that data: subjects with no personal info, with the group scope
  prefix stripped via `removeSubjectIdScope`.

**`apps/web/src/components/StartSessionForm/StartSessionForm.tsx`**
- New required `customSubjectIds: string[]` prop.
- The `subjectId` field goes from `variant: 'input'` to `variant: 'combobox'` with
  `allowCustomValue: true` and `options` built from `customSubjectIds`.

**`pnpm-workspace.yaml`** — catalog bumps that this feature requires:

| Package | From | To |
| --- | --- | --- |
| `@douglasneuroinformatics/libui` | `^6.11.2` | `^6.14.0` |
| `@douglasneuroinformatics/libui-form-types` | `^1.1.0` | `^1.3.0` |

`allowCustomValue` does not exist before these versions. On the older ones the flag is silently
ignored, and Base UI's combobox reverts the input text to the selected item whenever the popup
closes — so a newly typed identifier was wiped the moment the clinician clicked away. `1.3.0` also
carries a TSDoc fix (`@default` → `@defaultValue`) without which API Extractor fails
`@opendatacapture/runtime-core`'s build, since that package inlines `libui-form-types` via
`bundledPackages`.

**Storybook** — the `Default` story now passes sample identifiers so the dropdown is exercised.

### Tests

**Unit** — `apps/web/src/__tests__/start-session-form.test.tsx` (new, 5 tests): submits an
identifier matching no existing subject; leaves that text visible in the input; offers in-use
identifiers as options; submits an identifier picked from the options; still rejects a custom
identifier containing the `$` scope separator.

**E2E** — `testing/src/specs/start-session.spec.ts` (2 new tests): keeps a custom identifier when
the options popup is dismissed by clicking away (the exact regression), and starts a session for a
subject chosen from the existing identifiers. `start-session.page.ts` gains `typeSubjectId`,
`dismissSubjectIdOptions`, `subjectIdOption` and `endSession`, and its two fill helpers now share a
common `fillSessionDetails` rather than duplicating it.

Both tiers were confirmed collected, then watched to fail on purpose with `allowCustomValue` set to
`false`: 3 of 5 unit tests and 5 e2e tests go red — notably including three e2e tests that predate
this branch, since the combobox change makes them depend on the flag.

### Verification

| Gate | Result |
| --- | --- |
| `pnpm lint` | 33/33 |
| `pnpm test` | 83 files, 731 passed, 1 skipped |
| `pnpm test:e2e` | 147/147 |

### Known limitation

`libui@6.14.0` declares `libui-form-types@^1.1.0` and resolves its own copy, so the `Form` content
type in `apps/web` does not include the new combobox member. `allowCustomValue` is therefore
accepted as an unchecked excess property at the call site — a typo in the flag name compiles clean
and would silently disable the feature. The unit and e2e tests above are currently the only guard.
Deduping `libui-form-types` to a single version would close this; left out of scope here.

Closes issue #1216 

code helped with claude Opus 5