### PR TITLE
Load permission properly on initial manageUserForm selection

### DIFF
--- a/apps/web/src/__tests__/record-array-initial-values.test.tsx
+++ b/apps/web/src/__tests__/record-array-initial-values.test.tsx
@@ -1,0 +1,102 @@
+import React, { useMemo, useState } from 'react';
+
+import { Form } from '@douglasneuroinformatics/libui/components';
+import type { FormTypes } from '@opendatacapture/runtime-core';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+// Initialises the shared libui translator, which the form's controls read on render.
+import '@/services/i18n';
+
+type Permission = { action: string; subject: string };
+
+// Test scaffolding rather than copy, so it is not translated -- `jsx-no-literals` still applies here.
+const FORCE_RENDER_LABEL = 'Force Render';
+
+const $TestFormData = z.object({
+  permissions: z.array(z.object({ action: z.string(), subject: z.string() }))
+});
+
+const buildFieldset = () =>
+  ({
+    action: { kind: 'string', label: 'Action', options: { read: 'Read', update: 'Update' }, variant: 'select' },
+    subject: { kind: 'string', label: 'Resource', options: { Group: 'Group', User: 'User' }, variant: 'select' }
+  }) satisfies FormTypes.RecordArrayField['fieldset'];
+
+/**
+ * Exercises the contract the manage-users route depends on: a `record-array` seeded from
+ * `initialValues` keeps its records across a re-render only while its `fieldset` holds its
+ * identity, which is why the route memoizes that object rather than writing it inline.
+ */
+const RecordArrayForm = ({
+  onSubmit,
+  permissions,
+  stableFieldset
+}: {
+  onSubmit: (data: { permissions: Permission[] }) => void;
+  permissions: Permission[];
+  stableFieldset: boolean;
+}) => {
+  const [, forceRender] = useState(0);
+  const memoizedFieldset = useMemo(buildFieldset, []);
+  return (
+    <React.Fragment>
+      <button type="button" onClick={() => forceRender((count) => count + 1)}>
+        {FORCE_RENDER_LABEL}
+      </button>
+      <Form
+        content={{
+          permissions: {
+            fieldset: stableFieldset ? memoizedFieldset : buildFieldset(),
+            kind: 'record-array',
+            label: 'Permission'
+          }
+        }}
+        initialValues={{ permissions }}
+        validationSchema={$TestFormData}
+        onSubmit={onSubmit}
+      />
+    </React.Fragment>
+  );
+};
+
+describe('a record-array field seeded from initialValues', () => {
+  const permissions: Permission[] = [
+    { action: 'read', subject: 'User' },
+    { action: 'update', subject: 'Group' }
+  ];
+
+  // There are no setup files in this repo, so testing-library's auto-cleanup never runs.
+  afterEach(cleanup);
+
+  it('should render one row per seeded record', () => {
+    render(<RecordArrayForm stableFieldset permissions={permissions} onSubmit={vi.fn()} />);
+    expect(screen.getByText('Permission 1')).toBeTruthy();
+    expect(screen.getByText('Permission 2')).toBeTruthy();
+  });
+
+  it('should keep the seeded records when its parent re-renders', () => {
+    render(<RecordArrayForm stableFieldset permissions={permissions} onSubmit={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: FORCE_RENDER_LABEL }));
+    expect(screen.getByText('Permission 1')).toBeTruthy();
+    expect(screen.getByText('Permission 2')).toBeTruthy();
+  });
+
+  it('should submit the seeded records unchanged after its parent re-renders', async () => {
+    const onSubmit = vi.fn();
+    render(<RecordArrayForm stableFieldset permissions={permissions} onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole('button', { name: FORCE_RENDER_LABEL }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ permissions }));
+  });
+
+  // The hazard the memo exists to avoid: libui resets the field to one blank record whenever the
+  // fieldset changes identity, so an inline literal silently discards what the user was shown.
+  it('should discard the seeded records when the fieldset changes identity', () => {
+    render(<RecordArrayForm permissions={permissions} stableFieldset={false} onSubmit={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: FORCE_RENDER_LABEL }));
+    expect(screen.getByText('Permission 1')).toBeTruthy();
+    expect(screen.queryByText('Permission 2')).toBeNull();
+  });
+});

