### PR TITLE
fix(api): mint the granular instrument token with the action its route requires

### DIFF
--- a/apps/api/src/auth/__tests__/auth.service.spec.ts
+++ b/apps/api/src/auth/__tests__/auth.service.spec.ts
@@ -1,0 +1,83 @@
+import { CryptoService, LoggingService } from '@douglasneuroinformatics/libnest';
+import type { RequestUser } from '@douglasneuroinformatics/libnest';
+import { MockFactory } from '@douglasneuroinformatics/libnest/testing';
+import type { MockedInstance } from '@douglasneuroinformatics/libnest/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AuditLogger } from '@/audit/audit.logger';
+import { UsersService } from '@/users/users.service';
+
+import { AbilityFactory } from '../ability.factory.js';
+import { createAppAbility } from '../ability.utils.js';
+import { AuthService } from '../auth.service.js';
+
+import type { Permission } from '../auth.types.js';
+
+/** The base payload `login` signs, minus the permission level each test supplies. */
+const BASE_PAYLOAD = {
+  additionalPermissions: undefined,
+  firstName: 'Test',
+  groups: [{ id: 'group-1' }],
+  id: 'user-1',
+  lastName: 'User',
+  username: 'test-user'
+};
+
+describe('AuthService', () => {
+  let abilityFactory: AbilityFactory;
+  let authService: AuthService;
+  let jwtService: MockedInstance<JwtService>;
+
+  const requestUserFor = (basePermissionLevel: 'ADMIN' | 'GROUP_MANAGER' | 'STANDARD'): RequestUser => {
+    const ability = abilityFactory.createForPayload({ ...BASE_PAYLOAD, basePermissionLevel } as any);
+    return { ...BASE_PAYLOAD, ability, basePermissionLevel } as unknown as RequestUser;
+  };
+
+  /** The permissions the minted token actually carries, read back off the signed payload. */
+  const mintedPermissions = async (currentUser: RequestUser): Promise<Permission[]> => {
+    await authService.getCreateInstrumentToken(currentUser);
+    return (jwtService.signAsync.mock.lastCall?.[0] as { permissions: Permission[] }).permissions;
+  };
+
+  beforeEach(() => {
+    abilityFactory = new AbilityFactory(MockFactory.createMock(LoggingService) as unknown as LoggingService);
+    jwtService = MockFactory.createMock(JwtService);
+    jwtService.signAsync.mockResolvedValue('__TOKEN__');
+    authService = new AuthService(
+      abilityFactory,
+      MockFactory.createMock(AuditLogger) as unknown as AuditLogger,
+      MockFactory.createMock(CryptoService) as unknown as CryptoService,
+      jwtService as unknown as JwtService,
+      MockFactory.createMock(UsersService) as unknown as UsersService
+    );
+  });
+
+  describe('getCreateInstrumentToken', () => {
+    it('should mint a token that satisfies the instrument create route, so the playground can upload a bundle', async () => {
+      const ability = createAppAbility(await mintedPermissions(requestUserFor('ADMIN')));
+      expect(ability.can('manage', 'Instrument')).toBe(true);
+    });
+
+    it('should mint a token that grants nothing beyond instruments, since it travels outside the app', async () => {
+      const ability = createAppAbility(await mintedPermissions(requestUserFor('ADMIN')));
+      expect(ability.can('manage', 'all')).toBe(false);
+      expect(ability.can('read', 'Subject')).toBe(false);
+      expect(ability.can('read', 'InstrumentRecord')).toBe(false);
+    });
+
+    it('should refuse a group manager, whose create grant covers series instruments rather than arbitrary bundles', async () => {
+      await expect(authService.getCreateInstrumentToken(requestUserFor('GROUP_MANAGER'))).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(jwtService.signAsync).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a standard user, who may not create instruments at all', async () => {
+      await expect(authService.getCreateInstrumentToken(requestUserFor('STANDARD'))).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+  });
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -15,7 +15,7 @@ export class AuthController {
 
   @Get('create-instrument-token')
   @HttpCode(HttpStatus.OK)
-  @RouteAccess({ action: 'create', subject: 'Instrument' })
+  @RouteAccess({ action: 'manage', subject: 'Instrument' })
   @ThrottleLoginRequest()
   async getCreateInstrumentToken(@CurrentUser() currentUser: RequestUser): Promise<{ accessToken: string }> {
     return this.authService.getCreateInstrumentToken(currentUser);

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -20,12 +20,15 @@ export class AuthService {
     private readonly usersService: UsersService
   ) {}
 
+  // Scoped to `manage` rather than `create` because that is what `POST /instruments` requires. A
+  // narrower token would buy nothing: an uploaded bundle is evaluated server-side, so whoever may
+  // create an instrument can already run code here.
   async getCreateInstrumentToken(currentUser: RequestUser) {
-    if (!currentUser.ability.can('create', 'Instrument')) {
+    if (!currentUser.ability.can('manage', 'Instrument')) {
       throw new ForbiddenException();
     }
 
-    const limitedAbility = this.abilityFactory.createForPermissions([{ action: 'create', subject: 'Instrument' }]);
+    const limitedAbility = this.abilityFactory.createForPermissions([{ action: 'manage', subject: 'Instrument' }]);
 
     return {
       accessToken: await this.jwtService.signAsync({ permissions: limitedAbility.rules }, { expiresIn: '1h' })

--- a/apps/playground/AGENTS.md
+++ b/apps/playground/AGENTS.md
@@ -87,6 +87,12 @@ The playground has no backend and no baked-in API URL, but it is not offline-onl
 `/v1/auth/create-instrument-token`, `/v1/instruments`) with a raw `axios` call and a bearer token held
 in the store. There is no shared axios instance and no React Query here.
 
+The token `/v1/auth/create-instrument-token` mints is scoped to `manage Instrument`, which is what
+`POST /v1/instruments` requires — the two actions must stay in step, and this dialog is that route's
+only caller, so tightening it silently breaks upload here and nowhere else (#1392). It is scoped no
+narrower because a bundle is evaluated server-side: whoever may create an instrument can already run
+code on the API. `testing/src/specs/authorization.spec.ts` pins the contract.
+
 Share links come from `@opendatacapture/playground-url`, which lz-string-compresses file contents into
 a query parameter. Its `$EditorFile` requires `content` to be a UTF-8 string, so binary assets do not
 survive a share URL.

--- a/apps/playground/src/components/Header/ActionsDropdown/LoginDialog.tsx
+++ b/apps/playground/src/components/Header/ActionsDropdown/LoginDialog.tsx
@@ -122,8 +122,8 @@ export const LoginDialog = ({ isOpen, setIsOpen }: LoginDialogProps) => {
           <Dialog.Title>{t({ en: 'Login', fr: 'Connexion' })}</Dialog.Title>
           <Dialog.Description>
             {t({
-              en: 'Login to your Open Data Capture instance. A special access token is used that grants permissions to create instruments only. You must have permission to create instruments to use this functionality.',
-              fr: "Connectez-vous à votre instance Open Data Capture. Un jeton d'accès spécial est utilisé pour accorder l'autorisation de créer uniquement des instruments. Vous devez avoir la permission de créer des instruments pour utiliser cette fonctionnalité."
+              en: 'Login to your Open Data Capture instance. A special access token is used that grants permissions over instruments only. You must have permission to manage instruments to use this functionality.',
+              fr: "Connectez-vous à votre instance Open Data Capture. Un jeton d'accès spécial est utilisé pour accorder des autorisations portant uniquement sur les instruments. Vous devez avoir la permission de gérer les instruments pour utiliser cette fonctionnalité."
             })}
           </Dialog.Description>
           <div className="mt-2 flex items-center gap-1 text-sm font-medium">

--- a/testing/src/specs/authorization.spec.ts
+++ b/testing/src/specs/authorization.spec.ts
@@ -233,6 +233,15 @@ test.describe('authorization', () => {
   });
 });
 
+/** A real, already-interpretable bundle: the first seeded instrument's own compiled source. */
+async function readSeededBundle(request: APIRequestContext, token: string): Promise<string> {
+  const headers = { Authorization: `Bearer ${token}` };
+  const [instrument] = (await (await request.get(`${API}/instruments/info`, { headers })).json()) as { id: string }[];
+  const container = await request.get(`${API}/instruments/bundle/${instrument!.id}`, { headers });
+  expect(container.ok()).toBe(true);
+  return ((await container.json()) as { bundle: string }).bundle;
+}
+
 /** The user list `/admin/users` renders, read with the given user's own token. */
 async function readUsernames(request: APIRequestContext, token: string): Promise<string[]> {
   const response = await request.get(`${API}/users`, { headers: { Authorization: `Bearer ${token}` } });
@@ -264,6 +273,46 @@ test.describe('server-side authorization', () => {
       }
     });
   }
+
+  // The playground uploads a bundle with a token minted by `GET /auth/create-instrument-token`, and
+  // that token is the only non-interactive caller of `POST /instruments`. Nothing else in the suite
+  // exercises it, which is how #1392 severed the two: the route moved to `manage Instrument` while
+  // the token still carried `create`, and every upload answered 403.
+  test.describe('granular instrument token', () => {
+    test('should let an administrator mint a token their own bundle upload is accepted with', async ({
+      adminToken,
+      apiRequestContext
+    }) => {
+      const minted = await apiRequestContext.get(`${API}/auth/create-instrument-token`, {
+        headers: { Authorization: `Bearer ${adminToken}` }
+      });
+      expect(minted.status()).toBe(200);
+      const { accessToken } = (await minted.json()) as { accessToken: string };
+
+      // Re-posting a seeded instrument's own bundle. The conflict is the point: reaching the
+      // duplicate check means the guard admitted the token and the bundle was really interpreted
+      // and validated server-side, which a 403 would have cut short.
+      const response = await apiRequestContext.post(`${API}/instruments`, {
+        data: { bundle: await readSeededBundle(apiRequestContext, adminToken) },
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+
+      expect(response.status(), 'a minted token must be accepted by the instrument create route').toBe(409);
+    });
+
+    test('should not mint a token for a group manager, whose create grant is for series instruments', async ({
+      apiRequestContext,
+      roleAccount
+    }) => {
+      const { accessToken } = await roleAccount('GROUP_MANAGER');
+
+      const response = await apiRequestContext.get(`${API}/auth/create-instrument-token`, {
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+
+      expect(response.status()).toBe(403);
+    });
+  });
 
   // A group manager holds `manage Group` for their own groups, and `@RouteAccess` sees only the
   // subject type, so the guard lets these through and the row scoping in `GroupsService` is the


### PR DESCRIPTION
## The issue

Creating an instrument by uploading a bundle from the playground returns **403 Forbidden**. Reproducible on localhost against a local API, with an administrator account.

The playground never uploads with the user's own token. `LoginDialog` logs in, then immediately exchanges that token for a deliberately narrow one:

1. `POST /v1/auth/login` → the user's full token
2. `GET /v1/auth/create-instrument-token` → a **granular** token
3. `POST /v1/instruments` with the granular token

`AuthService.getCreateInstrumentToken` minted that token with exactly one rule, `{ action: 'create', subject: 'Instrument' }`.

## Where it was introduced, and why

`a55d8b703` ("Tighten series creation permissions"), which landed on main in #1392:

```diff
  @Post()
- @RouteAccess({ action: 'create', subject: 'Instrument' })
+ @RouteAccess({ action: 'manage', subject: 'Instrument' })
```

`manage` is CASL's wildcard action, so a rule granting `create` does not satisfy `can('manage', 'Instrument')`. The guard returns false and Nest answers 403.

**That change was correct on its own terms.** #1392 granted `create Instrument` to `GROUP_MANAGER` so group managers could assemble series instruments. Review flagged that the new grant also authorized them to `POST /v1/instruments` with an arbitrary bundle — and bundles are evaluated server-side, so that is code execution on the API. Moving the general create route to `manage` closed that escalation, and the commit pinned the intent in `ability.factory.test.ts`:

```ts
expect(ability.can('create', 'Instrument')).toBe(true);
expect(ability.can('manage', 'Instrument')).toBe(false);
```

What it missed is that `create Instrument` was already load-bearing elsewhere. It was the exact permission the granular token carries, and that token is the route's only non-interactive caller. Nothing else in the repo posts to `POST /v1/instruments`, and no test covered it, so the route moved, the token did not, and the break was silent everywhere except the playground.

## The fix

Mint and gate the granular token on `manage Instrument`, so it matches what the route requires.

Scoping it narrower buys nothing: an uploaded bundle is evaluated server-side, so whoever may create an instrument can already run code on the API — the narrower token was protecting a boundary that does not exist. The escalation #1392 closed stays closed, because a group manager holds `create` and not `manage`; they are now refused at the token endpoint rather than one request later, which is also a clearer failure.

`@RouteAccess` on `create-instrument-token` moves to `manage` for the same reason, so the guard and the service agree.

Two smaller things in the same change:

- The login dialog still told the user the token "grants permissions to create instruments only" and that create permission was required. Both are now false; corrected in `en` and `fr`.
- `apps/playground/AGENTS.md` listed the three endpoints the playground calls but not the contract between them. It now records that the minted action and the route's `@RouteAccess` must stay in step, and that this dialog is the route's only caller.

## Tests

**Unit** — new `apps/api/src/auth/__tests__/auth.service.spec.ts`: the minted token satisfies the create route, it grants nothing beyond `Instrument`, and a group manager and a standard user are both refused.

**E2E** — a `granular instrument token` block in `testing/src/specs/authorization.spec.ts`. An administrator mints a token and re-posts a seeded instrument's own bundle with it; the expected **409** is the assertion, because reaching the duplicate check proves the guard admitted the token *and* the bundle was really interpreted and validated server-side. A group manager gets 403 at the token endpoint.

Both were verified against the unfixed code and fail there — the e2e reports `403` where 409 is expected (the reported bug) and `200` where 403 is expected (a group manager minting a token they could not use).

`pnpm lint`, `pnpm test` (748 passed) and `pnpm test:e2e` (150 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
