### PR TITLE
Add form reset button variable to defineInstrument, button revealed in instrument viewer and odc

### DIFF
--- a/packages/instrument-guidelines/AGENTS.md
+++ b/packages/instrument-guidelines/AGENTS.md
@@ -473,10 +473,16 @@ type FormInstrument<TData extends FormInstrument.Data, TLanguage extends Instrum
   initialValues?: PartialDeep<TData>;
   kind: 'FORM';
   measures: InstrumentMeasures<TData, TLanguage> | null;
+  resetButton?: boolean;
 };
 ```
 
 - `initialValues` — optional pre-populated values, applied when the form is first rendered. This is a _deep_ partial (`PartialDeep<TData>`), so nested composite values (e.g. individual fields within `record-array` rows) may be partially specified.
+- `resetButton` — whether to show a button that clears every answer. Defaults to `false`.
+
+  **The button takes effect on the first click.** There is no confirmation step and no undo, and the subject loses everything they have entered. Set it on a long form the subject may reasonably want to start over, and leave it off a short one, where a stray click costs more than the button saves.
+
+  It also governs what happens to the answers after a successful submit: a form with `resetButton: true` is emptied, and a form without it retains its values. Neither is visible in the standard flow, which replaces the form once it is submitted.
 
 #### 1.3.2 Interactive Instruments
 

--- a/packages/instrument-library/src/forms/DNP_ENHANCED_DEMOGRAPHICS_QUESTIONNAIRE/index.ts
+++ b/packages/instrument-library/src/forms/DNP_ENHANCED_DEMOGRAPHICS_QUESTIONNAIRE/index.ts
@@ -598,6 +598,9 @@ export default defineInstrument({
     en: ['Demographics'],
     fr: ['Démographie']
   },
+  // This questionnaire is long enough that a subject who realises they have been answering for the
+  // wrong person is better served starting over than clearing twenty fields by hand.
+  resetButton: true,
   content: [
     {
       fields: {

--- a/packages/react-core/src/components/FormContent/FormContent.tsx
+++ b/packages/react-core/src/components/FormContent/FormContent.tsx
@@ -43,11 +43,18 @@ export const FormContent = ({ instrument, onSubmit, submitButtonLabel }: FormCon
           </Dialog.Content>
         </Dialog>
       </div>
+      {/*
+        libui's `resetBtn` and `preventResetValuesOnReset` are two ends of one switch: its `reset`
+        only empties the fields when the latter is absent, so offering the button while preventing
+        the clear would give a Reset that wipes validation errors and leaves every answer in place.
+        An instrument therefore either has a working button or has none.
+      */}
       <Form
-        preventResetValuesOnReset
         content={instrument.content}
         data-testid="form-content"
         initialValues={instrument.initialValues}
+        preventResetValuesOnReset={!instrument.resetButton}
+        resetBtn={instrument.resetButton}
         submitBtnLabel={submitButtonLabel ? t(submitButtonLabel) : undefined}
         validationSchema={instrument.validationSchema}
         onSubmit={(data) => void onSubmit({ data, kind: 'FORM' })}

--- a/packages/runtime-core/src/types/__tests__/instrument.form.test-d.ts
+++ b/packages/runtime-core/src/types/__tests__/instrument.form.test-d.ts
@@ -338,3 +338,17 @@ import type { FormInstrument } from '../instrument.form.js';
     Extract<FormInstrument<TData>['content'], unknown[]>[number]
   >();
 }
+
+/** FormInstrument.resetButton */
+{
+  type TData = { _: string };
+
+  expectTypeOf<FormInstrument<TData>['resetButton']>().toEqualTypeOf<boolean | undefined>();
+
+  /** Optional, so every instrument authored before it existed still satisfies the type */
+  expectTypeOf<{
+    content: FormInstrument<TData>['content'];
+    kind: 'FORM';
+    measures: FormInstrument<TData>['measures'];
+  }>().toMatchTypeOf<Partial<FormInstrument<TData>>>();
+}

--- a/packages/runtime-core/src/types/instrument.form.ts
+++ b/packages/runtime-core/src/types/instrument.form.ts
@@ -302,6 +302,12 @@ declare type FormInstrument<
     initialValues?: PartialDeep<TData>;
     kind: 'FORM';
     measures: InstrumentMeasures<TData, TLanguage> | null;
+    /**
+     * Whether to offer a button that clears every answer. Defaults to false. The button takes effect
+     * immediately, with no confirmation step and no way to undo, so it suits a long form the subject
+     * may want to start over rather than a short one where a stray click costs more than it saves.
+     */
+    resetButton?: boolean;
   }
 >;
 

--- a/packages/schemas/src/instrument/__tests__/instrument.form.test.ts
+++ b/packages/schemas/src/instrument/__tests__/instrument.form.test.ts
@@ -32,6 +32,25 @@ describe('$FormInstrument', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  // Zod strips what it does not declare, and `apps/web` only validates in development while the
+  // playground always does — so omitting `resetButton` here would drop the flag in exactly the places
+  // an author tests their instrument, while leaving it intact in production.
+  it('should preserve resetButton rather than stripping it', () => {
+    const result = $FormInstrument.safeParse({ ...unilingualFormInstrument.instance, resetButton: true });
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('resetButton', true);
+  });
+
+  it('should parse a form that omits resetButton, since it is optional', () => {
+    const result = $FormInstrument.safeParse(unilingualFormInstrument.instance);
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty('resetButton');
+  });
+
+  it('should reject a non-boolean resetButton', () => {
+    expect($FormInstrument.safeParse({ ...unilingualFormInstrument.instance, resetButton: 'yes' }).success).toBe(false);
+  });
 });
 
 describe('$FormInstrumentBlock', () => {

--- a/packages/schemas/src/instrument/instrument.form.ts
+++ b/packages/schemas/src/instrument/instrument.form.ts
@@ -225,6 +225,7 @@ const $$FormInstrument = <TLanguage extends InstrumentLanguage>(language?: TLang
     content: $$FormInstrumentContent(language),
     initialValues: z.record(z.string(), z.any()).optional(),
     kind: z.literal('FORM'),
+    resetButton: z.boolean().optional(),
     validationSchema: $InstrumentValidationSchema
   }) satisfies z.ZodType<FormInstrument<FormInstrument.Data, TLanguage>>;
 };

--- a/testing/src/pages/_app/instruments/render/$id.page.ts
+++ b/testing/src/pages/_app/instruments/render/$id.page.ts
@@ -10,6 +10,8 @@ export class RenderInstrumentPage extends AppPage {
   readonly beginButton: Locator;
   readonly consentPreamble: Locator;
   readonly errorMessages: Locator;
+  /** Rendered only for an instrument declaring `resetButton: true`; libui gives it this aria-label. */
+  readonly resetButton: Locator;
   readonly submitButton: Locator;
   readonly summaryHeading: Locator;
 
@@ -17,6 +19,7 @@ export class RenderInstrumentPage extends AppPage {
     super(page);
     this.beginButton = page.getByRole('button', { name: 'Begin' });
     this.consentPreamble = page.getByTestId('consent-preamble');
+    this.resetButton = page.getByRole('button', { name: 'Reset' });
     this.submitButton = page.getByRole('button', { name: 'Submit' });
     this.summaryHeading = page.getByRole('heading', { name: /Summary of Results/i });
     this.errorMessages = page.getByTestId('error-message-text');

--- a/testing/src/specs/form-reset.spec.ts
+++ b/testing/src/specs/form-reset.spec.ts
@@ -1,0 +1,84 @@
+import type { Page } from '@playwright/test';
+
+import { RenderInstrumentPage } from '../pages/_app/instruments/render/$id.page';
+import { expect, test } from '../support/fixtures';
+
+import type { GetPageModel } from '../support/fixtures';
+
+/** Declares `resetButton: true`; it is the longest form in the library, which is why it opts in. */
+const RESETTABLE_INSTRUMENT_TITLE = 'Enhanced Demographics Questionnaire';
+
+/** Declares no `resetButton`, so it stands in for every instrument authored before the option existed. */
+const NON_RESETTABLE_INSTRUMENT_TITLE = 'Happiness Questionnaire';
+
+/**
+ * Starts a session and opens an instrument by the title on its card. The session lives in memory, so
+ * every step navigates through the sidebar rather than by loading a URL.
+ */
+async function openInstrument(
+  getPageModel: GetPageModel,
+  page: Page,
+  uniqueId: string,
+  title: string
+): Promise<RenderInstrumentPage> {
+  const startSessionPage = await getPageModel('/session/start-session');
+  await startSessionPage.sessionForm.waitFor({ state: 'visible' });
+  await startSessionPage.selectIdentificationMethod('PERSONAL_INFO');
+  await startSessionPage.fillSessionForm(`Reset${uniqueId}`, `Subject${uniqueId}`, 'Female');
+  await startSessionPage.submitForm();
+  await expect(startSessionPage.successMessage).toBeVisible();
+
+  await page.getByTestId('nav-button-/instruments/accessible-instruments').click();
+  await page.waitForURL('**/instruments/accessible-instruments');
+
+  const card = page.locator('[data-testid^="instrument-card-"]').filter({ hasText: title }).first();
+  await expect(card).toBeVisible();
+  await card.click();
+
+  const instrumentPage = new RenderInstrumentPage(page);
+  await instrumentPage.begin();
+  return instrumentPage;
+}
+
+test.describe('form reset button', () => {
+  test('should clear every answer when an instrument opts in @smoke', async ({ getPageModel, page, uniqueId }) => {
+    const instrumentPage = await openInstrument(getPageModel, page, uniqueId, RESETTABLE_INSTRUMENT_TITLE);
+    await expect(instrumentPage.resetButton).toBeVisible();
+
+    await instrumentPage.completeEnhancedDemographicsQuestionnaire();
+
+    const householdSize = page.locator('[name="householdSize"]');
+    const maritalStatus = page.locator('[name="maritalStatus"]');
+    await expect(householdSize).toHaveValue('3');
+    await expect(maritalStatus).toHaveValue('married');
+
+    await instrumentPage.resetButton.click();
+
+    // Values, not just validation errors: this is what `preventResetValuesOnReset` would suppress if
+    // it were left on for an instrument that offers the button.
+    await expect(householdSize).toHaveValue('');
+    await expect(maritalStatus).toHaveValue('');
+  });
+
+  test('should not offer the button to an instrument that does not opt in', async ({
+    getPageModel,
+    page,
+    uniqueId
+  }) => {
+    const instrumentPage = await openInstrument(getPageModel, page, uniqueId, NON_RESETTABLE_INSTRUMENT_TITLE);
+
+    await expect(instrumentPage.submitButton).toBeVisible();
+    await expect(instrumentPage.resetButton).toHaveCount(0);
+  });
+
+  test('should still submit normally after a reset', async ({ getPageModel, page, uniqueId }) => {
+    const instrumentPage = await openInstrument(getPageModel, page, uniqueId, RESETTABLE_INSTRUMENT_TITLE);
+
+    await instrumentPage.completeEnhancedDemographicsQuestionnaire();
+    await instrumentPage.resetButton.click();
+    await instrumentPage.completeEnhancedDemographicsQuestionnaire();
+    await instrumentPage.submit();
+
+    await expect(instrumentPage.summaryHeading).toBeVisible();
+  });
+});


### PR DESCRIPTION
# feat: let an instrument opt into a form reset button

Adds `resetButton` to the `defineInstrument` form API. An author writes `resetButton: true`, and
every surface that renders the instrument shows a button that clears the subject's answers.

## Motivation

libui's `Form` has always supported a reset button, but the instrument API never exposed it, so no
authored instrument could offer one. `FormInstrument` is a deliberately curated subset of libui's
props — it also omits `readOnly`, `revalidateOnBlur` and `fieldsFooter` — so surfacing one means
declaring it in the type, mirroring it in the schema, and forwarding it at the single mount point.

## What changed

Six files, in dependency order:

| File | Change |
| --- | --- |
| `packages/runtime-core/src/types/instrument.form.ts` | `resetButton?: boolean` on `FormInstrument` |
| `packages/schemas/src/instrument/instrument.form.ts` | `resetButton: z.boolean().optional()` on `$$FormInstrument` |
| `packages/react-core/.../FormContent/FormContent.tsx` | forwards it to libui |
| `packages/instrument-library/.../DNP_ENHANCED_DEMOGRAPHICS_QUESTIONNAIRE/index.ts` | `resetButton: true` — the worked example |
| `packages/instrument-guidelines/AGENTS.md` | the published authoring spec |
| `testing/` + two test files | coverage |

### The one subtlety worth reviewing

`FormContent` previously passed `preventResetValuesOnReset` unconditionally. libui's reset is:

```js
const reset = () => {
  setRootErrors([]);                                    // always
  setErrors({});                                        // always
  if (!preventResetValuesOnReset) { setValues({}); }    // ← the only line that flag gates
};
```

So simply adding the button would have produced a **Reset that clears validation errors and leaves
every answer in place** — visibly broken. The two props are one switch, and this PR ties them
together:

```tsx
preventResetValuesOnReset={!instrument.resetButton}
resetBtn={instrument.resetButton}
```

The invariant: **a reset button renders if and only if `preventResetValuesOnReset` is off.** Never a
button that cannot clear; never silent clear-suppression when a button is offered.

Instruments that do not opt in are byte-identical to before.

### Why the names differ

The authoring API is `resetButton`; libui's prop is `resetBtn` and is not ours to rename. The two
meet on one adapter line in `FormContent`, which is the only coupling — the component enumerates
props and never spreads, so nothing leaks through implicitly.

This cannot drift silently: `FormProps` indexes only `` [key: `data-${string}`] ``, so passing the
wrong name is an excess-property error. Verified deliberately:

```
error TS2322: Property 'resetButton' does not exist on type
  'IntrinsicAttributes & FormProps<...>'. Did you mean 'resetBtn'?
