### PR TITLE
feat(playground): show the ODC version in the actions menu

### DIFF
--- a/apps/playground/src/components/Header/ActionsDropdown/ActionsDropdown.tsx
+++ b/apps/playground/src/components/Header/ActionsDropdown/ActionsDropdown.tsx
@@ -81,6 +81,10 @@ export const ActionsDropdown = () => {
               {t({ en: 'Restore Defaults', fr: 'Restaurer les paramètres par défaut' })}
             </button>
           </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Label className="text-muted-foreground text-xs font-normal">
+            {t({ en: 'ODC Version', fr: 'Version ODC' })} {__APP_VERSION__}
+          </DropdownMenu.Label>
         </DropdownMenu.Content>
       </DropdownMenu>
       <UserSettingsDialog isOpen={showUserSettingsDialog} setIsOpen={setShowUserSettingsDialog} />

--- a/apps/playground/src/vite-env.d.ts
+++ b/apps/playground/src/vite-env.d.ts
@@ -1,1 +1,2 @@
+const __APP_VERSION__: string;
 const __GITHUB_REPO_URL__: string;

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -1,9 +1,17 @@
+import fs from 'fs';
 import path from 'path';
 
 import runtime from '@opendatacapture/vite-plugin-runtime';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
+
+// Read straight from the monorepo root rather than through `@opendatacapture/release-info`: that
+// package pulls in `@opendatacapture/schemas`, which ships raw TypeScript, and loading it here would
+// mean running this config under tsx as `apps/web` does.
+const { version } = JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, '../../package.json'), 'utf-8')) as {
+  version: string;
+};
 
 export default defineConfig(({ mode }) => ({
   build: {
@@ -16,6 +24,7 @@ export default defineConfig(({ mode }) => ({
     target: 'es2022'
   },
   define: {
+    __APP_VERSION__: JSON.stringify(version),
     __GITHUB_REPO_URL__: `'${process.env.GITHUB_REPO_URL ?? '#'}'`
   },
   optimizeDeps: {


### PR DESCRIPTION
Adds the ODC version to the bottom of the playground's `...` menu, under a separator.

```
GitHub / Login / Upload Bundle / User Settings / Storage Usage
Delete Instrument / Restore Defaults
─────────────────
ODC Version 2.2.3
```

## How the version gets there

Read from the root `package.json` in `vite.config.ts` and supplied as `__APP_VERSION__`, alongside the existing `__GITHUB_REPO_URL__` define.

Not the `__RELEASE__` define `apps/web` uses: `@opendatacapture/release-info` pulls in `@opendatacapture/schemas`, which ships raw TypeScript, so importing it here fails to load the config unless the playground's `dev` and `build` scripts run Vite under `NODE_OPTIONS='--import=tsx'` the way `apps/web` does. Reading the file directly avoids changing how this app builds and adds no dependency.

## Tests

None. The playground has no `vitest.config.ts`, and `testing/`'s Playwright config only starts api, gateway and web — so there is no harness this could hook into without adding a webServer entry for an app that downloads an 11 MB wasm on boot.

Verified by hand instead: loaded the dev server, opened the menu, confirmed `ODC Version 2.2.3` renders with no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
