### PR TITLE
feat(web): redesign the audit log filters as a per-facet filter bar

### DIFF
--- a/apps/web/src/__tests__/filter-menu.test.tsx
+++ b/apps/web/src/__tests__/filter-menu.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FilterMenu } from '@/components/FilterMenu';
+
+import '@/services/i18n';
+
+const options = [
+  { label: 'Depression Clinic', value: 'depression-clinic' },
+  { label: 'Psychosis Lab', value: 'psychosis-lab' }
+] as const;
+
+type Value = (typeof options)[number]['value'];
+
+const renderMenu = (value: undefined | Value, onValueChange = vi.fn()) => {
+  render(
+    <FilterMenu
+      allLabel="All groups"
+      data-testid="filter"
+      label="Group"
+      options={[...options]}
+      value={value}
+      onValueChange={onValueChange}
+    />
+  );
+  return onValueChange;
+};
+
+const openMenu = () => fireEvent.keyDown(screen.getByTestId('filter'), { key: 'Enter' });
+
+beforeEach(() => {
+  // There are no vitest setup files in this repo, so RTL never auto-unmounts between tests.
+  cleanup();
+});
+
+describe('FilterMenu', () => {
+  it('should show only the facet name while nothing is selected', () => {
+    renderMenu(undefined);
+    expect(screen.getByTestId('filter').textContent).toBe('Group');
+    expect(screen.getByTestId('filter').dataset.active).toBe('false');
+  });
+
+  it('should show the selected option beside the facet name', () => {
+    renderMenu('psychosis-lab');
+    expect(screen.getByTestId('filter').textContent).toBe('GroupPsychosis Lab');
+    expect(screen.getByTestId('filter').dataset.active).toBe('true');
+  });
+
+  it('should report the chosen option', () => {
+    const onValueChange = renderMenu(undefined);
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Depression Clinic' }));
+    expect(onValueChange).toHaveBeenCalledWith('depression-clinic');
+  });
+
+  it('should report undefined when the all option is chosen, so the caller clears the filter', () => {
+    const onValueChange = renderMenu('psychosis-lab');
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'All groups' }));
+    expect(onValueChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should mark the all option as checked while nothing is selected', () => {
+    renderMenu(undefined);
+    openMenu();
+    expect(screen.getByRole('menuitemradio', { name: 'All groups' }).getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/apps/web/src/components/FilterMenu/FilterMenu.stories.tsx
+++ b/apps/web/src/components/FilterMenu/FilterMenu.stories.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { FilterMenu } from './FilterMenu';
+
+type Story = StoryObj<typeof FilterMenu>;
+
+const options = [
+  { label: 'Depression Clinic', value: 'depression-clinic' },
+  { label: 'Psychosis Lab', value: 'psychosis-lab' }
+];
+
+const Controlled = ({ initialValue }: { initialValue?: string }) => {
+  const [value, setValue] = useState<string | undefined>(initialValue);
+  return <FilterMenu allLabel="All groups" label="Group" options={options} value={value} onValueChange={setValue} />;
+};
+
+export default { component: FilterMenu } as Meta<typeof FilterMenu>;
+
+export const Empty: Story = {
+  render: () => <Controlled />
+};
+
+export const Selected: Story = {
+  render: () => <Controlled initialValue="psychosis-lab" />
+};

--- a/apps/web/src/components/FilterMenu/FilterMenu.tsx
+++ b/apps/web/src/components/FilterMenu/FilterMenu.tsx
@@ -1,0 +1,66 @@
+import { Button, DropdownMenu } from '@douglasneuroinformatics/libui/components';
+import { cn } from '@douglasneuroinformatics/libui/utils';
+import { ChevronDownIcon } from 'lucide-react';
+
+type FilterMenuOption<TValue extends string> = {
+  label: string;
+  value: TValue;
+};
+
+type FilterMenuProps<TValue extends string> = {
+  /** The option that clears the filter, e.g. "All groups" */
+  allLabel: string;
+  'data-testid'?: string;
+  label: string;
+  onValueChange: (value: TValue | undefined) => void;
+  options: FilterMenuOption<TValue>[];
+  value: TValue | undefined;
+};
+
+/** Radix requires a string for the "all" radio item, so the cleared state is the one value no option may have */
+const CLEARED_VALUE = '';
+
+/**
+ * A single-select filter that reads as a button: the facet name alone when nothing is selected,
+ * the facet name and the selected option once something is.
+ */
+export const FilterMenu = <TValue extends string>({
+  allLabel,
+  label,
+  onValueChange,
+  options,
+  value,
+  ...props
+}: FilterMenuProps<TValue>) => {
+  const selected = options.find((option) => option.value === value);
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button
+          className={cn('gap-1.5 font-normal', selected && 'bg-accent text-accent-foreground')}
+          data-active={Boolean(selected)}
+          data-testid={props['data-testid']}
+          variant="outline"
+        >
+          <span className="text-muted-foreground">{label}</span>
+          {selected && <span className="max-w-48 truncate font-medium">{selected.label}</span>}
+          <ChevronDownIcon className="h-4 w-4 opacity-50" />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="start" className="max-h-80 w-56 overflow-y-auto">
+        <DropdownMenu.RadioGroup
+          value={selected?.value ?? CLEARED_VALUE}
+          onValueChange={(next) => onValueChange(options.find((option) => option.value === next)?.value)}
+        >
+          <DropdownMenu.RadioItem value={CLEARED_VALUE}>{allLabel}</DropdownMenu.RadioItem>
+          <DropdownMenu.Separator />
+          {options.map((option) => (
+            <DropdownMenu.RadioItem key={option.value} value={option.value}>
+              {option.label}
+            </DropdownMenu.RadioItem>
+          ))}
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+};

--- a/apps/web/src/components/FilterMenu/index.ts
+++ b/apps/web/src/components/FilterMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterMenu';

--- a/apps/web/src/routes/_app/admin/audit/logs.tsx
+++ b/apps/web/src/routes/_app/admin/audit/logs.tsx
@@ -11,8 +11,9 @@ import type {
   $AuditLogsQuerySearchParams as AuditLogsSearchParams
 } from '@opendatacapture/schemas/audit';
 import { createFileRoute } from '@tanstack/react-router';
-import { ArrowDownIcon, ArrowUpIcon, CalendarIcon, ChevronDownIcon, DownloadIcon } from 'lucide-react';
+import { ArrowDownIcon, ArrowUpIcon, CalendarIcon, DownloadIcon, XIcon } from 'lucide-react';
 
+import { FilterMenu } from '@/components/FilterMenu';
 import { PageHeader } from '@/components/PageHeader';
 import { auditLogsQueryOptions, fetchAllAuditLogs, useAuditLogsQuery } from '@/hooks/useAuditLogsQuery';
 import { groupsQueryOptions, useGroupsQuery } from '@/hooks/useGroupsQuery';
@@ -33,47 +34,6 @@ const ENTITIES: $AuditLogEntity[] = [
   'SUBJECT',
   'USER'
 ];
-
-const SelectSingleFilterGroup = ({
-  label,
-  options,
-  searchKey
-}: {
-  label: string;
-  options: {
-    [key: string]: string;
-  };
-  searchKey: Extract<keyof $AuditLogsQuerySearchParams, string>;
-}) => {
-  const navigate = Route.useNavigate();
-  const search = Route.useSearch();
-  return (
-    <Fragment>
-      <DropdownMenu.Label>{label}</DropdownMenu.Label>
-      <DropdownMenu.Group>
-        {Object.entries(options).map(([option, label]) => {
-          return (
-            <DropdownMenu.CheckboxItem
-              checked={option === search[searchKey]}
-              key={option}
-              onCheckedChange={(checked) => {
-                void navigate({
-                  search: (search) => {
-                    return { ...search, [searchKey]: checked ? option : undefined };
-                  },
-                  to: '.'
-                });
-              }}
-              onSelect={(e) => e.preventDefault()}
-            >
-              {label}
-            </DropdownMenu.CheckboxItem>
-          );
-        })}
-      </DropdownMenu.Group>
-    </Fragment>
-  );
-};
 
 // The sort direction is rendered from the value the rows were actually fetched with, rather than from
 // `column.getIsSorted()`: in server mode the table mounts with no sorting state of its own, so the
@@ -133,10 +93,9 @@ const DateFormatMenu = ({ onChange, value }: { onChange: (value: DateFormat) => 
   );
 };
 
-const Toggles: React.FC<{ table: TanstackTable.Table<$AuditLog> }> = () => {
+const AuditLogsToolbar = () => {
+  const navigate = Route.useNavigate();
   const search = Route.useSearch();
-
-  const [isOpen, setIsOpen] = useState(false);
 
   const { data: groups } = useGroupsQuery();
   const { data: users } = useUsersQuery();
@@ -145,58 +104,77 @@ const Toggles: React.FC<{ table: TanstackTable.Table<$AuditLog> }> = () => {
 
   const download = useDownload();
 
-  // The table only holds the page currently displayed, so the download refetches every log matching
-  // the active filters rather than exporting what happens to be on screen.
-  const handleDownload = useCallback(() => {
-    void download(`ODC_Audit_Logs_${Date.now()}.json`, async () => {
-      const logs = await fetchAllAuditLogs(search);
-      return JSON.stringify(logs, null, 2);
-    });
-  }, [search]);
+  const setSearch = (patch: Partial<AuditLogsSearchParams>) => {
+    void navigate({ search: (current) => ({ ...current, ...patch }), to: '.' });
+  };
 
   const availableUsers = search.groupId ? users.filter((user) => user.groupIds.includes(search.groupId!)) : users;
+  const hasFilters = Object.values(search).some((value) => value !== undefined);
+
+  const localize = (value: $AuditLogAction | $AuditLogEntity) => t(`common.${snakeToCamelCase(toLowerCase(value))}`);
 
   return (
-    <div className="flex gap-3">
-      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenu.Trigger asChild>
-          <Button className="flex items-center justify-between gap-2" variant="outline">
-            {t('common.filters')}
-            <ChevronDownIcon className="opacity-50" />
-          </Button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="end" className="w-56">
-          <SelectSingleFilterGroup
-            label={t('common.group')}
-            options={Object.fromEntries(groups.map((group) => [group.id, group.name]))}
-            searchKey="groupId"
-          />
-          <SelectSingleFilterGroup
-            label={t('common.user')}
-            options={Object.fromEntries(availableUsers.map((user) => [user.id, user.username]))}
-            searchKey="userId"
-          />
-          <SelectSingleFilterGroup
-            label={t('common.action')}
-            options={Object.fromEntries(
-              ACTIONS.map((action) => [action, t(`common.${snakeToCamelCase(toLowerCase(action))}`)])
-            )}
-            searchKey="action"
-          />
-          <SelectSingleFilterGroup
-            label={t('common.entity')}
-            options={Object.fromEntries(
-              ENTITIES.map((entity) => [entity, t(`common.${snakeToCamelCase(toLowerCase(entity))}`)])
-            )}
-            searchKey="entity"
-          />
-        </DropdownMenu.Content>
-      </DropdownMenu>
+    <div className="flex flex-wrap items-center gap-2 pb-4" data-testid="audit-logs-toolbar">
+      <FilterMenu
+        allLabel={t({ en: 'All Groups', fr: 'Tous les groupes' })}
+        data-testid="audit-logs-filter-group"
+        label={t('common.group')}
+        options={groups.map((group) => ({ label: group.name, value: group.id }))}
+        value={search.groupId}
+        onValueChange={(groupId) => {
+          const selectedUser = users.find((user) => user.id === search.userId);
+          const userId = !groupId || selectedUser?.groupIds.includes(groupId) ? search.userId : undefined;
+          setSearch({ groupId, userId });
+        }}
+      />
+      <FilterMenu
+        allLabel={t({ en: 'All Users', fr: 'Tous les utilisateurs' })}
+        data-testid="audit-logs-filter-user"
+        label={t('common.user')}
+        options={availableUsers.map((user) => ({ label: user.username, value: user.id }))}
+        value={search.userId}
+        onValueChange={(userId) => setSearch({ userId })}
+      />
+      <FilterMenu
+        allLabel={t({ en: 'Any Action', fr: 'Toute action' })}
+        data-testid="audit-logs-filter-action"
+        label={t('common.action')}
+        options={ACTIONS.map((action) => ({ label: localize(action), value: action }))}
+        value={search.action}
+        onValueChange={(action) => setSearch({ action })}
+      />
+      <FilterMenu
+        allLabel={t({ en: 'Any Entity', fr: 'Toute entité' })}
+        data-testid="audit-logs-filter-entity"
+        label={t('common.entity')}
+        options={ENTITIES.map((entity) => ({ label: localize(entity), value: entity }))}
+        value={search.entity}
+        onValueChange={(entity) => setSearch({ entity })}
+      />
+      {hasFilters && (
+        <Button
+          className="text-muted-foreground hover:text-foreground gap-1.5"
+          data-testid="audit-logs-clear-filters"
+          size="sm"
+          variant="ghost"
+          onClick={() => void navigate({ search: {}, to: '.' })}
+        >
+          <XIcon className="h-3.5 w-3.5" />
+          {t({ en: 'Clear Filters', fr: 'Effacer les filtres' })}
+        </Button>
+      )}
       <Button
-        className="flex items-center justify-between gap-2"
+        className="ml-auto gap-2"
         type="button"
         variant="outline"
-        onClick={handleDownload}
+        onClick={() => {
+          // The table only holds the page currently displayed, so the download refetches every log
+          // matching the active filters rather than exporting what happens to be on screen.
+          void download(`ODC_Audit_Logs_${Date.now()}.json`, async () => {
+            const logs = await fetchAllAuditLogs(search);
+            return JSON.stringify(logs, null, 2);
+          });
+        }}
       >
         {t('core.download')}
         <DownloadIcon className="opacity-50" style={{ height: '14px', width: 'auto' }} />
@@ -231,6 +209,7 @@ const AuditLogsTable: React.FC<{ search: AuditLogsSearchParams }> = ({ search })
 
   return (
     <DataTable
+      disableSearch
       columns={[
         {
           accessorKey: 'timestamp',
@@ -294,7 +273,6 @@ const AuditLogsTable: React.FC<{ search: AuditLogsSearchParams }> = ({ search })
       data={auditLogsQuery.data?.data ?? []}
       mode="server"
       pageCount={auditLogsQuery.data?.pageCount ?? 0}
-      togglesComponent={Toggles}
       onPaginationChange={({ pageIndex }) => setPage(pageIndex + 1)}
       onSortingChange={(state) => {
         const timestamp = state.find(({ id }) => id === 'timestamp');
@@ -318,6 +296,7 @@ const RouteComponent = () => {
           {t('common.auditLogs')}
         </Heading>
       </PageHeader>
+      <AuditLogsToolbar />
       {/* Remounted when the filters change: in server mode the table owns its page index and offers no
           way to set it, so a fresh store is the only way to return it to the first page. */}
       <AuditLogsTable key={JSON.stringify(search)} search={search} />

--- a/apps/web/src/translations/common.json
+++ b/apps/web/src/translations/common.json
@@ -227,7 +227,7 @@
     "fr": "Recherche"
   },
   "sendEmail": {
-    "en": "Send email",
+    "en": "Send Email",
     "es": "Enviar correo electrónico",
     "fr": "Envoyer un courriel"
   },

--- a/testing/src/pages/_app/admin/audit/logs.page.ts
+++ b/testing/src/pages/_app/admin/audit/logs.page.ts
@@ -2,27 +2,29 @@ import type { Locator, Page } from '@playwright/test';
 
 import { AppPage } from '../../route.page';
 
+export type AuditLogsFilter = 'action' | 'entity' | 'group' | 'user';
+
 export class AuditLogsPage extends AppPage {
+  readonly clearFiltersButton: Locator;
   readonly dataTable: Locator;
   readonly downloadButton: Locator;
-  readonly filtersButton: Locator;
   readonly pageHeader: Locator;
 
   constructor(page: Page) {
     super(page);
     this.pageHeader = page.getByTestId('page-header');
     this.dataTable = page.getByTestId('data-table');
-    this.filtersButton = page.getByRole('button', { name: 'Filters' });
+    this.clearFiltersButton = page.getByTestId('audit-logs-clear-filters');
     this.downloadButton = page.getByRole('button', { name: 'Download' });
   }
 
-  /**
-   * Opens the Filters dropdown and checks a single option. Selecting a filter changes the search
-   * params, which remounts the table (and this dropdown along with it) to reset pagination -- so only
-   * one option can be checked per call. Call this again (it reopens the menu) to add another filter.
-   */
-  async filterBy(optionLabel: string) {
-    await this.filtersButton.click();
-    await this.$ref.getByRole('menuitemcheckbox', { exact: true, name: optionLabel }).click();
+  filterButton(filter: AuditLogsFilter) {
+    return this.$ref.getByTestId(`audit-logs-filter-${filter}`);
+  }
+
+  /** Opens one filter's menu and picks an option; the menu closes itself once the option is chosen. */
+  async filterBy(filter: AuditLogsFilter, optionLabel: string) {
+    await this.filterButton(filter).click();
+    await this.$ref.getByRole('menuitemradio', { exact: true, name: optionLabel }).click();
   }
 }

--- a/testing/src/specs/admin-audit-logs.spec.ts
+++ b/testing/src/specs/admin-audit-logs.spec.ts
@@ -22,11 +22,32 @@ test.describe('admin audit logs', () => {
     await ApiClient.login(apiRequestContext, { password: ADMIN.password, username: ADMIN.username });
 
     const auditLogsPage = await getPageModel('/admin/audit/logs');
-    await auditLogsPage.filterBy('Login');
+    await auditLogsPage.filterBy('action', 'Login');
 
     const firstRow = auditLogsPage.dataTable.getByTestId('data-table-row').first();
     await expect(firstRow).toContainText('Login');
     await expect(firstRow).toContainText('User');
+  });
+
+  test('should show the chosen option on its filter button and put it in the URL', async ({ getPageModel }) => {
+    const auditLogsPage = await getPageModel('/admin/audit/logs');
+    await auditLogsPage.filterBy('entity', 'Session');
+
+    await expect(auditLogsPage.filterButton('entity')).toContainText('Session');
+    await expect(auditLogsPage.$ref).toHaveURL(/entity=SESSION/);
+  });
+
+  test('should clear every filter at once', async ({ getPageModel }) => {
+    const auditLogsPage = await getPageModel('/admin/audit/logs');
+    await expect(auditLogsPage.clearFiltersButton).toBeHidden();
+
+    await auditLogsPage.filterBy('action', 'Login');
+    await auditLogsPage.filterBy('entity', 'User');
+    await auditLogsPage.clearFiltersButton.click();
+
+    await expect(auditLogsPage.clearFiltersButton).toBeHidden();
+    await expect(auditLogsPage.$ref).not.toHaveURL(/action=|entity=/);
+    await expect(auditLogsPage.filterButton('action')).toHaveText('Action');
   });
 
   test('should download the audit logs as JSON', async ({ getPageModel }) => {


### PR DESCRIPTION
## Summary

The audit logs page offered a single **Filters** menu that listed every group, user, action and entity as one long scrolling checkbox list, with nothing on the page showing what was selected.

This replaces it with a filter bar above the table:

- **One dropdown button per facet** (Group, User, Action, Entity). Each reads as just the facet name when nothing is selected, and shows the selected value inline with an accent background once something is.
- **Short, single-select menus.** Each menu is a radio list headed by "All Groups" / "Any Action" etc., so clearing one facet is the first item.
- **Clear Filters** appears at the end of the row only while a filter is active and resets the URL in one click.
- **Download** stays on the right.
- Choosing a group drops a selected user who is not in that group, so the URL can no longer hold a user the menu does not offer.
- The row wraps cleanly on narrow viewports.

The facet button is a new reusable `FilterMenu` component under `apps/web/src/components/`, with a Storybook story.

Two smaller copy/behaviour notes:

- The table's built-in search box is disabled on this page. In server mode it only filtered the ten rows already on screen, which misrepresented what "search" covered.
- The "Send email" action label in `common.json` is now "Send Email", matching the Title Case of every other action and entity label.

## Test plan

- [x] `pnpm --filter @opendatacapture/web lint`
- [x] `pnpm --filter @opendatacapture/testing lint`
- [x] `pnpm exec vitest run --project web` (new `filter-menu.test.tsx` covers the trigger label, the checked "all" item, and both callback shapes)
- [x] `admin-audit-logs.spec.ts` in chromium, including two new cases: the chosen option lands on the button and in the URL, and Clear Filters resets both
- [x] Verified visually at 1600px and 760px widths in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