```

If libui ever renames its prop, `tsc` fails on that one line rather than the button quietly
disappearing.

## Behaviour

| | `resetButton` unset | `resetButton: true` |
| --- | --- | --- |
| Reset button | not rendered | rendered |
| Clicking it | n/a | clears every answer, immediately |
| After a successful submit | values retained | values cleared |

The post-submit difference is not observable in the standard flow: the scalar renderer advances to
the summary (`setIndex(2)`) and the series renderer drops to its progress screen, so the form
unmounts either way. It is documented in the guidelines regardless, because it is real.

**The button has no confirmation step and no undo** — one click and the subject loses everything
entered. That is libui's behaviour, not something introduced here, and the guidelines now say so
explicitly, so authors opt in knowingly. It applies on every surface, including the patient-facing
gateway: the author opted in, and they know their instrument better than the platform does.

`DNP_ENHANCED_DEMOGRAPHICS_QUESTIONNAIRE` is the only instrument that opts in. It is the longest
form in the library — roughly twenty fields — which is where starting over beats clearing by hand.

## Testing

| Suite | Result |
| --- | --- |
| `pnpm lint` | 33/33 tasks |
| `pnpm test` | 751 passed, 1 skipped |
| `pnpm test:e2e` | 154/154 passed (Chromium, plus Firefox `@smoke`) |

New coverage:

- **Type-level** (`runtime-core`, checked by `tsc` in `lint`) — pins `resetButton` as
  `boolean | undefined` and confirms it is optional, so instruments predating it still satisfy the
  type.
- **Schema** (`packages/schemas`) — that `$FormInstrument` **preserves** `resetButton` rather than
  stripping it, that omitting it still parses, and that a non-boolean is rejected.
- **E2E** (`testing/src/specs/form-reset.spec.ts`, 3 tests) — the button clears a filled form; an
  instrument that does not opt in has no button; and a form still submits normally after a reset.

### Both guards were checked against the failure they exist for

Rather than trusting that the new tests pass, I confirmed each one fails when its protection is
removed:

- Deleting the line from `$$FormInstrument` → **2 schema tests fail**; restoring it → 8 pass.
- Reverting `preventResetValuesOnReset` to unconditional → the e2e fails with
  `Expected: "" / Received: "3"` — button rendered, field unchanged.

The schema test matters more than it looks: Zod strips undeclared keys, `apps/web` validates only in
development (`validate: import.meta.env.DEV`) and the playground always does. Omitting that one line
would have dropped the flag in exactly the places an author tests their instrument, while leaving it
working in production.

## Reviewer notes

- **Two build artifacts must be regenerated**, both gitignored: `runtime-core` (`lib/` + `dist/`) and
  `runtime/v1/dist`. Instruments import through `/runtime/v1/...`, so `tsc` fails on a fresh clone
  until `pnpm build` runs. Nothing to commit.
- `packages/instrument-guidelines` is a published npm package whose `bin` installs it into external
  instrument repos as their `AGENTS.md`. Its version tracks the root, and `increment-version.sh`
  rewrites every path, so this documentation ships with the next ordinary release — no separate
  action.
- `instrument-completion.spec.ts` already drives the demographics instrument, so the existing suite
  exercises the changed instrument. It passes.
- No new dependencies, no version bumps, no schema migration.

## Out of scope

#1517 

While tracing `preventResetValuesOnReset` I found and reproduced a pre-existing state-bleed in
`skipProgress` series: the form is not remounted between items, so answers carry forward. Filed
separately as #<ISSUE>. It is unrelated to this feature and its fix belongs in `SeriesInstrumentRenderer`
or `useInterpretedInstrument`, neither of which this PR touches.

One interaction is worth knowing while reviewing: because this PR makes `preventResetValuesOnReset`
conditional, an instrument declaring `resetButton: true` becomes **incidentally immune** to that bug —
`reset()` now empties its form after each submit. That is a side effect, not a fix, and #<ISSUE> says
so explicitly.

Also out of scope: any confirmation dialog on Reset, which would require an upstream libui change.

Closes issue #1391 