--- a/apps/web/src/routes/_app/admin/users/index.tsx
+++ b/apps/web/src/routes/_app/admin/users/index.tsx
@@ -70,6 +70,91 @@ const UpdateUserForm: React.FC<{
   const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
   const { applyGeneratedPassword, generatedPassword, generatePassword, isGeneratedPassword } = usePasswordGenerator();
 
+  // libui's `record-array` field resets itself to a single blank record whenever its `fieldset`
+  // changes identity, so an inline literal would discard the permissions it was seeded with on the
+  // next render of this component -- which a background refetch of either query triggers.
+  const additionalPermissionsFieldset = useMemo(
+    () => ({
+      action: {
+        kind: 'string' as const,
+        label: t({
+          en: 'Action',
+          fr: 'Action'
+        }),
+        options: {
+          create: t({
+            en: 'Create',
+            fr: 'Créer'
+          }),
+          delete: t({
+            en: 'Delete',
+            fr: 'Supprimer'
+          }),
+          manage: t({
+            en: 'Manage (All)',
+            fr: 'Gérer (Tout)'
+          }),
+          read: t({
+            en: 'Read',
+            fr: 'Lire'
+          }),
+          update: t({
+            en: 'Update',
+            fr: 'Modifier'
+          })
+        },
+        variant: 'select' as const
+      },
+      subject: {
+        kind: 'string' as const,
+        label: t({
+          en: 'Resource',
+          fr: 'Ressource'
+        }),
+        options: {
+          all: t({
+            en: 'All',
+            fr: 'Tous'
+          }),
+          Assignment: t({
+            en: 'Assignment',
+            fr: 'Assignation'
+          }),
+          Group: t({
+            en: 'Group',
+            fr: 'Groupe'
+          }),
+          Instrument: t({
+            en: 'Instrument',
+            fr: 'Instrument'
+          }),
+          InstrumentRecord: t({
+            en: 'Instrument Record',
+            fr: "Enregistrement de l'instrument"
+          }),
+          InstrumentRepo: t({
+            en: 'Instrument Repository',
+            fr: "Dépôt d'instruments"
+          }),
+          Session: t({
+            en: 'Session',
+            fr: 'Session'
+          }),
+          Subject: t({
+            en: 'Subject',
+            fr: 'Client'
+          }),
+          User: t({
+            en: 'User',
+            fr: 'Utilisateur'
+          })
+        },
+        variant: 'select' as const
+      }
+    }),
+    [resolvedLanguage]
+  );
+
   const $UpdateUserFormData = useMemo(() => {
     return z
       .object({
@@ -200,84 +285,7 @@ const UpdateUserForm: React.FC<{
             }),
             fields: {
               additionalPermissions: {
-                fieldset: {
-                  action: {
-                    kind: 'string',
-                    label: t({
-                      en: 'Action',
-                      fr: 'Action'
-                    }),
-                    options: {
-                      create: t({
-                        en: 'Create',
-                        fr: 'Créer'
-                      }),
-                      delete: t({
-                        en: 'Delete',
-                        fr: 'Supprimer'
-                      }),
-                      manage: t({
-                        en: 'Manage (All)',
-                        fr: 'Gérer (Tout)'
-                      }),
-                      read: t({
-                        en: 'Read',
-                        fr: 'Lire'
-                      }),
-                      update: t({
-                        en: 'Update',
-                        fr: 'Modifier'
-                      })
-                    },
-                    variant: 'select'
-                  },
-                  subject: {
-                    kind: 'string',
-                    label: t({
-                      en: 'Resource',
-                      fr: 'Ressource'
-                    }),
-                    options: {
-                      all: t({
-                        en: 'All',
-                        fr: 'Tous'
-                      }),
-                      Assignment: t({
-                        en: 'Assignment',
-                        fr: 'Assignation'
-                      }),
-                      Group: t({
-                        en: 'Group',
-                        fr: 'Groupe'
-                      }),
-                      Instrument: t({
-                        en: 'Instrument',
-                        fr: 'Instrument'
-                      }),
-                      InstrumentRecord: t({
-                        en: 'Instrument Record',
-                        fr: "Enregistrement de l'instrument"
-                      }),
-                      InstrumentRepo: t({
-                        en: 'Instrument Repository',
-                        fr: "Dépôt d'instruments"
-                      }),
-                      Session: t({
-                        en: 'Session',
-                        fr: 'Session'
-                      }),
-                      Subject: t({
-                        en: 'Subject',
-                        fr: 'Client'
-                      }),
-                      User: t({
-                        en: 'User',
-                        fr: 'Utilisateur'
-                      })
-                    },
-                    variant: 'select'
-                  }
-                },
+                fieldset: additionalPermissionsFieldset,
                 kind: 'record-array',
                 label: t({
                   en: 'Permission',

--- a/apps/web/src/routes/_app/admin/users/index.tsx
+++ b/apps/web/src/routes/_app/admin/users/index.tsx
@@ -73,10 +73,10 @@ const UpdateUserForm: React.FC<{
   // libui's `record-array` field resets itself to a single blank record whenever its `fieldset`
   // changes identity, so an inline literal would discard the permissions it was seeded with on the
   // next render of this component -- which a background refetch of either query triggers.
-  const additionalPermissionsFieldset = useMemo(
+  const additionalPermissionsFieldset = useMemo<FormTypes.Fieldset<UserPermission>>(
     () => ({
       action: {
-        kind: 'string' as const,
+        kind: 'string',
         label: t({
           en: 'Action',
           fr: 'Action'
@@ -103,10 +103,10 @@ const UpdateUserForm: React.FC<{
             fr: 'Modifier'
           })
         },
-        variant: 'select' as const
+        variant: 'select'
       },
       subject: {
-        kind: 'string' as const,
+        kind: 'string',
         label: t({
           en: 'Resource',
           fr: 'Ressource'
@@ -149,7 +149,7 @@ const UpdateUserForm: React.FC<{
             fr: 'Utilisateur'
           })
         },
-        variant: 'select' as const
+        variant: 'select'
       }
     }),
     [resolvedLanguage]

--- a/testing/src/specs/admin-management.spec.ts
+++ b/testing/src/specs/admin-management.spec.ts
@@ -294,6 +294,33 @@ test.describe('admin management', () => {
     await expect(api.createUser({ phoneNumber: '123' })).rejects.toThrow(/Phone number must contain at least 7 digits/);
   });
 
+  test('should show the permissions a user already holds when the edit sheet is first opened', async ({
+    api,
+    authenticateAs,
+    page
+  }) => {
+    const group = await api.createGroup();
+    const { user } = await api.createUser({ groupIds: [group.id] });
+    await api.updateUser(user.id, { additionalPermissions: [{ action: 'read', subject: 'Subject' }] });
+
+    await authenticateAs('ADMIN');
+    await page.goto('/admin/users');
+    await page.getByTestId('data-table-search-bar').getByRole('searchbox').fill(user.username);
+    await page.getByTestId('data-table-row').dblclick();
+
+    const editSheet = page.getByTestId('admin-user-edit-sheet');
+    await expect(editSheet.getByTestId('action-select-trigger')).toContainText('Read');
+    await expect(editSheet.getByTestId('subject-select-trigger')).toContainText('Subject');
+
+    // Any re-render of the sheet -- a background refetch landing, or opening this dialog and
+    // thinking better of it -- used to reset the permission field to a blank row, so saving
+    // afterwards silently cleared the permissions the admin never saw.
+    await editSheet.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'No' }).click();
+    await expect(editSheet.getByTestId('action-select-trigger')).toContainText('Read');
+    await expect(editSheet.getByTestId('subject-select-trigger')).toContainText('Subject');
+  });
+
   test("should clear a user's email from the edit sheet", async ({ api, authenticateAs, page, uniqueId }) => {
     const email = `contact-${uniqueId}@example.org`;
     const group = await api.createGroup();

--- a/testing/src/support/api-client.ts
+++ b/testing/src/support/api-client.ts
@@ -1,6 +1,6 @@
 import type { $LoginCredentials } from '@opendatacapture/schemas/auth';
 import type { CreateGroupData, Group } from '@opendatacapture/schemas/group';
-import type { CreateUserData, User } from '@opendatacapture/schemas/user';
+import type { CreateUserData, UpdateUserData, User } from '@opendatacapture/schemas/user';
 import type { APIRequestContext } from '@playwright/test';
 
 import { E2E_MAIL_CONFIG, SEEDED_USER_PASSWORD } from './constants';
@@ -90,6 +90,18 @@ export class ApiClient {
       }),
       `set mail enabled to ${enabled}`
     );
+  }
+
+  /**
+   * Updates a user. `additionalPermissions` is on the update schema and not the create one, so
+   * seeding a user who holds any is necessarily two calls.
+   */
+  async updateUser(id: string, data: Partial<UpdateUserData>): Promise<User> {
+    const response = await this.request.patch(`${API}/users/${id}`, { data, headers: this.authHeaders });
+    if (!response.ok()) {
+      throw new Error(`Failed to update user '${id}' (${response.status()}): ${await response.text()}`);
+    }
+    return (await response.json()) as User;
   }
 
   private async expectJson<T>(


### PR DESCRIPTION
## Show a user's existing permissions when the manage-user sheet is opened

Opening **Manage Users → a user** showed an empty permission row even when that user held
permissions. Reopening the sheet later showed them correctly, which made it look like a
loading problem.

It was not. The permissions loaded fine — they were erased immediately afterwards.

### Root cause

libui's `RecordArrayField` resets itself whenever its `fieldset` prop changes identity:

```tsx
const fieldsetRef = useRef(fieldset);
useEffect(() => {
  if (fieldsetRef.current !== fieldset) {
    setArrayValue([createNewRecord()]);   // ← discards the loaded permissions
    fieldsetRef.current = fieldset;
  }
}, [fieldset]);
```

UpdateUserForm declared that fieldset as an inline object literal in its JSX, so every
render handed the field a structurally identical object with a fresh identity, and the
field blanked itself. The form mounts with the correct values; the next render destroys them.

On a first visit that next render is guaranteed: queryClient sets no staleTime, so
useUsersQuery / useGroupsQuery background-refetch on mount. When the refetch lands,
groupsQuery.data is a new array, the effect rebuilds data, and UpdateUserForm re-renders.
On a later open the queries are already fresh, nothing refetches, and the values survive —
hence "it works the second time".

key={JSON.stringify(initialValues)} did not help: the serialized string is unchanged for the
same user, so the Form never remounted to re-seed itself.

###  Why this mattered beyond the empty row
The reset left the field holding [{ action: undefined, subject: undefined }], which the
schema's .transform collapses to []. An admin who opened the sheet and saved any change —
an email, a group — silently stripped that user's additional permissions, having never been
shown them. Data loss, not just a rendering glitch.

#### The fix
apps/web/src/routes/_app/admin/users/index.tsx — the permission fieldset is now useMemo'd
on [resolvedLanguage], the only input that can change it, giving it a stable identity across
re-renders.

Memoized at the fieldset level rather than around the whole content array on purpose:
groupOptions is rebuilt on every refetch, so a content-level memo keyed on it would keep
churning and re-introduce the bug.

#### Tests

Unit — apps/web/src/__tests__/record-array-initial-values.test.tsx pins both halves of the libui contract this fix depends on: a stable fieldset renders, keeps and submits its seeded records across a parent re-render; an unstable one discards them. Written against the libui contract rather than the route, following data-table-server-mode.test.tsx, because route files export only Route.

E2E — admin-management.spec.ts seeds a user holding read Subject, opens the sheet, asserts the selects show it, then forces a re-render through the UI (open the delete dialog, click No) and asserts they still do.

ApiClient.updateUser added to testing/src/support/api-client.ts: additionalPermissions is on the update schema and not the create one, so seeding such a user takes two calls.

The e2e test was confirmed to fail on the unfixed code with the exact reported symptom
(Expected "Read", Received "") and to pass with the fix.

#### Verification
pnpm lint — 33/33 tasks successful
pnpm test — 796 passed
pnpm test:e2e (chromium) — 146 passed

Closes issue #1527 
